### PR TITLE
Bz 47566 fix resolve mcp tool parameter type error and add configurable initialization timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+# [2.0.0](https://github.com/juspay/yama/compare/v1.6.0...v2.0.0) (2025-11-26)
+
+### Features
+
+- **v2:** complete revamp with XML-based prompts and observability ([8eb6153](https://github.com/juspay/yama/commit/8eb6153c6272adc276b1ca44c655bf359733d256))
+
+### BREAKING CHANGES
+
+- **v2:** Complete architecture overhaul to V2. V1 code moved to src/v1/ directory.
+
+* Added ReviewSystemPrompt.ts and EnhancementSystemPrompt.ts with generic XML-based instructions
+* Implemented Langfuse observability integration for AI tracing and monitoring
+* Changed userId format in traces from static to dynamic {repository}-{branch}
+* Refactored PromptBuilder to inject project-specific config into base prompts
+* Added ObservabilityConfig utility for environment-based Langfuse setup
+* Removed session command from CLI (determined unnecessary)
+* Switched to code_snippet approach for accurate inline comment placement
+* Added docs/ reference and LogicUtils helper instructions to workflow config
+* Created comprehensive V2 test suite (37 tests passing)
+* Removed outdated V1 unit tests (10 test files)
+* Updated .env.example with generic examples and Langfuse configuration
+* Genericized all company-specific information in configuration examples
+* CLI entry point now uses v2.cli.ts
+* Fixed husky deprecated warnings by removing old hook syntax
+* Fixed commit validation to support breaking change syntax
+
+Features:
+
+- Generic, reusable base prompts with project-specific YAML config injection
+- Better observability with Langfuse for debugging AI decisions
+- Autonomous code review workflow with lazy file loading
+- Search-first approach: AI must verify code before commenting
+- XML-structured prompts for better AI comprehension
+
 # [1.6.0](https://github.com/juspay/yama/compare/v1.5.1...v1.6.0) (2025-10-24)
 
 ### Features

--- a/src/v2/config/DefaultConfig.ts
+++ b/src/v2/config/DefaultConfig.ts
@@ -37,6 +37,7 @@ export class DefaultConfig {
       },
 
       mcpServers: {
+        initializationTimeout: 120000, // 2 minutes (in milliseconds) for MCP server initialization
         jira: {
           enabled: false, // Opt-in: users must explicitly enable Jira integration
         },

--- a/src/v2/core/MCPServerManager.ts
+++ b/src/v2/core/MCPServerManager.ts
@@ -13,6 +13,18 @@ export class MCPServerManager {
   private initialized = false;
 
   /**
+   * Validate timeout value
+   * Accepts timeout in milliseconds
+   */
+  private parseTimeout(timeout: number): number {
+    if (timeout <= 0) {
+      console.warn(`Invalid timeout value: ${timeout}, using default 120000ms`);
+      return 120000; // 2 minutes default
+    }
+    return timeout;
+  }
+
+  /**
    * Setup all MCP servers in NeuroLink
    * Bitbucket is always enabled, Jira is optional based on config
    */
@@ -22,12 +34,15 @@ export class MCPServerManager {
   ): Promise<void> {
     console.log("🔌 Setting up MCP servers...");
 
+    const timeoutMs = this.parseTimeout(config.initializationTimeout);
+    console.log(`   ⏱️  MCP initialization timeout: ${timeoutMs}ms`);
+
     // Setup Bitbucket MCP (always enabled)
-    await this.setupBitbucketMCP(neurolink);
+    await this.setupBitbucketMCP(neurolink, timeoutMs);
 
     // Setup Jira MCP (optional)
     if (config.jira.enabled) {
-      await this.setupJiraMCP(neurolink);
+      await this.setupJiraMCP(neurolink, timeoutMs);
     } else {
       console.log("   ⏭️  Jira MCP disabled in config");
     }
@@ -39,7 +54,10 @@ export class MCPServerManager {
   /**
    * Setup Bitbucket MCP server (hardcoded, always enabled)
    */
-  private async setupBitbucketMCP(neurolink: any): Promise<void> {
+  private async setupBitbucketMCP(
+    neurolink: any,
+    timeoutMs: number,
+  ): Promise<void> {
     try {
       console.log("   🔧 Registering Bitbucket MCP server...");
 
@@ -59,6 +77,7 @@ export class MCPServerManager {
         command: "npx",
         args: ["-y", "@nexus2520/bitbucket-mcp-server"],
         transport: "stdio",
+        timeout: timeoutMs,
         env: {
           BITBUCKET_USERNAME: process.env.BITBUCKET_USERNAME,
           BITBUCKET_TOKEN: process.env.BITBUCKET_TOKEN,
@@ -77,7 +96,7 @@ export class MCPServerManager {
   /**
    * Setup Jira MCP server (hardcoded, optionally enabled)
    */
-  private async setupJiraMCP(neurolink: any): Promise<void> {
+  private async setupJiraMCP(neurolink: any, timeoutMs: number): Promise<void> {
     try {
       console.log("   🔧 Registering Jira MCP server...");
 
@@ -99,6 +118,7 @@ export class MCPServerManager {
         command: "npx",
         args: ["-y", "@nexus2520/jira-mcp-server"],
         transport: "stdio",
+        timeout: timeoutMs,
         env: {
           JIRA_EMAIL: process.env.JIRA_EMAIL,
           JIRA_API_TOKEN: process.env.JIRA_API_TOKEN,

--- a/src/v2/prompts/PromptBuilder.ts
+++ b/src/v2/prompts/PromptBuilder.ts
@@ -45,7 +45,7 @@ ${projectStandards ? `<project-standards>\n${projectStandards}\n</project-standa
 <review-task>
   <workspace>${this.escapeXML(request.workspace)}</workspace>
   <repository>${this.escapeXML(request.repository)}</repository>
-  <pull_request_id>${request.pullRequestId || "find-by-branch"}</pull_request_id>
+  <pull_request_id>${request.pullRequestId || ""}</pull_request_id>
   <branch>${this.escapeXML(request.branch || "N/A")}</branch>
   <mode>${request.dryRun ? "dry-run" : "live"}</mode>
 
@@ -210,7 +210,7 @@ ${enhancementConfigXML}
 <enhancement-task>
   <workspace>${this.escapeXML(request.workspace)}</workspace>
   <repository>${this.escapeXML(request.repository)}</repository>
-  <pull_request_id>${request.pullRequestId || "find-by-branch"}</pull_request_id>
+  <pull_request_id>${request.pullRequestId || ""}</pull_request_id>
   <branch>${this.escapeXML(request.branch || "N/A")}</branch>
   <mode>${request.dryRun ? "dry-run" : "live"}</mode>
 

--- a/src/v2/types/config.types.ts
+++ b/src/v2/types/config.types.ts
@@ -71,6 +71,7 @@ export interface RedisConfig {
 // ============================================================================
 
 export interface MCPServersConfig {
+  initializationTimeout: number; // Timeout in milliseconds (e.g., 120000 for 2 minutes)
   jira: {
     enabled: boolean;
   };

--- a/yama.config.example.yaml
+++ b/yama.config.example.yaml
@@ -40,6 +40,7 @@ ai:
 # Bitbucket MCP is always enabled (hardcoded)
 # Jira MCP can be enabled/disabled here
 mcpServers:
+  initializationTimeout: 120000 # Timeout in milliseconds (120000 = 2 minutes)
   jira:
     enabled: true # Set to false to disable Jira integration
 


### PR DESCRIPTION
# Pull Request

## Description

This PR integrates Yama v2 for automated AI-powered code review and PR description enhancement in the Lighthouse CI/CD pipeline. It includes bug fixes to the Yama wrapper script and optimizations to the Jenkins pipeline by removing redundant Node.js setup steps.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Build/CI configuration change
- [x] ⚡ Performance improvement

## Related Issues

- Fixes BZ-46803
- Related to Yama v2 migration

## Changes Made

### 1. Yama v2 Wrapper Script (`scripts/run-yama.js`)
- **Added validation** for required arguments (`--workspace`, `--repository`, `--branch`)
  - Script now fails fast with clear error messages if required inputs are missing
  - Prevents confusing CI failures from undefined parameters
- **Fixed operations parsing bug**
  - IIFE pattern to handle empty string edge case: `--operations ""`
  - Prevents `['']` from being treated as valid operations
  - Properly falls back to default `['review', 'enhance']`

### 2. Jenkins Pipeline Optimization (`Jenkinsfile`)
- **Removed redundant Node.js 20 download**
  - Jenkins agent already has Node.js 20.19.6 installed
  - Eliminated 15-20 second overhead per build
- **Removed global MCP package installation**
  - MCP packages already in `node_modules` via `devDependencies`
  - Fixes potential timeout issues from global installs not inheriting env vars

### 3. Package.json
- **Removed `--experimental-global-webcrypto` flag** from `pr:process` script
  - Flag unnecessary for Node.js 20+ (Web Crypto API is stable)
  - Reduces console noise

### 4. Configuration Cleanup (`yama.config.yaml`)
- **Removed invalid `mcpTimeout` config**
  - Not a valid Yama v2 configuration field
  - MCP timeout is controlled internally by NeuroLink

## Platform Impact

- [x] Bitbucket
- [ ] GitHub
- [ ] GitLab
- [ ] All platforms
- [ ] No platform-specific changes

## AI Provider Impact

- [ ] OpenAI
- [ ] Anthropic
- [ ] Google AI
- [ ] All providers
- [x] No AI provider changes (uses existing Vertex AI configuration)

## Component Impact

- [x] CLI
- [x] Core Engine (Yama wrapper)
- [x] API Integration (MCP servers)
- [x] AI Features (Code review)
- [ ] Security
- [x] Configuration
- [ ] Documentation
- [ ] Tests

## Testing

- [x] Manual testing performed
- [x] All existing tests pass
- [x] Verified in Jenkins CI environment

### Test Environment

- OS: Linux (Jenkins agent)
- Node.js version: 20.19.6
- Package manager: pnpm 10.15.0

### Test Results
- ✅ MCP servers (Bitbucket, Jira) now initialize successfully (no timeout)
- ✅ Environment variable mapping works correctly
- ✅ Yama wrapper validates inputs properly
- ⚠️ Known issue: Bitbucket MCP expects numeric PR ID, Yama v2 passes `"find-by-branch"` string (upstream bug)

## Performance Impact

- [x] Performance improvement
  - Reduced build time by ~15-20 seconds (removed Node.js download)
  - Eliminated redundant global package installations

## Security Considerations

- [x] No security impact
- All credentials properly mapped from Jenkins environment variables
- MCP servers use existing secure credential handling

## Breaking Changes

None. This change is additive and doesn't affect existing functionality.

## Configuration Changes

- [x] Configuration schema updated
  - Removed invalid `mcpTimeout` from `yama.config.yaml`
  - All other Yama configuration follows standard v2 schema

**Environment Variables Required:**
- `BITBUCKET_TOKEN` ✅ (existing)
- `BITBUCKET_USERNAME` ✅ (existing)
- `BITBUCKET_BASE_URL` ✅ (existing)
- `JIRA` (mapped to `JIRA_API_TOKEN`) ✅ (existing)

## Screenshots/Demo

```
🚀 Yama v2 Wrapper Starting...
📋 Workspace: BZ
📦 Repository: lighthouse
🌿 Branch: BZ-46803-add-support-for-yama-v-2-in-lh
⚙️  Operations: review, enhance-description

🔌 Setting up MCP servers...
   ✅ Bitbucket MCP server registered and tools available
   ✅ Jira MCP server registered and tools available
✅ MCP servers ready
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md if needed (automated on release)
- [x] I have verified that sensitive data is not exposed

## Additional Notes

### Architecture Decisions

1. **Why remove global MCP install?**
   - Packages already in `node_modules` via `@nexus2520/bitbucket-mcp-server` and `@nexus2520/jira-mcp-server` dependencies
   - Global installs can't access workspace-specific configuration
   - Potential source of MCP timeout issues

2. **Why IIFE for operations parsing?**
   - Robust handling of edge cases in CI environments
   - Jenkins parameter substitution can result in empty strings
   - Previous code: `"".split(',')` → `['']` (invalid)
   - Fixed code: Empty string properly detected → defaults applied

3. **Known Limitation**
   - Yama v2 currently passes `pull_request_id: "find-by-branch"` to Bitbucket MCP
   - Bitbucket MCP expects numeric PR ID
   - This is an upstream Yama v2 bug that needs to be reported
   - Workaround: Pass `--pr <numeric-id>` explicitly (defeats automation purpose)

### Future Improvements

- [ ] Report MCP timeout configuration issue to Yama/NeuroLink team
- [ ] Report `find-by-branch` string literal bug to Yama team
- [ ] Add E2E tests for Yama integration
- [ ] Add retry logic for MCP initialization failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable MCP server initialization timeout setting (default: 2 minutes).

* **Changes**
  * Updated default pull request identification behavior from "find-by-branch" to empty string.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->