### PR TITLE
fix(deps): pin undici to 5.x for Node 20 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,8 @@
       "esbuild"
     ],
     "overrides": {
-      "@semantic-release/npm": "^13.1.2"
+      "@semantic-release/npm": "^13.1.2",
+      "undici": "^5.28.5"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   "@semantic-release/npm": ^13.1.2
+  undici: ^5.28.5
 
 importers:
   .:
@@ -10253,13 +10254,6 @@ packages:
       }
     engines: { node: ">=14.0" }
 
-  undici@7.24.6:
-    resolution:
-      {
-        integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==,
-      }
-    engines: { node: ">=20.18.1" }
-
   unicode-emoji-modifier-base@1.0.0:
     resolution:
       {
@@ -12588,7 +12582,7 @@ snapshots:
       pptxgenjs: 4.0.1
       redis: 5.11.0
       tar-stream: 3.1.8
-      undici: 7.24.6
+      undici: 5.28.5
       uuid: 13.0.0
       ws: 8.20.0
       xml2js: 0.6.2
@@ -17911,8 +17905,6 @@ snapshots:
   undici@5.28.5:
     dependencies:
       "@fastify/busboy": 2.1.1
-
-  undici@7.24.6: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 


### PR DESCRIPTION
## Summary

- Pins `undici` to `^5.28.5` via pnpm overrides to fix `webidl.util.markAsUncloneable is not a function` crash on Node.js 20.18.1

## Root cause

`@juspay/neurolink@9.42.0` (via `@juspay/hippocampus`) pulls `undici@7.24.6` which requires Node >= 22. Jenkins CI runs Node 20.18.1, causing `CacheStorage` constructor to fail on import.

## Fix

Added `"undici": "^5.28.5"` to `pnpm.overrides` in `package.json`. This forces all transitive undici dependencies to resolve to `5.28.5` (the version bundled with Node 20.x), eliminating the incompatibility.

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm test` — 73/73 passing
- [x] `grep "undici@7" pnpm-lock.yaml` returns no matches
- [ ] Jenkins pipeline run on `juspay-portal` with this Yama version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency versions to improve stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->