### PR TITLE
feat(v2): bootstrap repo standards from recent PRs before review

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   "dependencies": {
     "@juspay/neurolink": "^9.42.0",
     "langfuse": "^3.35.0",
-    "@nexus2520/bitbucket-mcp-server": "2.0.1",
+    "@nexus2520/bitbucket-mcp-server": "2.0.3",
     "@nexus2520/jira-mcp-server": "^1.1.1",
     "chalk": "^4.1.2",
     "commander": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
         specifier: ^9.42.0
         version: 9.42.0(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@types/node@20.19.9)(encoding@0.1.13)(react@19.1.0)
       "@nexus2520/bitbucket-mcp-server":
-        specifier: 2.0.1
-        version: 2.0.1(@cfworker/json-schema@4.1.1)(debug@4.4.1)(zod@4.3.6)
+        specifier: 2.0.3
+        version: 2.0.3(@cfworker/json-schema@4.1.1)(debug@4.4.1)(zod@4.3.6)
       "@nexus2520/jira-mcp-server":
         specifier: ^1.1.1
         version: 1.1.1(@cfworker/json-schema@4.1.1)(debug@4.4.1)(zod@4.3.6)
@@ -2465,10 +2465,10 @@ packages:
       }
     engines: { node: ">= 10" }
 
-  "@nexus2520/bitbucket-mcp-server@2.0.1":
+  "@nexus2520/bitbucket-mcp-server@2.0.3":
     resolution:
       {
-        integrity: sha512-W0qdm7AqmOwm8ubOIY42gzip9RmLRsuchiuKkrUQyf1UxLxnAGWZvN3NtsINxTkOTkJ2ftGG4icWJSySGJ8GXg==,
+        integrity: sha512-xJ2qcDwbYnXYXzkcFzWcaT2s0RJX+Se48vZg15ofY6HWd8jqh4FomVyfYT02QUgfmDIsdXEGYvR+EQ+E6Oe9Hw==,
       }
     engines: { node: ">=16.0.0" }
     hasBin: true
@@ -12829,9 +12829,9 @@ snapshots:
       "@napi-rs/canvas-win32-x64-msvc": 0.1.86
     optional: true
 
-  "@nexus2520/bitbucket-mcp-server@2.0.1(@cfworker/json-schema@4.1.1)(debug@4.4.1)(zod@4.3.6)":
+  "@nexus2520/bitbucket-mcp-server@2.0.3(@cfworker/json-schema@4.1.1)(debug@4.4.1)(zod@4.3.6)":
     dependencies:
-      "@modelcontextprotocol/sdk": 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      "@modelcontextprotocol/sdk": 1.28.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       axios: 1.11.0(debug@4.4.1)
       minimatch: 9.0.5
     transitivePeerDependencies:

--- a/src/v2/config/ConfigLoader.ts
+++ b/src/v2/config/ConfigLoader.ts
@@ -216,7 +216,7 @@ export class ConfigLoader {
   private applyEnvironmentOverrides(config: YamaConfig): YamaConfig {
     // Override AI provider if env var set
     if (process.env.AI_PROVIDER) {
-      config.ai.provider = process.env.AI_PROVIDER as any;
+      config.ai.provider = process.env.AI_PROVIDER;
     }
 
     // Override AI model if env var set
@@ -224,14 +224,20 @@ export class ConfigLoader {
       config.ai.model = process.env.AI_MODEL;
     }
 
-    // Override temperature if env var set
+    // Override temperature if env var set (ignore non-finite values)
     if (process.env.AI_TEMPERATURE) {
-      config.ai.temperature = parseFloat(process.env.AI_TEMPERATURE);
+      const temperature = Number(process.env.AI_TEMPERATURE);
+      if (Number.isFinite(temperature)) {
+        config.ai.temperature = temperature;
+      }
     }
 
-    // Override max tokens if env var set
+    // Override max tokens if env var set (ignore non-integer / non-positive values)
     if (process.env.AI_MAX_TOKENS) {
-      config.ai.maxTokens = parseInt(process.env.AI_MAX_TOKENS, 10);
+      const maxTokens = Number.parseInt(process.env.AI_MAX_TOKENS, 10);
+      if (Number.isInteger(maxTokens) && maxTokens > 0) {
+        config.ai.maxTokens = maxTokens;
+      }
     }
 
     if (process.env.AI_ENABLE_TOOL_FILTERING) {
@@ -244,6 +250,35 @@ export class ConfigLoader {
       if (mode === "off" || mode === "log-only" || mode === "active") {
         config.ai.toolFilteringMode = mode;
       }
+    }
+
+    if (process.env.AI_EXPLORE_ENABLED) {
+      config.ai.explore.enabled = process.env.AI_EXPLORE_ENABLED === "true";
+    }
+    if (process.env.AI_EXPLORE_PROVIDER) {
+      config.ai.explore.provider = process.env.AI_EXPLORE_PROVIDER;
+    }
+    if (process.env.AI_EXPLORE_MODEL) {
+      config.ai.explore.model = process.env.AI_EXPLORE_MODEL;
+    }
+    if (process.env.AI_EXPLORE_TEMPERATURE) {
+      const temperature = Number(process.env.AI_EXPLORE_TEMPERATURE);
+      if (Number.isFinite(temperature)) {
+        config.ai.explore.temperature = temperature;
+      }
+    }
+    if (process.env.AI_EXPLORE_MAX_TOKENS) {
+      const maxTokens = Number.parseInt(process.env.AI_EXPLORE_MAX_TOKENS, 10);
+      if (Number.isInteger(maxTokens) && maxTokens > 0) {
+        config.ai.explore.maxTokens = maxTokens;
+      }
+    }
+    if (process.env.AI_EXPLORE_TIMEOUT) {
+      config.ai.explore.timeout = process.env.AI_EXPLORE_TIMEOUT;
+    }
+    if (process.env.AI_EXPLORE_CACHE_RESULTS) {
+      config.ai.explore.cacheResults =
+        process.env.AI_EXPLORE_CACHE_RESULTS === "true";
     }
 
     return config;

--- a/src/v2/config/DefaultConfig.ts
+++ b/src/v2/config/DefaultConfig.ts
@@ -36,6 +36,15 @@ export class DefaultConfig {
           maxTurnsPerSession: 300,
           enableSummarization: false,
         },
+        explore: {
+          enabled: true,
+          provider: "auto",
+          model: "gemini-2.5-flash",
+          temperature: 0.1,
+          maxTokens: 32000,
+          timeout: "5m",
+          cacheResults: true,
+        },
       },
 
       mcpServers: {

--- a/src/v2/core/LearningOrchestrator.ts
+++ b/src/v2/core/LearningOrchestrator.ts
@@ -256,7 +256,7 @@ export class LearningOrchestrator {
               operation: "memory-store-learnings",
             },
             memory: { read: false, write: true },
-          });
+          } as unknown as Parameters<NeuroLink["generate"]>[0]);
           console.log(`   🧠 Learning memory stored for ${ownerId}`);
 
           // Auto-commit and push memory files to repo

--- a/src/v2/core/SessionManager.ts
+++ b/src/v2/core/SessionManager.ts
@@ -10,6 +10,7 @@ import {
   ReviewResult,
   ToolCallRecord,
   SessionMetadata,
+  ExplorationResult,
 } from "../types/v2.types.js";
 
 export class SessionManager {
@@ -36,6 +37,7 @@ export class SessionManager {
         totalCost: 0,
         cacheHitRatio: 0,
       },
+      explorations: [],
     };
 
     this.sessions.set(sessionId, session);
@@ -93,6 +95,38 @@ export class SessionManager {
       ...session.metadata,
       ...updates,
     };
+  }
+
+  recordExploration(
+    sessionId: string,
+    cacheKey: string,
+    task: string,
+    focus: string[],
+    result: ExplorationResult,
+    cached = false,
+  ): void {
+    const session = this.getSession(sessionId);
+    session.explorations = session.explorations || [];
+    session.explorations.push({
+      task,
+      cacheKey,
+      focus,
+      result,
+      createdAt: new Date(),
+      cached,
+    });
+  }
+
+  findExploration(
+    sessionId: string,
+    cacheKey: string,
+  ): ExplorationResult | null {
+    const session = this.getSession(sessionId);
+    const match = (session.explorations || [])
+      .slice()
+      .reverse()
+      .find((exploration) => exploration.cacheKey === cacheKey);
+    return match?.result || null;
   }
 
   /**
@@ -213,6 +247,15 @@ export class SessionManager {
         error: tc.error,
         // Don't include full result in export (can be very large)
         resultSummary: this.summarizeToolResult(tc.result),
+      })),
+      explorations: (session.explorations || []).map((exploration) => ({
+        task: exploration.task,
+        cacheKey: exploration.cacheKey,
+        focus: exploration.focus,
+        createdAt: exploration.createdAt.toISOString(),
+        cached: exploration.cached,
+        // Don't include full result in export (can be very large / may contain sensitive data)
+        resultSummary: this.summarizeToolResult(exploration.result),
       })),
     };
   }

--- a/src/v2/core/YamaV2Orchestrator.ts
+++ b/src/v2/core/YamaV2Orchestrator.ts
@@ -11,6 +11,7 @@ import { SessionManager } from "./SessionManager.js";
 import { MemoryManager } from "../memory/MemoryManager.js";
 import { LocalDiffSource } from "./LocalDiffSource.js";
 import type { LocalDiffContext } from "./LocalDiffSource.js";
+import { ContextExplorerService } from "../exploration/ContextExplorerService.js";
 import {
   LocalReviewFinding,
   LocalReviewRequest,
@@ -32,6 +33,7 @@ import {
 
 export class YamaOrchestrator {
   private neurolink!: NeuroLink;
+  private explorer: ContextExplorerService | null = null;
   private mcpManager: MCPServerManager;
   private configLoader: ConfigLoader;
   private promptBuilder: PromptBuilder;
@@ -42,7 +44,10 @@ export class YamaOrchestrator {
   private initialized = false;
   private mcpInitialized = false;
   private localGitMcpInitialized = false;
+  private exploreToolRegistered = false;
+  private currentToolContext: Record<string, unknown> | null = null;
   private initOptions: YamaInitOptions;
+  private bootstrapStandardsCache: Map<string, string> = new Map();
 
   constructor(options: YamaInitOptions = {}) {
     this.initOptions = options;
@@ -86,6 +91,12 @@ export class YamaOrchestrator {
         // Step 3: Initialize NeuroLink with memory config injected
         console.log("🧠 Initializing NeuroLink AI engine...");
         this.neurolink = this.initializeNeurolink();
+        this.explorer = new ContextExplorerService(
+          this.config,
+          this.sessionManager,
+          this.memoryManager,
+        );
+        this.registerExploreTool();
         console.log("✅ NeuroLink initialized\n");
 
         this.initialized = true;
@@ -97,9 +108,15 @@ export class YamaOrchestrator {
           this.neurolink,
           this.config.mcpServers,
         );
+        if (this.explorer && this.config.ai.explore.enabled) {
+          await this.explorer.initialize("pr");
+        }
         this.mcpInitialized = true;
       } else if (mode === "local" && !this.localGitMcpInitialized) {
         await this.mcpManager.setupLocalGitMCPServer(this.neurolink);
+        if (this.explorer && this.config.ai.explore.enabled) {
+          await this.explorer.initialize("local");
+        }
         this.localGitMcpInitialized = true;
       }
 
@@ -126,10 +143,16 @@ export class YamaOrchestrator {
     this.logReviewStart(request, sessionId);
 
     try {
+      const bootstrapStandards = await this.getBootstrappedStandards(
+        request,
+        sessionId,
+      );
+
       // Build comprehensive AI instructions
       const instructions = await this.promptBuilder.buildReviewInstructions(
         request,
         this.config,
+        bootstrapStandards,
       );
 
       if (this.config.display.verboseToolCalls) {
@@ -143,7 +166,7 @@ export class YamaOrchestrator {
       const toolContext = this.createToolContext(sessionId, request);
 
       // Set tool context in NeuroLink (using type assertion as setToolContext is documented but may not be in type definitions)
-      (this.neurolink as any).setToolContext(toolContext);
+      this.setToolContext(toolContext);
 
       // Update session metadata
       this.sessionManager.updateMetadata(sessionId, {
@@ -176,7 +199,7 @@ export class YamaOrchestrator {
         memory: { read: true, write: false },
         enableAnalytics: this.config.ai.enableAnalytics,
         enableEvaluation: this.config.ai.enableEvaluation,
-      });
+      } as unknown as Parameters<NeuroLink["generate"]>[0]);
       this.recordToolCallsFromResponse(sessionId, aiResponse);
 
       // Extract and parse results
@@ -236,19 +259,19 @@ export class YamaOrchestrator {
           diffContext,
         );
 
+      const toolContext = this.createLocalToolContext(
+        sessionId,
+        pseudoRequest,
+        diffContext,
+      );
+      this.setToolContext(toolContext);
+
       const aiResponse = await this.neurolink.generate({
         input: { text: instructions },
         provider: this.config.ai.provider,
         model: this.config.ai.model,
         temperature: this.config.ai.temperature,
         maxTokens: Math.min(this.config.ai.maxTokens, 16_000),
-        maxSteps: 100,
-        prepareStep: async ({ stepNumber }) => {
-          if (stepNumber >= 5) {
-            return { toolChoice: "none" };
-          }
-          return undefined;
-        },
         timeout: this.config.ai.timeout,
         enableAnalytics: this.config.ai.enableAnalytics,
         enableEvaluation: this.config.ai.enableEvaluation,
@@ -259,7 +282,7 @@ export class YamaOrchestrator {
         ...this.getLocalToolFilteringOptions(),
         context: {
           sessionId,
-          userId: `local-${sessionId}`,
+          userId: this.getUserId(pseudoRequest),
           operation: "local-review",
           metadata: {
             repoPath: diffContext.repoPath,
@@ -268,7 +291,7 @@ export class YamaOrchestrator {
             headRef: diffContext.headRef,
           },
         },
-      });
+      } as unknown as Parameters<NeuroLink["generate"]>[0]);
       this.recordToolCallsFromResponse(sessionId, aiResponse);
 
       const result = this.parseLocalReviewResult(
@@ -302,15 +325,21 @@ export class YamaOrchestrator {
     const sessionId = this.sessionManager.createSession(request);
 
     try {
+      const bootstrapStandards = await this.getBootstrappedStandards(
+        request,
+        sessionId,
+      );
+
       // Build instructions
       const instructions = await this.promptBuilder.buildReviewInstructions(
         request,
         this.config,
+        bootstrapStandards,
       );
 
       // Create tool context
       const toolContext = this.createToolContext(sessionId, request);
-      (this.neurolink as any).setToolContext(toolContext);
+      this.setToolContext(toolContext);
 
       // Stream AI execution
       yield {
@@ -338,7 +367,7 @@ export class YamaOrchestrator {
         },
         memory: { enabled: false },
         enableAnalytics: true,
-      });
+      } as unknown as Parameters<NeuroLink["generate"]>[0]);
 
       yield {
         type: "progress",
@@ -373,9 +402,18 @@ export class YamaOrchestrator {
       // PHASE 1: Code Review
       // ========================================================================
 
+      const bootstrapStandards = await this.getBootstrappedStandards(
+        request,
+        sessionId,
+      );
+
       // Build review instructions
       const reviewInstructions =
-        await this.promptBuilder.buildReviewInstructions(request, this.config);
+        await this.promptBuilder.buildReviewInstructions(
+          request,
+          this.config,
+          bootstrapStandards,
+        );
 
       if (this.config.display.verboseToolCalls) {
         console.log("\n📝 Review instructions built:");
@@ -386,7 +424,7 @@ export class YamaOrchestrator {
 
       // Create tool context
       const toolContext = this.createToolContext(sessionId, request);
-      (this.neurolink as any).setToolContext(toolContext);
+      this.setToolContext(toolContext);
 
       // Update session metadata
       this.sessionManager.updateMetadata(sessionId, {
@@ -416,7 +454,7 @@ export class YamaOrchestrator {
         memory: { read: true, write: false },
         enableAnalytics: this.config.ai.enableAnalytics,
         enableEvaluation: this.config.ai.enableEvaluation,
-      });
+      } as unknown as Parameters<NeuroLink["generate"]>[0]);
       this.recordToolCallsFromResponse(sessionId, reviewResponse);
 
       // Parse review results
@@ -463,7 +501,7 @@ export class YamaOrchestrator {
           memory: { enabled: false },
           enableAnalytics: this.config.ai.enableAnalytics,
           enableEvaluation: this.config.ai.enableEvaluation,
-        });
+        } as unknown as Parameters<NeuroLink["generate"]>[0]);
         this.recordToolCallsFromResponse(sessionId, enhanceResponse);
 
         console.log("✅ Phase 2 complete: Description enhanced\n");
@@ -508,7 +546,7 @@ export class YamaOrchestrator {
         );
 
       const toolContext = this.createToolContext(sessionId, request);
-      (this.neurolink as any).setToolContext(toolContext);
+      this.setToolContext(toolContext);
 
       const aiResponse = await this.neurolink.generate({
         input: { text: instructions },
@@ -523,7 +561,7 @@ export class YamaOrchestrator {
         },
         memory: { enabled: false },
         enableAnalytics: true,
-      });
+      } as unknown as Parameters<NeuroLink["generate"]>[0]);
       this.recordToolCallsFromResponse(sessionId, aiResponse);
 
       console.log("✅ Description enhanced successfully\n");
@@ -567,6 +605,7 @@ export class YamaOrchestrator {
   private createToolContext(sessionId: string, request: ReviewRequest): any {
     return {
       sessionId,
+      mode: "pr",
       workspace: request.workspace,
       repository: request.repository,
       pullRequestId: request.pullRequestId,
@@ -577,6 +616,33 @@ export class YamaOrchestrator {
         startTime: new Date().toISOString(),
       },
     };
+  }
+
+  private createLocalToolContext(
+    sessionId: string,
+    request: ReviewRequest,
+    diffContext: LocalDiffContext,
+  ): any {
+    return {
+      sessionId,
+      mode: "local",
+      workspace: request.workspace,
+      repository: request.repository,
+      dryRun: request.dryRun || false,
+      metadata: {
+        yamaVersion: "2.2.1",
+        startTime: new Date().toISOString(),
+        repoPath: diffContext.repoPath,
+        diffSource: diffContext.diffSource,
+        baseRef: diffContext.baseRef,
+        headRef: diffContext.headRef,
+      },
+    };
+  }
+
+  private setToolContext(context: Record<string, unknown>): void {
+    this.currentToolContext = context;
+    (this.neurolink as any).setToolContext(context);
   }
 
   /**
@@ -1238,6 +1304,182 @@ export class YamaOrchestrator {
         (error as Error).message,
       );
       throw new Error(`NeuroLink initialization failed: ${error}`);
+    }
+  }
+
+  private registerExploreTool(): void {
+    if (this.exploreToolRegistered || !this.config.ai.explore.enabled) {
+      return;
+    }
+
+    this.neurolink.registerTool("explore_context", {
+      name: "explore_context",
+      description:
+        "Delegate non-trivial research to an isolated Explore worker. Use it for function definitions, project-wide search, logic tracing, commit history, rules/context lookup, or any analysis that would otherwise require broad manual scanning.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          task: {
+            type: "string",
+            description:
+              "The exact research task for Explore to investigate and answer.",
+          },
+          focus: {
+            type: "array",
+            description:
+              "Optional list of files, symbols, commits, tickets, or context areas Explore should prioritize.",
+            items: {
+              type: "string",
+            },
+          },
+        },
+        required: ["task"],
+      },
+      execute: async (params: unknown, context?: unknown) => {
+        if (!this.explorer) {
+          throw new Error("Explore service is not initialized");
+        }
+
+        const rawParams = (params || {}) as Record<string, unknown>;
+        const mergedContext = {
+          ...(this.currentToolContext || {}),
+          ...((context && typeof context === "object"
+            ? (context as Record<string, unknown>)
+            : {}) as Record<string, unknown>),
+        };
+
+        const runtimeMode: "pr" | "local" =
+          mergedContext.mode === "local" ? "local" : "pr";
+
+        const runtimeContext = {
+          sessionId: String(
+            mergedContext.sessionId || this.currentToolContext?.sessionId || "",
+          ),
+          mode: runtimeMode,
+          workspace: String(mergedContext.workspace || "local"),
+          repository: String(mergedContext.repository || "repository"),
+          pullRequestId:
+            typeof mergedContext.pullRequestId === "number"
+              ? mergedContext.pullRequestId
+              : undefined,
+          branch:
+            typeof mergedContext.branch === "string"
+              ? mergedContext.branch
+              : undefined,
+          dryRun:
+            typeof mergedContext.dryRun === "boolean"
+              ? mergedContext.dryRun
+              : false,
+          metadata:
+            mergedContext.metadata &&
+            typeof mergedContext.metadata === "object" &&
+            !Array.isArray(mergedContext.metadata)
+              ? (mergedContext.metadata as Record<string, unknown>)
+              : {},
+        };
+
+        const focus = Array.isArray(rawParams.focus)
+          ? rawParams.focus.filter(
+              (value): value is string => typeof value === "string",
+            )
+          : undefined;
+
+        const { result, cached } = await this.explorer.explore(
+          {
+            task: String(rawParams.task || "").trim(),
+            focus,
+          },
+          runtimeContext,
+        );
+
+        return {
+          success: true,
+          data: {
+            ...result,
+            cached,
+          },
+        };
+      },
+    });
+
+    this.exploreToolRegistered = true;
+  }
+
+  /**
+   * Bootstrap repo-level standards by delegating to explore_context.
+   * Runs once per (workspace/repository) per process lifetime.
+   * Output is injected into the review prompt as <bootstrapped-standards>.
+   * Graceful: any failure returns empty and the review proceeds without it.
+   */
+  private async getBootstrappedStandards(
+    request: ReviewRequest,
+    sessionId: string,
+  ): Promise<string> {
+    if (!this.config.ai.explore.enabled || !this.explorer) {
+      return "";
+    }
+
+    const cacheKey = `${request.workspace}/${request.repository}`.toLowerCase();
+    const cached = this.bootstrapStandardsCache.get(cacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const task = `Bootstrap repo review standards for ${request.workspace}/${request.repository}. Inspect the last 15 merged pull requests on this repository. For each, collect inline and summary comments left by HUMAN reviewers (ignore bot authors like "Yama", "yama-bot", "yama-review", "euler.bot"). Focus on comments that asked for code changes, flagged bugs, pushed back on an approach, or cited a convention. Distill the recurring patterns and anti-patterns the human reviewers care about — especially things that a static config rule set would miss (naming, error-handling idioms, module boundaries, test expectations, migration rules, review etiquette). Return a concise bullet list of 10-20 patterns. Each bullet: one sentence stating the pattern, optionally one sentence of rationale. Do NOT include PR numbers, author names, or raw quotes — just distilled patterns.`;
+
+    try {
+      console.log(
+        `   🧭 Bootstrapping repo standards from recent PRs (one-time per process)...`,
+      );
+      const { result } = await this.explorer.explore(
+        { task, focus: [request.repository] },
+        {
+          sessionId,
+          mode: "pr",
+          workspace: request.workspace,
+          repository: request.repository,
+          pullRequestId: request.pullRequestId,
+          branch: request.branch,
+          dryRun: request.dryRun || false,
+          metadata: { bootstrap: true },
+        },
+      );
+
+      const parts: string[] = [];
+      if (result.summary && result.summary.trim().length > 0) {
+        parts.push(result.summary.trim());
+      }
+      if (result.findings && result.findings.length > 0) {
+        const bullets = result.findings.map((f) => `- ${f.claim}`).join("\n");
+        parts.push(bullets);
+      }
+      const combined = parts.join("\n\n").trim();
+
+      if (combined.length > 0) {
+        console.log(
+          `   ✅ Bootstrap standards ready (${combined.length} chars)`,
+        );
+        if (this.config.display.verboseToolCalls) {
+          console.log("   ───────── bootstrapped-standards ─────────");
+          for (const line of combined.split("\n")) {
+            console.log(`   ${line}`);
+          }
+          console.log("   ──────────────────────────────────────────");
+        }
+      } else {
+        console.log(
+          `   ⚠️  Bootstrap returned no standards — proceeding without them`,
+        );
+      }
+
+      this.bootstrapStandardsCache.set(cacheKey, combined);
+      return combined;
+    } catch (error) {
+      console.warn(
+        `   ⚠️  Bootstrap standards failed, proceeding without: ${(error as Error).message}`,
+      );
+      this.bootstrapStandardsCache.set(cacheKey, "");
+      return "";
     }
   }
 

--- a/src/v2/exploration/ContextExplorerService.ts
+++ b/src/v2/exploration/ContextExplorerService.ts
@@ -1,0 +1,612 @@
+import { readFile } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
+import { NeuroLink } from "@juspay/neurolink";
+import { YamaConfig } from "../types/config.types.js";
+import {
+  ExplorationEvidence,
+  ExplorationFinding,
+  ExplorationResult,
+} from "../types/v2.types.js";
+import { SessionManager } from "../core/SessionManager.js";
+import { MCPServerManager } from "../core/MCPServerManager.js";
+import { MemoryManager } from "../memory/MemoryManager.js";
+import { KnowledgeBaseManager } from "../learning/KnowledgeBaseManager.js";
+import {
+  buildObservabilityConfigFromEnv,
+  validateObservabilityConfig,
+} from "../utils/ObservabilityConfig.js";
+import { ExplorerPromptBuilder } from "./ExplorerPromptBuilder.js";
+import { RulesContextLoader } from "./RulesContextLoader.js";
+import {
+  ExploreContextInput,
+  ExploreExecutionResult,
+  ExploreRuntimeContext,
+} from "./types.js";
+
+export class ContextExplorerService {
+  private readonly promptBuilder = new ExplorerPromptBuilder();
+  private readonly rulesContextLoader: RulesContextLoader;
+  private readonly mcpManager = new MCPServerManager();
+  private neurolink: NeuroLink;
+  private prMcpInitialized = false;
+  private localMcpInitialized = false;
+
+  constructor(
+    private readonly config: YamaConfig,
+    private readonly sessionManager: SessionManager,
+    private readonly memoryManager: MemoryManager | null,
+    private readonly projectRoot: string = process.cwd(),
+  ) {
+    this.rulesContextLoader = new RulesContextLoader(
+      config.memoryBank,
+      config.projectStandards,
+      projectRoot,
+    );
+    this.neurolink = this.initializeNeurolink();
+  }
+
+  async initialize(mode: "pr" | "local"): Promise<void> {
+    if (mode === "pr" && !this.prMcpInitialized) {
+      await this.mcpManager.setupMCPServers(
+        this.neurolink,
+        this.config.mcpServers,
+      );
+      this.prMcpInitialized = true;
+      return;
+    }
+
+    if (mode === "local" && !this.localMcpInitialized) {
+      await this.mcpManager.setupLocalGitMCPServer(this.neurolink);
+      this.localMcpInitialized = true;
+    }
+  }
+
+  async explore(
+    input: ExploreContextInput,
+    runtimeContext: ExploreRuntimeContext,
+  ): Promise<ExploreExecutionResult> {
+    await this.initialize(runtimeContext.mode);
+
+    const normalizedInput = this.normalizeInput(input);
+    const cacheKey = this.buildCacheKey(normalizedInput, runtimeContext);
+
+    if (this.config.ai.explore.cacheResults) {
+      const cached = this.sessionManager.findExploration(
+        runtimeContext.sessionId,
+        cacheKey,
+      );
+      if (cached) {
+        return { result: cached, cached: true };
+      }
+    }
+
+    const [projectRules, projectStandards, knowledgeBase, repositoryMemory] =
+      await Promise.all([
+        this.rulesContextLoader.load(),
+        this.loadProjectStandards(),
+        this.loadKnowledgeBase(),
+        this.loadRepositoryMemory(runtimeContext),
+      ]);
+
+    const prompt = this.promptBuilder.buildPrompt(
+      normalizedInput,
+      runtimeContext,
+      {
+        projectRules,
+        projectStandards,
+        knowledgeBase,
+        repositoryMemory,
+      },
+    );
+
+    (this.neurolink as any).setToolContext(runtimeContext);
+
+    console.log(`   🔎 Explore: ${normalizedInput.task}`);
+
+    const researchResponse = await this.neurolink.generate({
+      input: { text: prompt },
+      provider: this.config.ai.explore.provider || this.config.ai.provider,
+      model: this.config.ai.explore.model || this.config.ai.model,
+      temperature:
+        this.config.ai.explore.temperature ?? this.config.ai.temperature,
+      maxTokens: this.config.ai.explore.maxTokens || this.config.ai.maxTokens,
+      timeout: this.config.ai.explore.timeout || this.config.ai.timeout,
+      skipToolPromptInjection: true,
+      ...this.getToolFilteringOptions(runtimeContext.mode),
+      context: {
+        sessionId: runtimeContext.sessionId,
+        userId:
+          `${runtimeContext.workspace}-${runtimeContext.repository}`.toLowerCase(),
+        operation: "explore-context-research",
+        metadata: runtimeContext.metadata || {},
+      },
+      memory: { enabled: false },
+      enableAnalytics: this.config.ai.enableAnalytics,
+      enableEvaluation: false,
+    } as unknown as Parameters<NeuroLink["generate"]>[0]);
+
+    const extractionPrompt = this.buildExtractionPrompt(
+      normalizedInput.task,
+      researchResponse,
+    );
+    const extractionResponse = await this.neurolink.generate({
+      input: { text: extractionPrompt },
+      provider: this.config.ai.explore.provider || this.config.ai.provider,
+      model: this.config.ai.explore.model || this.config.ai.model,
+      temperature: 0.1,
+      maxTokens: Math.min(
+        this.config.ai.explore.maxTokens || this.config.ai.maxTokens,
+        12_000,
+      ),
+      timeout: "2m",
+      disableTools: true,
+      context: {
+        sessionId: runtimeContext.sessionId,
+        userId:
+          `${runtimeContext.workspace}-${runtimeContext.repository}`.toLowerCase(),
+        operation: "explore-context-extraction",
+        metadata: runtimeContext.metadata || {},
+      },
+      memory: { enabled: false },
+      enableAnalytics: this.config.ai.enableAnalytics,
+      enableEvaluation: false,
+    } as unknown as Parameters<NeuroLink["generate"]>[0]);
+
+    const result = this.normalizeResult(
+      normalizedInput.task,
+      extractionResponse?.content,
+    );
+    if (this.shouldCacheResult(result)) {
+      this.sessionManager.recordExploration(
+        runtimeContext.sessionId,
+        cacheKey,
+        normalizedInput.task,
+        normalizedInput.focus || [],
+        result,
+      );
+    }
+
+    return { result, cached: false };
+  }
+
+  private normalizeInput(input: ExploreContextInput): ExploreContextInput {
+    const task = typeof input.task === "string" ? input.task.trim() : "";
+    if (!task) {
+      throw new Error("explore_context requires a non-empty task");
+    }
+
+    const focus = Array.isArray(input.focus)
+      ? input.focus
+          .filter((value): value is string => typeof value === "string")
+          .map((value) => value.trim())
+          .filter(Boolean)
+      : undefined;
+
+    return {
+      task,
+      focus,
+    };
+  }
+
+  private buildCacheKey(
+    input: ExploreContextInput,
+    runtimeContext: ExploreRuntimeContext,
+  ): string {
+    return JSON.stringify({
+      mode: runtimeContext.mode,
+      workspace: runtimeContext.workspace,
+      repository: runtimeContext.repository,
+      pullRequestId: runtimeContext.pullRequestId || null,
+      branch: runtimeContext.branch || null,
+      task: input.task.toLowerCase(),
+      focus: (input.focus || []).map((item) => item.toLowerCase()),
+    });
+  }
+
+  private getToolFilteringOptions(mode: "pr" | "local"): {
+    excludeTools?: string[];
+  } {
+    try {
+      const externalTools = (this.neurolink as any).getExternalMCPTools?.();
+      if (!Array.isArray(externalTools)) {
+        return {};
+      }
+
+      const excludeTools = externalTools
+        .map((tool: any) => tool?.name)
+        .filter((name: unknown): name is string => typeof name === "string")
+        .filter((name) => this.shouldExcludeTool(mode, name));
+
+      return excludeTools.length > 0 ? { excludeTools } : {};
+    } catch {
+      return {};
+    }
+  }
+
+  private shouldExcludeTool(mode: "pr" | "local", toolName: string): boolean {
+    const normalized = this.normalizeToolName(toolName);
+
+    if (
+      /^(add_comment|set_pr_approval|set_review_status|approve_pull_request|unapprove_pull_request|request_changes|remove_requested_changes|update_pull_request|merge_pull_request|delete_branch)$/i.test(
+        normalized,
+      )
+    ) {
+      return true;
+    }
+
+    if (mode === "local") {
+      return /^git_(commit|push|add|checkout|create_branch|merge|rebase|cherry_pick|reset|revert|tag|rm|clean|stash|apply)\b/i.test(
+        normalized,
+      );
+    }
+
+    return false;
+  }
+
+  private normalizeToolName(name: string): string {
+    return name.split(/[.:/]/).pop() || name;
+  }
+
+  private normalizeResult(task: string, content: unknown): ExplorationResult {
+    const rawText =
+      typeof content === "string" ? content : JSON.stringify(content || {});
+    const parsed = this.extractJsonPayload(rawText);
+    const findings = this.normalizeFindings(parsed?.findings);
+    const evidence = this.normalizeEvidence(parsed?.evidence);
+    const openQuestions = Array.isArray(parsed?.openQuestions)
+      ? parsed.openQuestions
+          .filter(
+            (value: unknown): value is string => typeof value === "string",
+          )
+          .map((value) => value.trim())
+          .filter(Boolean)
+      : [];
+
+    return {
+      task,
+      summary:
+        (typeof parsed?.summary === "string" && parsed.summary.trim()) ||
+        "Explore returned unstructured output and could not produce verified findings.",
+      findings,
+      evidence,
+      openQuestions:
+        openQuestions.length > 0
+          ? openQuestions
+          : parsed
+            ? []
+            : [
+                "Explore did not return structured JSON. Retry with a narrower task or inspect the raw investigation path.",
+              ],
+      recommendedNextStep: parsed
+        ? this.normalizeNextStep(parsed?.recommendedNextStep)
+        : "explore_more",
+      completedAt: new Date().toISOString(),
+    };
+  }
+
+  private buildExtractionPrompt(task: string, researchResponse: any): string {
+    const researchContent = this.truncateForExtraction(
+      typeof researchResponse?.content === "string"
+        ? researchResponse.content
+        : JSON.stringify(researchResponse?.content || {}),
+      16_000,
+    );
+
+    const toolCalls = Array.isArray(researchResponse?.toolCalls)
+      ? researchResponse.toolCalls.map((call: any) => ({
+          toolName:
+            call?.toolName || call?.name || call?.tool || "unknown_tool",
+          parameters: call?.parameters || call?.args || {},
+        }))
+      : [];
+
+    const toolResults = Array.isArray(researchResponse?.toolResults)
+      ? researchResponse.toolResults.map((result: any) => ({
+          toolName: result?.toolName || "unknown_tool",
+          error: result?.error,
+          result: this.truncateForExtraction(
+            JSON.stringify(result?.result || result?.content || result || {}),
+            8_000,
+          ),
+        }))
+      : [];
+
+    return `
+You are converting an Explore research run into strict JSON.
+
+Original task:
+${task}
+
+Research response text:
+${researchContent || "(empty)"}
+
+Tool calls:
+${JSON.stringify(toolCalls, null, 2)}
+
+Tool results:
+${JSON.stringify(toolResults, null, 2)}
+
+Return ONLY valid JSON with this exact shape:
+{
+  "summary": "string",
+  "findings": [
+    {
+      "claim": "string",
+      "confidence": "high|medium|low"
+    }
+  ],
+  "evidence": [
+    {
+      "sourceType": "file|commit|diff|jira|memory|rules|kb",
+      "ref": "string",
+      "snippet": "string",
+      "reason": "string"
+    }
+  ],
+  "openQuestions": ["string"],
+  "recommendedNextStep": "continue_review|explore_more|avoid_commenting"
+}
+
+Rules:
+- Use only information present in the research response and tool results.
+- If evidence is insufficient, keep findings empty and set recommendedNextStep to "explore_more".
+- Prefer precise file paths, commit SHAs, or ticket IDs in evidence.ref.
+- Do not include markdown fences or prose outside JSON.
+    `.trim();
+  }
+
+  private truncateForExtraction(value: string, maxChars: number): string {
+    if (value.length <= maxChars) {
+      return value;
+    }
+    return `${value.slice(0, maxChars)}\n... [truncated]`;
+  }
+
+  private shouldCacheResult(result: ExplorationResult): boolean {
+    if (result.findings.length > 0 || result.evidence.length > 0) {
+      return true;
+    }
+
+    return (
+      result.summary !==
+        "Explore returned unstructured output and could not produce verified findings." &&
+      result.openQuestions.length === 0
+    );
+  }
+
+  private normalizeFindings(input: unknown): ExplorationFinding[] {
+    if (!Array.isArray(input)) {
+      return [];
+    }
+
+    return input
+      .map((entry) => {
+        const value = (entry || {}) as Record<string, unknown>;
+        const claim = typeof value.claim === "string" ? value.claim.trim() : "";
+        if (!claim) {
+          return null;
+        }
+
+        return {
+          claim,
+          confidence: this.normalizeConfidence(value.confidence),
+        };
+      })
+      .filter((entry): entry is ExplorationFinding => entry !== null);
+  }
+
+  private normalizeEvidence(input: unknown): ExplorationEvidence[] {
+    if (!Array.isArray(input)) {
+      return [];
+    }
+
+    return input
+      .map((entry) => {
+        const value = (entry || {}) as Record<string, unknown>;
+        const sourceType = this.normalizeSourceType(value.sourceType);
+        const ref = typeof value.ref === "string" ? value.ref.trim() : "";
+        const reason =
+          typeof value.reason === "string" ? value.reason.trim() : "";
+
+        if (!ref || !reason) {
+          return null;
+        }
+
+        const result: ExplorationEvidence = {
+          sourceType,
+          ref,
+          reason,
+        };
+
+        if (typeof value.snippet === "string" && value.snippet.trim()) {
+          result.snippet = value.snippet.trim();
+        }
+
+        return result;
+      })
+      .filter((entry): entry is ExplorationEvidence => entry !== null);
+  }
+
+  private normalizeConfidence(
+    value: unknown,
+  ): ExplorationFinding["confidence"] {
+    if (typeof value !== "string") {
+      return "medium";
+    }
+
+    const normalized = value.toLowerCase();
+    return normalized === "high" ||
+      normalized === "medium" ||
+      normalized === "low"
+      ? normalized
+      : "medium";
+  }
+
+  private normalizeSourceType(
+    value: unknown,
+  ): ExplorationEvidence["sourceType"] {
+    if (typeof value !== "string") {
+      return "file";
+    }
+
+    const normalized = value.toLowerCase();
+    if (
+      normalized === "file" ||
+      normalized === "commit" ||
+      normalized === "diff" ||
+      normalized === "jira" ||
+      normalized === "memory" ||
+      normalized === "rules" ||
+      normalized === "kb"
+    ) {
+      return normalized;
+    }
+
+    return "file";
+  }
+
+  private normalizeNextStep(
+    value: unknown,
+  ): ExplorationResult["recommendedNextStep"] {
+    if (typeof value !== "string") {
+      return "continue_review";
+    }
+
+    const normalized = value.toLowerCase();
+    if (
+      normalized === "continue_review" ||
+      normalized === "explore_more" ||
+      normalized === "avoid_commenting"
+    ) {
+      return normalized;
+    }
+
+    return "continue_review";
+  }
+
+  private extractJsonPayload(content: string): Record<string, any> | null {
+    if (!content || typeof content !== "string") {
+      return null;
+    }
+
+    const trimmed = content.trim();
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      // Fall through to extraction strategies
+    }
+
+    const fenceOpen = trimmed.toLowerCase().indexOf("```json");
+    if (fenceOpen !== -1) {
+      let contentStart = fenceOpen + 7;
+      while (
+        contentStart < trimmed.length &&
+        (trimmed[contentStart] === " " ||
+          trimmed[contentStart] === "\n" ||
+          trimmed[contentStart] === "\r")
+      ) {
+        contentStart++;
+      }
+      const fenceClose = trimmed.indexOf("```", contentStart);
+      if (fenceClose !== -1) {
+        try {
+          return JSON.parse(trimmed.slice(contentStart, fenceClose).trim());
+        } catch {
+          return null;
+        }
+      }
+    }
+
+    const start = trimmed.indexOf("{");
+    const end = trimmed.lastIndexOf("}");
+    if (start >= 0 && end > start) {
+      try {
+        return JSON.parse(trimmed.slice(start, end + 1));
+      } catch {
+        return null;
+      }
+    }
+
+    return null;
+  }
+
+  private async loadProjectStandards(): Promise<string | null> {
+    if (!this.config.projectStandards?.customPromptsPath) {
+      return null;
+    }
+
+    const promptDir = join(
+      this.projectRoot,
+      this.config.projectStandards.customPromptsPath,
+    );
+    const promptFiles = [
+      "review-standards.md",
+      "security-guidelines.md",
+      "coding-conventions.md",
+    ];
+    const sections: string[] = [];
+
+    for (const file of promptFiles) {
+      const absolutePath = join(promptDir, file);
+      if (!existsSync(absolutePath)) {
+        continue;
+      }
+
+      try {
+        const content = await readFile(absolutePath, "utf-8");
+        sections.push(`## ${file}\n\n${content}`);
+      } catch {
+        continue;
+      }
+    }
+
+    return sections.length > 0 ? sections.join("\n\n---\n\n") : null;
+  }
+
+  private async loadKnowledgeBase(): Promise<string | null> {
+    if (!this.config.knowledgeBase?.enabled) {
+      return null;
+    }
+
+    try {
+      return await new KnowledgeBaseManager(
+        this.config.knowledgeBase,
+        this.projectRoot,
+      ).getForPrompt();
+    } catch {
+      return null;
+    }
+  }
+
+  private async loadRepositoryMemory(
+    runtimeContext: ExploreRuntimeContext,
+  ): Promise<string | null> {
+    if (!this.memoryManager) {
+      return null;
+    }
+
+    return this.memoryManager.readRepositoryMemory(
+      runtimeContext.workspace,
+      runtimeContext.repository,
+    );
+  }
+
+  private initializeNeurolink(): NeuroLink {
+    const observabilityConfig = buildObservabilityConfigFromEnv();
+    const neurolinkConfig: Record<string, unknown> = {
+      conversationMemory: {
+        enabled: false,
+      },
+    };
+
+    if (observabilityConfig) {
+      if (!validateObservabilityConfig(observabilityConfig)) {
+        throw new Error("Invalid observability configuration");
+      }
+      neurolinkConfig.observability = observabilityConfig;
+    }
+
+    return new NeuroLink(neurolinkConfig);
+  }
+}

--- a/src/v2/exploration/ExplorerPromptBuilder.ts
+++ b/src/v2/exploration/ExplorerPromptBuilder.ts
@@ -1,0 +1,87 @@
+import {
+  ExplorerSupportingContext,
+  ExploreContextInput,
+  ExploreRuntimeContext,
+} from "./types.js";
+
+export class ExplorerPromptBuilder {
+  buildPrompt(
+    input: ExploreContextInput,
+    runtimeContext: ExploreRuntimeContext,
+    supportingContext: ExplorerSupportingContext,
+  ): string {
+    const focus =
+      input.focus && input.focus.length > 0
+        ? input.focus
+        : ["No explicit focus provided"];
+    const contextSections: string[] = [];
+
+    if (supportingContext.projectRules) {
+      contextSections.push(
+        `<project-rules>\n${supportingContext.projectRules}\n</project-rules>`,
+      );
+    }
+    if (supportingContext.projectStandards) {
+      contextSections.push(
+        `<project-standards>\n${supportingContext.projectStandards}\n</project-standards>`,
+      );
+    }
+    if (supportingContext.knowledgeBase) {
+      contextSections.push(
+        `<knowledge-base>\n${supportingContext.knowledgeBase}\n</knowledge-base>`,
+      );
+    }
+    if (supportingContext.repositoryMemory) {
+      contextSections.push(
+        `<repository-memory>\n${supportingContext.repositoryMemory}\n</repository-memory>`,
+      );
+    }
+
+    return `
+You are Explore, a generic research worker for Yama.
+Your job is to investigate the assigned task using available tools and return only the required JSON object.
+
+Rules:
+1. You are not the reviewer. Do not approve, block, comment on the PR, or mutate repository state.
+2. Use tools as many times as needed until you can answer the task with evidence.
+3. Prefer the smallest sufficient evidence. Do not dump raw tool output.
+4. If you are uncertain, say so explicitly in findings or openQuestions.
+5. Return valid JSON only. No markdown fences or commentary outside JSON.
+
+Research task:
+- Task: ${input.task}
+- Review mode: ${runtimeContext.mode}
+- Workspace: ${runtimeContext.workspace}
+- Repository: ${runtimeContext.repository}
+- Pull request: ${runtimeContext.pullRequestId ?? "N/A"}
+- Branch: ${runtimeContext.branch || "N/A"}
+
+Focus areas:
+${focus.map((item) => `- ${item}`).join("\n")}
+
+${contextSections.join("\n\n")}
+
+Return this exact JSON shape:
+{
+  "task": "string",
+  "summary": "string",
+  "findings": [
+    {
+      "claim": "string",
+      "confidence": "high|medium|low"
+    }
+  ],
+  "evidence": [
+    {
+      "sourceType": "file|commit|diff|jira|memory|rules|kb",
+      "ref": "string",
+      "snippet": "string",
+      "reason": "string"
+    }
+  ],
+  "openQuestions": ["string"],
+  "recommendedNextStep": "continue_review|explore_more|avoid_commenting"
+}
+    `.trim();
+  }
+}

--- a/src/v2/exploration/RulesContextLoader.ts
+++ b/src/v2/exploration/RulesContextLoader.ts
@@ -1,0 +1,123 @@
+import { readdir, readFile } from "fs/promises";
+import { existsSync } from "fs";
+import { join, resolve } from "path";
+import {
+  MemoryBankConfig,
+  ProjectStandardsConfig,
+} from "../types/config.types.js";
+
+const ROOT_RULE_FILES = ["CLAUDE.md", ".clinerules", "CONTRIBUTING.md"];
+const CONTEXT_EXTENSIONS = new Set([".md", ".txt", ".yml", ".yaml"]);
+
+export class RulesContextLoader {
+  constructor(
+    private readonly memoryBank: MemoryBankConfig,
+    private readonly projectStandards?: ProjectStandardsConfig,
+    private readonly projectRoot: string = process.cwd(),
+  ) {}
+
+  async load(): Promise<string | null> {
+    const sections: string[] = [];
+
+    for (const file of ROOT_RULE_FILES) {
+      const absolutePath = resolve(this.projectRoot, file);
+      const content = await this.tryReadFile(absolutePath);
+      if (content) {
+        sections.push(`## ${file}\n\n${content}`);
+      }
+    }
+
+    const memoryBankDir = this.resolveMemoryBankDir();
+    if (memoryBankDir) {
+      const standardFiles = this.memoryBank.standardFiles || [];
+      for (const file of standardFiles) {
+        const absolutePath = join(memoryBankDir, file);
+        const content = await this.tryReadFile(absolutePath);
+        if (content) {
+          sections.push(`## memory-bank/${file}\n\n${content}`);
+        }
+      }
+
+      const directoryEntries = await this.tryReadDirectory(memoryBankDir);
+      for (const entry of directoryEntries) {
+        if (standardFiles.includes(entry)) {
+          continue;
+        }
+        const extension = entry.slice(entry.lastIndexOf("."));
+        if (!CONTEXT_EXTENSIONS.has(extension)) {
+          continue;
+        }
+        const absolutePath = join(memoryBankDir, entry);
+        const content = await this.tryReadFile(absolutePath);
+        if (content) {
+          sections.push(`## memory-bank/${entry}\n\n${content}`);
+        }
+      }
+    }
+
+    if (this.projectStandards?.customPromptsPath) {
+      const promptDir = resolve(
+        this.projectRoot,
+        this.projectStandards.customPromptsPath,
+      );
+      const promptFiles = [
+        "review-standards.md",
+        "security-guidelines.md",
+        "coding-conventions.md",
+      ];
+
+      for (const file of promptFiles) {
+        const content = await this.tryReadFile(join(promptDir, file));
+        if (content) {
+          sections.push(`## prompts/${file}\n\n${content}`);
+        }
+      }
+    }
+
+    if (sections.length === 0) {
+      return null;
+    }
+
+    return sections.join("\n\n---\n\n");
+  }
+
+  private resolveMemoryBankDir(): string | null {
+    if (!this.memoryBank.enabled) {
+      return null;
+    }
+
+    const candidates = [this.memoryBank.path, ...this.memoryBank.fallbackPaths];
+    for (const candidate of candidates) {
+      const absolutePath = resolve(this.projectRoot, candidate);
+      if (existsSync(absolutePath)) {
+        return absolutePath;
+      }
+    }
+
+    return null;
+  }
+
+  private async tryReadDirectory(path: string): Promise<string[]> {
+    try {
+      const entries = await readdir(path, { withFileTypes: true });
+      return entries
+        .filter((entry) => entry.isFile())
+        .map((entry) => entry.name)
+        .sort((left, right) => left.localeCompare(right));
+    } catch {
+      return [];
+    }
+  }
+
+  private async tryReadFile(path: string): Promise<string | null> {
+    if (!existsSync(path)) {
+      return null;
+    }
+
+    try {
+      return await readFile(path, "utf-8");
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/v2/exploration/types.ts
+++ b/src/v2/exploration/types.ts
@@ -1,0 +1,29 @@
+import { ExplorationResult } from "../types/v2.types.js";
+
+export interface ExploreContextInput {
+  task: string;
+  focus?: string[];
+}
+
+export interface ExploreRuntimeContext {
+  sessionId: string;
+  mode: "pr" | "local";
+  workspace: string;
+  repository: string;
+  pullRequestId?: number;
+  branch?: string;
+  dryRun?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ExplorerSupportingContext {
+  projectRules: string | null;
+  projectStandards: string | null;
+  knowledgeBase: string | null;
+  repositoryMemory: string | null;
+}
+
+export interface ExploreExecutionResult {
+  result: ExplorationResult;
+  cached: boolean;
+}

--- a/src/v2/memory/MemoryManager.ts
+++ b/src/v2/memory/MemoryManager.ts
@@ -147,6 +147,34 @@ export class MemoryManager {
   }
 
   /**
+   * Read persisted condensed memory for a repository owner ID.
+   */
+  async readMemory(ownerId: string): Promise<string | null> {
+    const storageDir = this.resolveStorageDir();
+    const filePath = this.ownerIdToFilePath(storageDir, ownerId);
+
+    if (!existsSync(filePath)) {
+      return null;
+    }
+
+    try {
+      return await readFile(filePath, "utf-8");
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Read persisted condensed memory for a workspace/repository pair.
+   */
+  async readRepositoryMemory(
+    workspace: string,
+    repository: string,
+  ): Promise<string | null> {
+    return this.readMemory(MemoryManager.buildOwnerId(workspace, repository));
+  }
+
+  /**
    * Commit memory files to the repository if autoCommit is enabled.
    *
    * Checks git status for changes in the storagePath directory,

--- a/src/v2/prompts/LangfusePromptManager.ts
+++ b/src/v2/prompts/LangfusePromptManager.ts
@@ -27,6 +27,17 @@ export class LangfusePromptManager {
    * Initialize Langfuse client if credentials are available
    */
   private initializeClient(): void {
+    const skipLangfusePrompts =
+      process.env.YAMA_SKIP_LANGFUSE_PROMPTS === "true" ||
+      process.env.YAMA_SKIP_LANGFUSE_PROMPTS === "1";
+
+    if (skipLangfusePrompts) {
+      console.log(
+        "   ⏭️  Langfuse prompt fetch disabled (YAMA_SKIP_LANGFUSE_PROMPTS) — using local prompts",
+      );
+      return;
+    }
+
     const publicKey = process.env.LANGFUSE_PUBLIC_KEY;
     const secretKey = process.env.LANGFUSE_SECRET_KEY;
     const baseUrl = process.env.LANGFUSE_BASE_URL;

--- a/src/v2/prompts/PromptBuilder.ts
+++ b/src/v2/prompts/PromptBuilder.ts
@@ -29,9 +29,10 @@ export class PromptBuilder {
   async buildReviewInstructions(
     request: ReviewRequest,
     config: YamaConfig,
+    bootstrapStandards?: string | null,
   ): Promise<string> {
     // Base system prompt - fetched from Langfuse or local fallback
-    const basePrompt = await this.langfuseManager.getReviewPrompt();
+    const basePromptRaw = await this.langfuseManager.getReviewPrompt();
 
     // Project-specific configuration in XML format
     const projectConfig = this.buildProjectConfigXML(config, request);
@@ -41,6 +42,32 @@ export class PromptBuilder {
 
     // Knowledge base learnings (reinforcement learning)
     const knowledgeBase = await this.loadKnowledgeBase(config);
+    const exploreEnabled = config.ai.explore.enabled;
+
+    // Strip explore_context references when the subagent is disabled.
+    const basePrompt = PromptBuilder.stripDisabledSections(
+      basePromptRaw,
+      exploreEnabled,
+    );
+
+    const workflowBlock = PromptBuilder.stripDisabledSections(
+      this.buildReviewWorkflow(request),
+      exploreEnabled,
+    );
+
+    const bootstrapBlock =
+      bootstrapStandards && bootstrapStandards.trim().length > 0
+        ? `<bootstrapped-standards>
+<!--
+Recurring reviewer patterns observed in recent merged PRs on this repo.
+These are runtime observations, not config rules. Treat them as guidance
+that ranks BELOW <blocking-criteria> but ABOVE generic suggestions.
+If they conflict with <project-standards> or <blocking-criteria>, the
+config wins.
+-->
+${bootstrapStandards.trim()}
+</bootstrapped-standards>`
+        : "";
 
     // Combine all parts
     return `
@@ -52,6 +79,8 @@ ${projectConfig}
 
 ${projectStandards ? `<project-standards>\n${projectStandards}\n</project-standards>` : ""}
 
+${bootstrapBlock}
+
 ${knowledgeBase ? `<learned-knowledge>\n${knowledgeBase}\n</learned-knowledge>` : ""}
 
 <review-task>
@@ -61,22 +90,119 @@ ${knowledgeBase ? `<learned-knowledge>\n${knowledgeBase}\n</learned-knowledge>` 
   <branch>${this.escapeXML(request.branch || "N/A")}</branch>
   <mode>${request.dryRun ? "dry-run" : "live"}</mode>
 
-  <instructions>
-    Begin your autonomous code review now.
-
-    1. Call get_pull_request() to read PR details and existing comments
-    2. Analyze files one by one using get_pull_request_diff()
-    3. Use search_code() BEFORE commenting on unfamiliar code
-    4. Post comments immediately with add_comment() using line_number and line_type from diff
-    5. Apply blocking criteria to make final decision
-    6. Call set_pr_approval(approved: true) or set_review_status(request_changes: true)
-    7. Post summary comment with statistics
-
-    ${request.dryRun ? "DRY RUN MODE: Simulate actions only, do not post real comments." : "LIVE MODE: Post real comments and make real decisions."}
-    ${request.prompt ? `ADDITIONAL INSTRUCTIONS: ${this.escapeXML(request.prompt)}` : ""}
-  </instructions>
+${workflowBlock}
 </review-task>
     `.trim();
+  }
+
+  /**
+   * Per-PR workflow block. Standards-first, file-by-file, explore-on-uncertainty.
+   * The agent stays autonomous; this just choreographs the order it should follow.
+   */
+  private buildReviewWorkflow(request: ReviewRequest): string {
+    const modeLine = request.dryRun
+      ? "DRY RUN MODE: simulate actions only, do not post real comments or change PR state."
+      : "LIVE MODE: post real comments and make real decisions.";
+    const additional = request.prompt
+      ? `\n  ADDITIONAL INSTRUCTIONS: ${this.escapeXML(request.prompt)}`
+      : "";
+
+    return `  <instructions>
+    Begin your autonomous review. Follow this order.
+
+    STEP 1 — Read project standards
+    Read the <project-standards> block above carefully. Treat any reviewer-expectation
+    entry with severity=BLOCKING as a blocking criterion for this PR. If the block is
+    missing or empty, fall back to <focus-areas> and <blocking-criteria>.
+
+    STEP 2 — Read the PR shell
+    Call get_pull_request once to get changed files, branch info, and existing comments.
+    Build a mental map of which files exist and which already have comments.
+    Do NOT request the full PR diff.
+
+    STEP 3 — Walk files one at a time
+    For each changed file, in order:
+      a. Call get_pull_request_diff(file_path=&lt;this file&gt;).
+      b. Cross-check the diff against project-standards and existing comments on this file.
+      c. If anything is non-trivial — multi-file impact, unfamiliar pattern, unclear intent,
+         history-dependent behavior — <!-- EXPLORE_BEGIN -->call explore_context with a precise
+         task and wait for its evidence before commenting<!-- EXPLORE_END --><!-- EXPLORE_DISABLED_BEGIN -->use search_code or get_file_content to verify before commenting<!-- EXPLORE_DISABLED_END -->.
+      d. For every confirmed issue, call add_comment immediately with line_number and
+         line_type from the diff JSON. Include a real-code suggestion for CRITICAL/MAJOR.
+      e. Move to the next file. Never request another file's diff before finishing the
+         current one. Never request a multi-file diff.
+
+    STEP 4 — Decision
+    After the last file, count issues by severity, apply <blocking-criteria>, and call
+    set_pr_approval(approved=true) OR set_review_status(request_changes=true).
+
+    STEP 5 — Summary comment
+    Post one summary comment with file count, issue counts by severity, and next steps.
+
+    Budget guidance: roughly 10 tool calls per file in the main loop. If you exceed
+    that on a single file, <!-- EXPLORE_BEGIN -->delegate the rest to explore_context<!-- EXPLORE_END --><!-- EXPLORE_DISABLED_BEGIN -->stop investigating<!-- EXPLORE_DISABLED_END --> and move on.
+
+    ${modeLine}${additional}
+  </instructions>`;
+  }
+
+  /**
+   * Strip sections that depend on explore_context being enabled.
+   * Keeps the prompt single-source and avoids forking files for the disabled case.
+   *
+   * - <!-- EXPLORE_BEGIN -->...<!-- EXPLORE_END --> is removed when explore is OFF.
+   * - <!-- EXPLORE_DISABLED_BEGIN -->...<!-- EXPLORE_DISABLED_END --> is removed when explore is ON.
+   * - The marker comments themselves are always stripped.
+   *
+   * Implementation uses linear indexOf/slice instead of regex to avoid any
+   * polynomial-backtracking risk on adversarial input.
+   */
+  static stripDisabledSections(
+    prompt: string,
+    exploreEnabled: boolean,
+  ): string {
+    const EXPLORE_BEGIN = "<!-- EXPLORE_BEGIN -->";
+    const EXPLORE_END = "<!-- EXPLORE_END -->";
+    const EXPLORE_DISABLED_BEGIN = "<!-- EXPLORE_DISABLED_BEGIN -->";
+    const EXPLORE_DISABLED_END = "<!-- EXPLORE_DISABLED_END -->";
+
+    const stripBlock = (text: string, start: string, end: string): string => {
+      let out = "";
+      let cursor = 0;
+      while (cursor <= text.length) {
+        const s = text.indexOf(start, cursor);
+        if (s === -1) {
+          out += text.slice(cursor);
+          break;
+        }
+        out += text.slice(cursor, s);
+        const e = text.indexOf(end, s + start.length);
+        if (e === -1) {
+          out += text.slice(s);
+          break;
+        }
+        cursor = e + end.length;
+      }
+      return out;
+    };
+
+    const removeAll = (text: string, marker: string): string =>
+      text.split(marker).join("");
+
+    if (exploreEnabled) {
+      let result = stripBlock(
+        prompt,
+        EXPLORE_DISABLED_BEGIN,
+        EXPLORE_DISABLED_END,
+      );
+      result = removeAll(result, EXPLORE_BEGIN);
+      result = removeAll(result, EXPLORE_END);
+      return result;
+    }
+    let result = stripBlock(prompt, EXPLORE_BEGIN, EXPLORE_END);
+    result = removeAll(result, EXPLORE_DISABLED_BEGIN);
+    result = removeAll(result, EXPLORE_DISABLED_END);
+    return result;
   }
 
   /**
@@ -301,23 +427,24 @@ ${enhancementConfigXML}
       diffContext.diff.length > diffPreviewMaxChars
         ? `${diffContext.diff.slice(0, diffPreviewMaxChars)}\n... [truncated preview]`
         : diffContext.diff;
+    const exploreEnabled = config.ai.explore.enabled;
 
-    return `
+    const projectStandards = await this.loadProjectStandards(config);
+
+    const rawPrompt = `
 You are Yama operating in LOCAL SDK MODE.
 Review the provided git changes and return a strict JSON object only.
 
-Rules:
-1. Use available local repository tools to verify unfamiliar symbols, imports, and patterns before reporting issues.
-2. Do not use PR/Jira MCP tools in local mode.
-3. Do not add markdown code fences.
-4. Output must start with "{" and end with "}".
-5. Keep findings actionable and file/line specific where possible.
-6. Prefer bounded local-git/file tools for targeted context; avoid broad full-repo or full-history fetches.
+${projectStandards ? `<project-standards>\n${projectStandards}\n</project-standards>\n` : ""}
 
-Context Verification Workflow:
-- Start from the diff.
-- If logic is unclear, inspect referenced files/functions with local tools.
-- Avoid assumptions when code context is missing.
+Workflow (follow in order):
+1. STANDARDS FIRST. Read <project-standards> above (if present). Treat any rule with severity=BLOCKING as a blocking criterion.
+2. WALK FILES ONE AT A TIME. For each file in the changed-files list below, inspect its diff portion, then use local-git/file tools to verify any unfamiliar symbols, imports, or patterns in THAT file before moving on. Never analyse multiple files in parallel.
+3. VERIFY BEFORE REPORTING.<!-- EXPLORE_BEGIN --> For non-trivial research — multi-file tracing, project search, older commit understanding, ambiguous logic — delegate to explore_context() and trust its evidence. Do not report findings on areas where explore_context returned no evidence.<!-- EXPLORE_END --><!-- EXPLORE_DISABLED_BEGIN --> Use bounded local-git/file tools (search_code, get_file_content) to verify before reporting. If a check would need more than a few tool calls, narrow the scope or skip that area instead of guessing.<!-- EXPLORE_DISABLED_END -->
+4. NEVER use PR/Jira MCP tools in local mode.
+5. KEEP FINDINGS ACTIONABLE — file path + line number + concrete fix where possible.
+6. BUDGET — roughly 10 tool calls per file in the main loop. If you exceed it,<!-- EXPLORE_BEGIN --> delegate the rest to explore_context<!-- EXPLORE_END --><!-- EXPLORE_DISABLED_BEGIN --> stop investigating that file<!-- EXPLORE_DISABLED_END --> and move to the next file.
+7. OUTPUT — return strict JSON only. No markdown code fences. Output must start with "{" and end with "}".
 
 Focus Areas:
 ${focusAreas.map((area) => `- ${area}`).join("\n")}
@@ -368,7 +495,11 @@ Output Schema (version ${schemaVersion}):
     }
   ]
 }
-    `.trim();
+`;
+    return PromptBuilder.stripDisabledSections(
+      rawPrompt,
+      exploreEnabled,
+    ).trim();
   }
 
   /**

--- a/src/v2/prompts/ReviewSystemPrompt.ts
+++ b/src/v2/prompts/ReviewSystemPrompt.ts
@@ -1,280 +1,87 @@
 /**
- * Base Review System Prompt
- * Generic, project-agnostic instructions for code review
- * Project-specific rules come from config
+ * Base Review System Prompt.
+ *
+ * Generic, project-agnostic. Project-specific rules and the per-PR workflow
+ * come from PromptBuilder. Keep this file lean — anything the orchestrator
+ * already enforces or the model reliably produces should NOT live here.
+ *
+ * Sections wrapped in <!-- EXPLORE_BEGIN --> ... <!-- EXPLORE_END --> markers
+ * are stripped by PromptBuilder when config.ai.explore.enabled is false.
  */
 
 export const REVIEW_SYSTEM_PROMPT = `
 <yama-review-system>
   <identity>
     <role>Autonomous Code Review Agent</role>
-    <authority>Read code, analyze changes, post comments, make PR decisions</authority>
+    <authority>Read code, post inline comments, approve or request changes on a PR.</authority>
   </identity>
 
   <core-rules>
-    <rule priority="CRITICAL" id="verify-before-comment">
-      <title>Never Assume - Always Verify</title>
-      <description>
-        Before commenting on ANY code, use tools to understand context.
-        If you see unfamiliar functions, imports, or patterns: search first, comment second.
-      </description>
-      <examples>
-        <example>See function call → search_code() to find definition</example>
-        <example>See import statement → get_file_content() to read module</example>
-        <example>Unsure about pattern → search_code() to find similar usage</example>
-      </examples>
-    </rule>
-
-    <rule priority="CRITICAL" id="accurate-commenting">
-      <title>Accurate Comment Placement</title>
-      <description>
-        Use line_number and line_type from diff JSON for inline comments.
-        The diff provides structured line information - use it directly.
-      </description>
-      <workflow>
-        <step>Read diff JSON to identify issue (note line type and number)</step>
-        <step>For ADDED lines: use destination_line as line_number</step>
-        <step>For REMOVED lines: use source_line as line_number</step>
-        <step>For CONTEXT lines: use destination_line as line_number</step>
-        <step>Call add_comment with file_path, line_number, line_type</step>
-      </workflow>
-    </rule>
-
-    <rule priority="MAJOR" id="progressive-loading">
-      <title>Lazy Context Loading</title>
-      <description>
-        Never request all information upfront.
-        Read files ONLY when you need specific context.
-        Use tools progressively as you discover what you need.
-      </description>
-    </rule>
-
-    <rule priority="MAJOR" id="real-time-feedback">
-      <title>Comment Immediately When Found</title>
-      <description>
-        Post comments as soon as you find issues.
-        Don't wait until the end to batch all comments.
-        Provide actionable feedback with specific examples.
-      </description>
-    </rule>
-
-    <rule priority="MAJOR" id="file-by-file">
-      <title>Process Files One at a Time</title>
-      <description>
-        Get diff for ONE file, analyze it completely, post all comments.
-        Only then move to the next file.
-        Never jump between files.
-      </description>
-    </rule>
-
-    <rule priority="MAJOR" id="avoid-duplicates">
-      <title>Check Existing Comments</title>
-      <description>
-        Before adding a comment, check if the issue is already reported.
-        If developer replied incorrectly, reply to their comment.
-        Track: new_comments, replies, skipped_duplicates.
-      </description>
-    </rule>
+    <rule id="standards-first">Read the &lt;project-standards&gt; block in your task before touching any file. Treat reviewer-expectation entries with severity=BLOCKING as blocking criteria for the PR.</rule>
+    <rule id="verify-before-comment">Never comment on code you don't understand. Use search_code or get_file_content for cheap, single-shot lookups.<!-- EXPLORE_BEGIN --> Use explore_context whenever the investigation is broader than a single tool call, spans multiple files, or depends on history.<!-- EXPLORE_END --></rule>
+    <rule id="file-by-file">Process exactly one file at a time. Get its diff, analyze it fully, post all comments for it, then move on. Never request another file's diff before finishing the current file. Never request a full multi-file PR diff.</rule>
+    <rule id="accurate-commenting">Inline comments use line_number and line_type taken directly from the diff JSON: ADDED → destination_line, REMOVED → source_line, CONTEXT → destination_line.</rule>
+    <rule id="comment-immediately">Post comments as you find issues. Do not batch them until the end.</rule>
+    <rule id="avoid-duplicates">Check existing comments before posting. If a developer's reply is wrong, reply to it instead of duplicating.</rule>
   </core-rules>
 
   <tool-usage>
     <tool name="get_pull_request">
-      <when>At the start of review</when>
-      <purpose>Get PR details, branch names, existing comments</purpose>
-      <output>Parse source/destination branches, build comments map</output>
-    </tool>
-
-    <tool name="search_code">
-      <when>Before commenting on unfamiliar code</when>
-      <purpose>Find function definitions, understand patterns, verify usage</purpose>
-      <critical>MANDATORY before commenting if you don't understand the code</critical>
-      <examples>
-        <example>
-          <situation>See "validatePayment(data)" in diff</situation>
-          <action>search_code(search_query="function validatePayment")</action>
-          <reason>Understand validation logic before reviewing</reason>
-        </example>
-        <example>
-          <situation>See "import { AuthService } from '@/services/auth'"</situation>
-          <action>get_file_content(file_path="services/auth.ts")</action>
-          <reason>Understand AuthService interface before reviewing usage</reason>
-        </example>
-      </examples>
-    </tool>
-
-    <tool name="get_file_content">
-      <when>Need to understand imports or surrounding code</when>
-      <purpose>Read files for context</purpose>
-      <note>For context understanding only - add_comment uses line_number from diff</note>
+      <use-when>Once at the start, to read PR metadata and existing comments.</use-when>
     </tool>
 
     <tool name="get_pull_request_diff">
-      <when>For EACH file, ONE at a time</when>
-      <purpose>Get code changes for analysis</purpose>
-      <workflow>
-        <step>Get diff for file A</step>
-        <step>Analyze all changes in file A</step>
-        <step>Post all comments for file A</step>
-        <step>Move to file B</step>
-      </workflow>
+      <use-when>For ONE file at a time, immediately before reviewing it.</use-when>
+      <do-not-use-when>Never call this without a file_path argument. Never request the full PR diff.</do-not-use-when>
     </tool>
 
+    <tool name="search_code">
+      <use-when>A single direct lookup answers your question (function definition, single file).</use-when>
+      <do-not-use-when>The investigation needs more than one call or spans multiple files — delegate to explore_context instead.</do-not-use-when>
+    </tool>
+
+    <tool name="get_file_content">
+      <use-when>You already know the path and need the file's contents.</use-when>
+    </tool>
+
+    <!-- EXPLORE_BEGIN -->
+    <tool name="explore_context">
+      <use-when>Multi-step research, multi-file tracing, history lookup, ambiguous behavior, or anything that would otherwise need 3+ tool calls in the main loop.</use-when>
+      <do-not-use-when>A single search_code or get_file_content would answer it. Delegating cheap lookups wastes a turn.</do-not-use-when>
+      <how>Pass a one-sentence research question as task and optional file paths/PR refs as focus. The subagent returns evidence-backed findings; trust the evidence, and if it's empty, do not comment on that area.</how>
+      <example positive>Diff adds a retry guard in PaymentProcessor → explore_context(task="Is this retry guard consistent with how other payment handlers retry, and does it match the convention from PR 842?", focus=["src/payments/", "PR 842"])</example>
+      <example negative>Don't: explore_context(task="What does validatePayment do?"). Do: search_code(search_query="function validatePayment").</example>
+    </tool>
+    <!-- EXPLORE_END -->
+
     <tool name="add_comment">
-      <format>
-        <field name="file_path" required="true">
-          Path to the file from the diff
-        </field>
-        <field name="line_number" required="true">
-          Line number from diff JSON:
-          - ADDED lines: use destination_line
-          - REMOVED lines: use source_line
-          - CONTEXT lines: use destination_line
-        </field>
-        <field name="line_type" required="true">
-          Line type from diff: "ADDED", "REMOVED", or "CONTEXT"
-        </field>
-        <field name="comment_text" required="true">
-          The review comment content
-        </field>
-        <field name="suggestion" required="for-critical-major">
-          Real, executable fix code (creates "Apply" button in UI)
-        </field>
-      </format>
-
-      <critical-requirements>
-        <requirement>line_number must match the diff JSON exactly</requirement>
-        <requirement>line_type must match the line's type from diff</requirement>
-        <requirement>For CRITICAL issues: MUST include suggestion with real fix</requirement>
-        <requirement>For MAJOR issues: MUST include suggestion with real fix</requirement>
-        <requirement>Suggestions must be real code, not comments or pseudo-code</requirement>
-      </critical-requirements>
-
-      <line-mapping-examples>
-        <example type="ADDED">
-          Diff line: {"destination_line": 42, "type": "ADDED", "content": "  return null;"}
-          Comment: {line_number: 42, line_type: "ADDED"}
-        </example>
-        <example type="REMOVED">
-          Diff line: {"source_line": 15, "type": "REMOVED", "content": "  oldFunction();"}
-          Comment: {line_number: 15, line_type: "REMOVED"}
-        </example>
-      </line-mapping-examples>
+      <fields>file_path, line_number, line_type (ADDED|REMOVED|CONTEXT), comment_text, and suggestion (required for CRITICAL and MAJOR — must be real, executable code).</fields>
+      <do-not-use-when>You only have a code_snippet but no line_number/line_type from the diff JSON.</do-not-use-when>
     </tool>
 
     <tool name="set_pr_approval">
-      <when>No blocking issues found</when>
-      <usage>Use approved: true</usage>
+      <use-when>No blocking issues found. Pass approved=true.</use-when>
     </tool>
 
     <tool name="set_review_status">
-      <when>Blocking criteria met</when>
-      <usage>Use request_changes: true</usage>
+      <use-when>Blocking criteria met. Pass request_changes=true.</use-when>
     </tool>
   </tool-usage>
 
   <severity-levels>
-    <level name="CRITICAL" emoji="🔒" action="ALWAYS_BLOCK">
-      <description>Issues that could cause security breaches, data loss, or system failures</description>
-      <characteristics>
-        <item>Security vulnerabilities</item>
-        <item>Data loss risks</item>
-        <item>Authentication/authorization flaws</item>
-        <item>Hardcoded secrets</item>
-      </characteristics>
-      <requirement>MUST provide real fix code in suggestion field</requirement>
-    </level>
-
-    <level name="MAJOR" emoji="⚠️" action="BLOCK_IF_MULTIPLE">
-      <description>Significant bugs, performance issues, or broken functionality</description>
-      <characteristics>
-        <item>Performance bottlenecks (N+1 queries, memory leaks)</item>
-        <item>Logic errors that break functionality</item>
-        <item>Unhandled errors in critical paths</item>
-        <item>Breaking API changes</item>
-      </characteristics>
-      <requirement>MUST provide real fix code in suggestion field</requirement>
-    </level>
-
-    <level name="MINOR" emoji="💡" action="REQUEST_CHANGES">
-      <description>Code quality and maintainability issues</description>
-      <characteristics>
-        <item>Code duplication</item>
-        <item>Poor naming</item>
-        <item>Missing error handling in non-critical paths</item>
-        <item>Complexity issues</item>
-      </characteristics>
-      <requirement>Provide guidance, fix optional</requirement>
-    </level>
-
-    <level name="SUGGESTION" emoji="💬" action="INFORM">
-      <description>Improvements and optimizations</description>
-      <characteristics>
-        <item>Better patterns available</item>
-        <item>Potential optimizations</item>
-        <item>Documentation improvements</item>
-      </characteristics>
-      <requirement>Informational only</requirement>
-    </level>
+    <level name="CRITICAL" emoji="🔒">Blocks the PR. MUST include a real-code suggestion. Security, data loss, auth flaws, hardcoded secrets.</level>
+    <level name="MAJOR"    emoji="⚠️">Blocks if multiple. MUST include a real-code suggestion. Logic bugs, perf issues, broken APIs.</level>
+    <level name="MINOR"    emoji="💡">Request changes. Suggestion optional. Quality, naming, duplication.</level>
+    <level name="SUGGESTION" emoji="💬">Informational. Optimizations and improvements.</level>
   </severity-levels>
 
-  <comment-format>
-    <structure>
-{emoji} **{SEVERITY}**: {one-line summary}
-
-**Issue**: {detailed explanation of what's wrong}
-
-**Impact**: {what could go wrong if not fixed}
-
-**Fix**:
-\`\`\`language
-// Real, working code that solves the problem
-\`\`\`
-
-**Reference**: {link to docs/standards if applicable}
-    </structure>
-  </comment-format>
-
-  <decision-workflow>
-    <step>Count issues by severity (critical, major, minor, suggestions)</step>
-    <step>Apply blocking criteria from project configuration</step>
-    <step>If blocked: set_review_status(request_changes: true) with summary</step>
-    <step>If approved: set_pr_approval(approved: true)</step>
-    <step>Post summary comment with statistics and next steps</step>
-  </decision-workflow>
-
-  <summary-format>
-## 🤖 Yama Review Summary
-
-**Decision**: {✅ APPROVED | ⚠️ CHANGES REQUESTED | 🚫 BLOCKED}
-
-**Issues Found**: 🔒 {critical} | ⚠️ {major} | 💡 {minor} | 💬 {suggestions}
-**Comments**: {new} new, {replies} replies | Skipped {duplicates} duplicates
-
-{IF blocked:}
-### 🔒 Critical Issues to Fix
-- {file:line} - {brief summary}
-
-### ⚠️ Major Issues to Address
-- {file:line} - {brief summary}
-
-### 📋 Next Steps
-- [ ] Apply fix suggestions (click "Apply" button)
-- [ ] Fix critical issues
-- [ ] Re-request review after fixes
-
----
-_Review powered by Yama V2 • {files} files analyzed_
-  </summary-format>
-
   <anti-patterns>
-    <dont>Request all files upfront - use lazy loading</dont>
-    <dont>Batch comments until the end - comment immediately</dont>
-    <dont>Assume what code does - use search_code() to verify</dont>
-    <dont>Skip verification - always search before commenting</dont>
-    <dont>Give vague feedback - provide specific examples</dont>
-    <dont>Use code_snippet approach - use line_number and line_type from diff JSON instead</dont>
-    <dont>Jump between files - complete one file before moving on</dont>
-    <dont>Duplicate existing comments - check first</dont>
+    <dont>Request all files upfront — use lazy loading, one file at a time.</dont>
+    <dont>Batch comments until the end — comment immediately as you find issues.</dont>
+    <dont>Assume what code does — verify with tools first.</dont>
+    <dont>Use a code_snippet field — always use line_number and line_type from the diff JSON.</dont>
+    <dont>Jump between files — finish one file before starting another.</dont>
+    <dont>Duplicate an existing comment — check first; reply if a developer's response is wrong.</dont>
   </anti-patterns>
 </yama-review-system>
 `;

--- a/src/v2/types/config.types.ts
+++ b/src/v2/types/config.types.ts
@@ -42,8 +42,17 @@ export interface DisplayConfig {
 // AI Configuration
 // ============================================================================
 
+/**
+ * AI provider identifier. Yama does not maintain its own provider allow-list —
+ * the value is forwarded verbatim to NeuroLink, which owns the real list
+ * (vertex, google-ai, anthropic, openai, bedrock, azure, litellm, ollama,
+ * huggingface, mistral, sagemaker, auto, ...). Typed as `string` so new
+ * NeuroLink providers work without a type bump here.
+ */
+export type AIProvider = string;
+
 export interface AIConfig {
-  provider: "auto" | "google-ai" | "anthropic" | "openai" | "bedrock" | "azure";
+  provider: AIProvider;
   model: string;
   temperature: number;
   maxTokens: number;
@@ -54,6 +63,17 @@ export interface AIConfig {
   enableToolFiltering?: boolean;
   toolFilteringMode?: "off" | "log-only" | "active";
   conversationMemory: ConversationMemoryConfig;
+  explore: ExploreAIConfig;
+}
+
+export interface ExploreAIConfig {
+  enabled: boolean;
+  provider?: AIProvider;
+  model?: string;
+  temperature?: number;
+  maxTokens?: number;
+  timeout?: string;
+  cacheResults?: boolean;
 }
 
 export interface ConversationMemoryConfig {

--- a/src/v2/types/v2.types.ts
+++ b/src/v2/types/v2.types.ts
@@ -169,6 +169,7 @@ export interface ReviewSession {
   result?: ReviewResult;
   error?: Error;
   metadata: SessionMetadata;
+  explorations?: ExplorationRecord[];
 }
 
 export interface ToolCallRecord {
@@ -188,6 +189,37 @@ export interface SessionMetadata {
   totalTokens: number;
   totalCost: number;
   cacheHitRatio: number;
+}
+
+export interface ExplorationRecord {
+  task: string;
+  cacheKey: string;
+  focus: string[];
+  result: ExplorationResult;
+  createdAt: Date;
+  cached: boolean;
+}
+
+export interface ExplorationResult {
+  task: string;
+  summary: string;
+  findings: ExplorationFinding[];
+  evidence: ExplorationEvidence[];
+  openQuestions: string[];
+  recommendedNextStep: "continue_review" | "explore_more" | "avoid_commenting";
+  completedAt: string;
+}
+
+export interface ExplorationFinding {
+  claim: string;
+  confidence: "high" | "medium" | "low";
+}
+
+export interface ExplorationEvidence {
+  sourceType: "file" | "commit" | "diff" | "jira" | "memory" | "rules" | "kb";
+  ref: string;
+  snippet?: string;
+  reason: string;
 }
 
 // ============================================================================

--- a/tests/__mocks__/@juspay/neurolink.ts
+++ b/tests/__mocks__/@juspay/neurolink.ts
@@ -1,6 +1,41 @@
 // Mock for @juspay/neurolink
 export class NeuroLink {
+  private customTools = new Map<string, any>();
+  private toolContext: Record<string, unknown> | null = null;
+
   constructor() {}
+
+  registerTool(name: string, tool: any): void {
+    this.customTools.set(name, tool);
+  }
+
+  setToolContext(context: Record<string, unknown>): void {
+    this.toolContext = context;
+  }
+
+  getCustomTools(): Map<string, any> {
+    return this.customTools;
+  }
+
+  async addExternalMCPServer(): Promise<void> {}
+
+  async listMCPServers(): Promise<any[]> {
+    return [];
+  }
+
+  async getMCPStatus(): Promise<any> {
+    return { totalServers: 0, totalTools: 0 };
+  }
+
+  getExternalMCPTools(): any[] {
+    return [];
+  }
+
+  getExternalMCPServerTools(): any[] {
+    return [];
+  }
+
+  async removeExternalMCPServer(): Promise<void> {}
 
   async generate(options: any): Promise<any> {
     // Mock AI response for testing
@@ -36,6 +71,7 @@ export class NeuroLink {
         provider: "mock",
         responseTime: 100,
       },
+      toolContext: this.toolContext,
     };
   }
 }

--- a/tests/v2/unit/prompts.test.ts
+++ b/tests/v2/unit/prompts.test.ts
@@ -17,6 +17,13 @@ describe("Review System Prompt", () => {
     expect(REVIEW_SYSTEM_PROMPT.length).toBeGreaterThan(100);
   });
 
+  it("should stay tight — guard against drift back to the long prompt", () => {
+    // The slimmed prompt is ~75 lines of content. Cap at 110 so trivial
+    // additions don't silently regrow it back toward the old ~295-line version.
+    const lineCount = REVIEW_SYSTEM_PROMPT.split("\n").length;
+    expect(lineCount).toBeLessThanOrEqual(110);
+  });
+
   it("should contain core XML structure", () => {
     expect(REVIEW_SYSTEM_PROMPT).toContain("<yama-review-system>");
     expect(REVIEW_SYSTEM_PROMPT).toContain("</yama-review-system>");
@@ -28,19 +35,38 @@ describe("Review System Prompt", () => {
     expect(REVIEW_SYSTEM_PROMPT).toContain("Autonomous Code Review Agent");
   });
 
-  it("should contain core rules", () => {
+  it("should contain core rules including the new standards-first and file-by-file rules", () => {
     expect(REVIEW_SYSTEM_PROMPT).toContain("<core-rules>");
+    expect(REVIEW_SYSTEM_PROMPT).toContain('id="standards-first"');
     expect(REVIEW_SYSTEM_PROMPT).toContain('id="verify-before-comment"');
+    expect(REVIEW_SYSTEM_PROMPT).toContain('id="file-by-file"');
     expect(REVIEW_SYSTEM_PROMPT).toContain('id="accurate-commenting"');
   });
 
-  it("should contain tool usage instructions", () => {
+  it("should contain tool usage instructions for the tools the agent actually uses", () => {
     expect(REVIEW_SYSTEM_PROMPT).toContain("<tool-usage>");
+    expect(REVIEW_SYSTEM_PROMPT).toContain('<tool name="get_pull_request">');
+    expect(REVIEW_SYSTEM_PROMPT).toContain(
+      '<tool name="get_pull_request_diff">',
+    );
     expect(REVIEW_SYSTEM_PROMPT).toContain('<tool name="search_code">');
+    expect(REVIEW_SYSTEM_PROMPT).toContain('<tool name="explore_context">');
     expect(REVIEW_SYSTEM_PROMPT).toContain('<tool name="add_comment">');
     expect(REVIEW_SYSTEM_PROMPT).toContain('<tool name="set_pr_approval">');
     expect(REVIEW_SYSTEM_PROMPT).toContain('<tool name="set_review_status">');
-    expect(REVIEW_SYSTEM_PROMPT).toContain("code_snippet");
+  });
+
+  it("should describe explore_context with use-when / do-not-use-when guidance", () => {
+    // The whole point of the rewrite — the model needs a clear decision rule.
+    const exploreBlockMatch = REVIEW_SYSTEM_PROMPT.match(
+      /<tool name="explore_context">[\s\S]*?<\/tool>/,
+    );
+    expect(exploreBlockMatch).not.toBeNull();
+    const block = exploreBlockMatch![0];
+    expect(block).toContain("<use-when>");
+    expect(block).toContain("<do-not-use-when>");
+    expect(block).toMatch(/example positive/);
+    expect(block).toMatch(/example negative/);
   });
 
   it("should contain severity levels", () => {
@@ -53,7 +79,7 @@ describe("Review System Prompt", () => {
 
   it("should contain anti-patterns", () => {
     expect(REVIEW_SYSTEM_PROMPT).toContain("<anti-patterns>");
-    expect(REVIEW_SYSTEM_PROMPT).toContain("use lazy loading");
+    expect(REVIEW_SYSTEM_PROMPT).toContain("lazy loading");
     expect(REVIEW_SYSTEM_PROMPT).toContain("code_snippet");
   });
 
@@ -128,6 +154,15 @@ describe("PromptBuilder", () => {
         enableEvaluation: false,
         timeout: "10m",
         retryAttempts: 3,
+        explore: {
+          enabled: true,
+          provider: "google-ai",
+          model: "gemini-2.5-flash",
+          temperature: 0.1,
+          maxTokens: 32000,
+          timeout: "5m",
+          cacheResults: true,
+        },
         conversationMemory: {
           enabled: true,
           store: "memory",
@@ -293,6 +328,113 @@ describe("PromptBuilder", () => {
 
       expect(result).toContain("<mode>live</mode>");
       expect(result).toContain("LIVE MODE");
+    });
+
+    it("should follow the standards-first / file-by-file workflow", async () => {
+      const result = await builder.buildReviewInstructions(
+        mockRequest,
+        mockConfig,
+      );
+
+      expect(result).toContain("STEP 1 — Read project standards");
+      expect(result).toContain("STEP 2 — Read the PR shell");
+      expect(result).toContain("STEP 3 — Walk files one at a time");
+      expect(result).toContain("STEP 4 — Decision");
+      expect(result).toContain("STEP 5 — Summary comment");
+      // Ordering invariant — STEP 1 must come before STEP 3 in the rendered prompt.
+      expect(result.indexOf("STEP 1")).toBeLessThan(result.indexOf("STEP 3"));
+    });
+
+    it("should reference explore_context when explore is enabled", async () => {
+      mockConfig.ai.explore.enabled = true;
+      const result = await builder.buildReviewInstructions(
+        mockRequest,
+        mockConfig,
+      );
+
+      expect(result).toContain("explore_context");
+      // Markers themselves must always be stripped, regardless of mode.
+      expect(result).not.toContain("EXPLORE_BEGIN");
+      expect(result).not.toContain("EXPLORE_END");
+      expect(result).not.toContain("EXPLORE_DISABLED_BEGIN");
+      expect(result).not.toContain("EXPLORE_DISABLED_END");
+    });
+
+    it("should strip explore_context references when explore is disabled", async () => {
+      mockConfig.ai.explore.enabled = false;
+      const result = await builder.buildReviewInstructions(
+        mockRequest,
+        mockConfig,
+      );
+
+      // The dedicated tool block and the workflow callouts should be gone.
+      expect(result).not.toContain('<tool name="explore_context">');
+      // Markers themselves must always be stripped.
+      expect(result).not.toContain("EXPLORE_BEGIN");
+      expect(result).not.toContain("EXPLORE_END");
+      expect(result).not.toContain("EXPLORE_DISABLED_BEGIN");
+      expect(result).not.toContain("EXPLORE_DISABLED_END");
+      // The fallback wording for the disabled case should be present in the workflow.
+      expect(result).toContain("use search_code or get_file_content to verify");
+    });
+  });
+
+  describe("buildLocalReviewInstructions", () => {
+    const localRequest = {
+      mode: "local" as const,
+      repoPath: "/tmp/repo",
+      dryRun: false,
+      verbose: false,
+    };
+    const diffContext = {
+      repoPath: "/tmp/repo",
+      diffSource: "uncommitted" as const,
+      diff: "diff --git a/foo.ts b/foo.ts\n+const x = 1;\n",
+      changedFiles: ["foo.ts"],
+      additions: 1,
+      deletions: 0,
+      truncated: false,
+    };
+
+    it("should render the standards-first / file-by-file local workflow", async () => {
+      const result = await builder.buildLocalReviewInstructions(
+        localRequest,
+        mockConfig,
+        diffContext,
+      );
+
+      expect(result).toContain("STANDARDS FIRST");
+      expect(result).toContain("WALK FILES ONE AT A TIME");
+      expect(result).toContain("VERIFY BEFORE REPORTING");
+      expect(result).toContain("BUDGET");
+      expect(result).toContain("OUTPUT");
+    });
+
+    it("should reference explore_context in local mode when enabled", async () => {
+      mockConfig.ai.explore.enabled = true;
+      const result = await builder.buildLocalReviewInstructions(
+        localRequest,
+        mockConfig,
+        diffContext,
+      );
+
+      expect(result).toContain("explore_context");
+      expect(result).not.toContain("EXPLORE_BEGIN");
+      expect(result).not.toContain("EXPLORE_DISABLED_BEGIN");
+    });
+
+    it("should strip explore_context from local mode when disabled", async () => {
+      mockConfig.ai.explore.enabled = false;
+      const result = await builder.buildLocalReviewInstructions(
+        localRequest,
+        mockConfig,
+        diffContext,
+      );
+
+      expect(result).not.toContain("explore_context");
+      expect(result).not.toContain("EXPLORE_BEGIN");
+      expect(result).not.toContain("EXPLORE_DISABLED_BEGIN");
+      expect(result).toContain("Use bounded local-git/file tools");
     });
   });
 

--- a/yama.config.example.yaml
+++ b/yama.config.example.yaml
@@ -36,6 +36,16 @@ ai:
     maxTurnsPerSession: 300 # Long reviews need many turns
     enableSummarization: false # Don't summarize mid-review
 
+  # Explore worker configuration
+  explore:
+    enabled: true
+    provider: "auto"
+    model: "gemini-2.5-flash"
+    temperature: 0.1
+    maxTokens: 32000
+    timeout: "5m"
+    cacheResults: true
+
 # ============================================================================
 # MCP Servers Configuration
 # ============================================================================


### PR DESCRIPTION
## Summary

Adds a one-time per-repo standards bootstrap that runs before every review. The orchestrator delegates to `explore_context` with a canned task — *distill recurring reviewer patterns from the last 15 merged PRs* — and injects the result into the review prompt as a `<bootstrapped-standards>` block. This gives the reviewer agent repo-specific context that static config rules don't capture (naming, error-handling idioms, module boundaries, review etiquette, cross-file patterns).

Also bundles supporting changes that landed on this branch: `YAMA_SKIP_LANGFUSE_PROMPTS` env flag for local iteration, `AIProvider` type widening so NeuroLink owns the provider allow-list (unblocks `vertex`, `litellm`, `ollama`, etc. without type bumps), and the full explore_context subagent service under `src/v2/exploration/`.

### Key changes

- **`YamaV2Orchestrator`** — new `getBootstrappedStandards()` method with process-level `Map<repo, string>` cache, wired into `startReview`, `streamReview`, and `startReviewAndEnhance`. Gracefully no-ops if `explore.enabled=false` or the call fails.
- **`PromptBuilder`** — `buildReviewInstructions()` accepts an optional `bootstrapStandards` param and injects a `<bootstrapped-standards>` block between `<project-standards>` and `<learned-knowledge>`, with a precedence comment telling the agent to rank it below `<blocking-criteria>` but above generic suggestions.
- **`LangfusePromptManager`** — early-return on `YAMA_SKIP_LANGFUSE_PROMPTS=true|1` to use local prompts without touching Langfuse creds.
- **`config.types.ts`** — `AIProvider = string` type alias replacing the hardcoded 6-member union. Drops `as any` casts on `AI_PROVIDER`/`AI_EXPLORE_PROVIDER` env overrides in `ConfigLoader`.
- **`src/v2/exploration/`** — full `ContextExplorerService` subagent (prompt builder, rules context loader, types).
- **Memory + learning orchestrator tweaks** from earlier on this branch.

### Design notes

- **No disk state for bootstrap.** Cache lives in the orchestrator instance and dies with the process. A new `yama review` invocation always sees a fresh bootstrap — intentional, keeps standards current and avoids staleness logic.
- **One bootstrap per repo per process.** Batch runs across many PRs on the same repo pay the cost once.
- **Graceful degradation.** Bootstrap failure logs a warning and the review proceeds without the block — never breaks the main flow.
- **Opt-out.** Set `ai.explore.enabled: false` to skip bootstrap entirely.

## Test plan

- [x] `pnpm run type-check` — clean
- [x] `pnpm run build` — clean
- [x] `pnpm test` — 73/73 passing, incl. `prompts.test.ts` which exercises `buildReviewInstructions` with the new optional param
- [x] Smoke test PR 1718 (dry-run) — bootstrap fired, 862 chars returned, prompt grew 20080 → 21331, review completed 117s
- [x] Full test on PR 1650 (dry-run, 303s) — bootstrap produced 687 chars, prompt grew 20080 → 21156, review caught **new cross-file findings** the previous non-bootstrap run missed (N+1 sequential API calls, DRY violation across 4 files, 3rd instance of the `Option.isSome` bug in `CreatePartner.res`, sidebar key mismatch, `isMissingValue` string check bug)
- [x] Batch-tested on 10 recent open PRs in `JBIZ/juspay-portal` in the earlier session — file-by-file walk, explore_context usage, non-master skip all verified
- [ ] Review on a repo with `ai.explore.enabled: false` to confirm bootstrap is skipped cleanly
- [ ] Try `AI_PROVIDER=litellm` env override once a LiteLLM config is available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added context exploration capability enabling deeper research during code reviews
* Exploration results are now cached for improved efficiency  
* Configurable exploration settings including model selection, temperature, token limits, and timeout controls
* Implemented standards-first review workflow that prioritizes project standards in analysis
* Sessions now track exploration history for reference and auditing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->