### PR TITLE
fix(docs): list get_file_blame in Bitbucket MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ Yama uses MCP (Model Context Protocol) servers for tool access:
 ### Bitbucket MCP
 
 - **Package**: `@nexus2520/bitbucket-mcp-server`
-- **Tools**: get_pull_request, add_comment, search_code, etc.
+- **Tools**: get_pull_request, add_comment, search_code, get_file_blame, etc.
 - **Status**: Production ready
 
 ### Jira MCP


### PR DESCRIPTION
## Summary
- Adds `get_file_blame` to the Bitbucket MCP tools list in the README so docs match the 2.0.4 dep bump (4cda865) that introduced the tool.

## Test plan
- [ ] README renders correctly on GitHub
- [ ] semantic-release picks up `fix:` commit and cuts a patch release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Bitbucket MCP tools reference documentation to include the `get_file_blame` tool in the documented tools list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->