### PR TITLE
feat(github): add GitHub provider for PR reviews

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,36 @@
 # Copy this file to .env and fill in your actual credentials
 
 # ============================================================================
-# Bitbucket Configuration (Required)
+# Provider Selection (GitHub or Bitbucket)
 # ============================================================================
+# Auto-detected from: GITHUB_* env vars > CLI params > clone URL > default (Bitbucket)
+# To use GitHub provider:
+#   1. Set GITHUB_TOKEN, or
+#   2. Use --owner and --repo CLI parameters, or
+#   3. Set GITHUB_REPOSITORY env var (auto set in GitHub Actions)
+
+# ============================================================================
+# GitHub MCP Configuration (for GitHub provider)
+# ============================================================================
+# The hosted GitHub MCP server (https://api.githubcopilot.com/mcp/) authenticates
+# with a GitHub Personal Access Token (PAT) — a real PAT, NOT the ephemeral
+# Actions GITHUB_TOKEN. Create one with `repo` (or pull_requests) scope:
+#   https://github.com/settings/personal-access-tokens
+# Yama accepts any of these (first one set wins):
+#   GITHUB_TOKEN -> GH_TOKEN -> GITHUB_PERSONAL_ACCESS_TOKEN -> GITHUB_ACCESS_TOKEN
+GITHUB_TOKEN=github_pat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# GITHUB_ACCESS_TOKEN=github_pat_...   # dedicated PAT name (Curator/DNV parity)
+
+# Optional: override the GitHub MCP endpoint (e.g. GitHub Enterprise / self-host)
+# via yama.config.yaml -> mcpServers.github.url
+
+# Automatically set by GitHub Actions, used for provider auto-detection
+# GITHUB_REPOSITORY=owner/repo-name
+
+# ============================================================================
+# Bitbucket Configuration (Required for Bitbucket provider)
+# ============================================================================
+# Optional if using GitHub provider instead
 BITBUCKET_USERNAME=your.email@company.com
 BITBUCKET_TOKEN=your-http-access-token
 BITBUCKET_BASE_URL=https://bitbucket.company.com

--- a/GITHUB_SETUP.md
+++ b/GITHUB_SETUP.md
@@ -1,0 +1,285 @@
+# Using Yama on GitHub — PR Review Setup Guide
+
+Yama reviews GitHub pull requests the same way it reviews Bitbucket PRs: an AI agent
+reads the PR, walks the diff file‑by‑file, posts **inline review comments**, and
+**submits a review** (Approve / Request changes). On GitHub this is driven through
+GitHub's hosted Model Context Protocol (MCP) server, so no Bitbucket credentials are
+needed.
+
+This guide covers the GitHub Action, the local CLI, configuration, authentication, and
+troubleshooting.
+
+---
+
+## 1. What you get
+
+- **Inline, line‑level comments** on the diff (parity with the Bitbucket flow).
+- **A submitted review**: `APPROVE` when clean, `REQUEST_CHANGES` when blocking criteria are met.
+- **Optional PR description enhancement**.
+- **Provider auto‑detection** — no extra flags. In an Action, `GITHUB_*` env vars make Yama
+  pick the GitHub provider automatically; the GitHub MCP server (not Bitbucket) is the only
+  one started.
+
+---
+
+## 2. Prerequisites
+
+| Requirement                                                               | Why                                                                                                                          |
+| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| An **AI provider API key** (Anthropic, OpenAI, Google AI, …)              | Yama's reviewer model runs through NeuroLink.                                                                                |
+| A **GitHub Personal Access Token (PAT)** with `repo` / pull‑request scope | Bearer token for GitHub's hosted MCP server (`api.githubcopilot.com`) to read the PR and post review comments. See ⚠️ below. |
+| Node.js 20 (handled for you in the Action)                                | Runtime.                                                                                                                     |
+
+> ⚠️ **A real PAT is required — not the default Actions `GITHUB_TOKEN`.** The hosted GitHub
+> MCP endpoint (`https://api.githubcopilot.com/mcp/`) authenticates with a GitHub **PAT**. This
+> is the same pattern Curator uses in production (a dedicated `GITHUB_ACCESS_TOKEN`). The
+> ephemeral `secrets.GITHUB_TOKEN` provided by Actions may be rejected by that endpoint, so
+> store a PAT as a secret and pass it as `github-token`. Yama recognizes any of
+> `GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_PERSONAL_ACCESS_TOKEN`, or `GITHUB_ACCESS_TOKEN`.
+
+---
+
+## 3. Quick start (GitHub Action)
+
+Add `.github/workflows/yama-review.yml` to the repository you want reviewed:
+
+```yaml
+name: Yama AI Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: yama-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # read the repo / diff
+  pull-requests: write # post inline comments + submit the review
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Yama Review
+        uses: juspay/yama@v1
+        with:
+          github-token: ${{ secrets.YAMA_GITHUB_TOKEN }} # a PAT (see §6)
+          ai-provider: anthropic
+          ai-model: claude-opus-4-8
+          focus-areas: security,performance,codeQuality
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+Then add the secrets:
+
+```bash
+# AI provider key (match ai-provider)
+gh secret set ANTHROPIC_API_KEY --body "sk-ant-..."
+# or: OPENAI_API_KEY / GOOGLE_AI_API_KEY
+
+# GitHub PAT for the hosted MCP endpoint (repo / pull_requests scope)
+gh secret set YAMA_GITHUB_TOKEN --body "github_pat_..."
+```
+
+See [§6 Authentication](#6-authentication-deep-dive) for why a PAT (not the default
+`secrets.GITHUB_TOKEN`) is used.
+
+---
+
+## 4. Action inputs
+
+All inputs are kebab‑case.
+
+| Input                      | Default               | Description                                               |
+| -------------------------- | --------------------- | --------------------------------------------------------- |
+| `github-token`             | `${{ github.token }}` | Token for the GitHub MCP server (read PR, post comments). |
+| `ai-provider`              | from config           | `anthropic` \| `openai` \| `google-ai` \| …               |
+| `ai-model`                 | from config           | e.g. `claude-opus-4-8`.                                   |
+| `config-path`              | —                     | Path to a `yama.config.yaml` in your repo.                |
+| `focus-areas`              | —                     | Comma list, e.g. `security,performance`.                  |
+| `custom-prompt`            | —                     | Extra review instructions.                                |
+| `dry-run`                  | `false`               | Run the review but post nothing.                          |
+| `skip-description-enhance` | `false`               | Review only; skip PR‑description enhancement.             |
+| `verbose`                  | `false`               | Verbose logs.                                             |
+
+### Outputs
+
+`decision` (`APPROVED` / `CHANGES_REQUESTED` / `BLOCKED`), `summary`,
+`critical-issues`, `major-issues`, `minor-issues`, `total-comments`.
+
+The job **fails** (`exit 1`) when the decision is `BLOCKED`, so you can make Yama a required check.
+
+---
+
+## 5. How it works (internals)
+
+`action.yml` is a **composite action** (not a bundled JS action). On each run it:
+
+1. Sets up Node 20 and builds the Yama CLI from the action checkout (`dist/cli/cli.js`).
+2. Resolves the PR number from the event payload and runs:
+   `node dist/cli/cli.js review --owner <owner> --repo <repo> --pr <n>`
+   against your checked‑out workspace, with `GITHUB_TOKEN`, `AI_PROVIDER`, `AI_MODEL` in env.
+3. The CLI auto‑detects the **GitHub** provider (`ProviderDetector`) and starts **only** the
+   GitHub MCP server — the hosted remote server at `https://api.githubcopilot.com/mcp/`
+   (Bearer‑authenticated with your token).
+4. The AI reviewer (NeuroLink `generate()`) is given a GitHub‑specific prompt and calls the
+   GitHub MCP tools to read the PR and post the review.
+
+> **Why composite, not a bundled `node20` action?** NeuroLink imports `interceptors` from
+> `undici`, which `ncc` cannot statically bundle under the repo's undici‑5.x pin. Running the
+> built CLI via a composite action avoids the bundler entirely while preserving full behavior.
+
+### Write‑safety
+
+Yama blocks GitHub repo‑mutating tools (`push_files`, `create_or_update_file`, `create_branch`,
+`delete_file`, `create_pull_request_with_copilot`, `assign_copilot_to_issue`). It only **reads**
+the PR and **posts review comments / submits a review** — it never writes code to your repo.
+
+---
+
+## 6. Authentication deep-dive
+
+The hosted GitHub MCP server (`https://api.githubcopilot.com/mcp/`) is authenticated with a
+**Bearer GitHub PAT**. Yama resolves the token from, in order:
+`GITHUB_TOKEN` → `GH_TOKEN` → `GITHUB_PERSONAL_ACCESS_TOKEN` → `GITHUB_ACCESS_TOKEN`.
+
+This is the same approach Curator uses in production: a dedicated PAT (`GITHUB_ACCESS_TOKEN`,
+sourced from KMS in prod / env in dev) is passed as `Authorization: Bearer <pat>`. The
+registration also sets a 30s connect timeout + retry/backoff because the remote endpoint is
+slow to handshake (~3–4 s).
+
+- **Use a PAT.** Create a fine‑grained or classic PAT with **`repo`** (or `pull_requests:
+read+write`) scope, store it as a secret, and pass it as `github-token`:
+
+  ```yaml
+  with:
+    github-token: ${{ secrets.YAMA_GITHUB_TOKEN }}
+  ```
+
+  ```bash
+  gh secret set YAMA_GITHUB_TOKEN --body "github_pat_..."
+  ```
+
+- **The default Actions `secrets.GITHUB_TOKEN`** is the ephemeral installation token. It may be
+  **rejected** by the hosted Copilot MCP endpoint (you'll see `GitHub MCP server registered but
+not connected` — see Troubleshooting). It is also read‑only on **fork** PRs. Prefer a PAT.
+
+> ⚠️ **Fork PRs & `pull_request_target`.** The default token can't post on fork PRs. You can
+> trigger on `pull_request_target` to get a write token, but that runs in the **base** repo's
+> context — never check out and execute untrusted PR code in that mode. Prefer a PAT with
+> `pull_request` triggers, or restrict reviews to internal branches.
+
+---
+
+## 7. Local CLI usage (GitHub)
+
+```bash
+# Build once
+pnpm install && pnpm run build
+
+# Review a GitHub PR
+export GITHUB_TOKEN=ghp_xxx          # or GH_TOKEN / GITHUB_PERSONAL_ACCESS_TOKEN
+export ANTHROPIC_API_KEY=sk-ant-xxx  # your AI provider key
+node dist/cli/cli.js review --owner <owner> --repo <repo> --pr <number>
+
+# Dry run (post nothing)
+node dist/cli/cli.js review --owner <owner> --repo <repo> --pr <number> --dry-run --verbose
+```
+
+Bitbucket usage is unchanged: `--workspace <ws> --repository <repo> --pr <id>`.
+Yama refuses to mix GitHub (`--owner/--repo`) and Bitbucket (`--workspace/--repository`) flags.
+
+---
+
+## 8. Configuration (`yama.config.yaml`)
+
+The GitHub MCP server has sensible defaults, so config is optional. To customize:
+
+```yaml
+version: 2
+configType: yama
+
+ai:
+  provider: anthropic
+  model: claude-opus-4-8
+
+mcpServers:
+  github:
+    enabled: true
+    # transport: http                          # default; the hosted remote server
+    # url: https://api.githubcopilot.com/mcp/  # override for GitHub Enterprise / self-host
+    # blockedTools: [delete_file]              # add to the default write-block list
+  jira:
+    enabled: false
+
+review:
+  focusAreas: [security, performance, codeQuality, testing, documentation]
+  maxIssues: 10
+```
+
+A self‑hosted / Docker GitHub MCP server can be used by setting `transport: stdio` plus
+`command`/`args` on `mcpServers.github`.
+
+---
+
+## 9. Publishing the Action (maintainers)
+
+The example workflow references `juspay/yama@v1`. To make that resolve, tag a major‑version
+ref on the `juspay/yama` repo:
+
+```bash
+git tag -f v1            # moving major tag
+git push -f origin v1
+# (or a fixed tag like v2.5.0 and reference uses: juspay/yama@v2.5.0)
+```
+
+Until a tag is published, consumers can pin `uses: juspay/yama@main`. Because the action is
+composite and builds from source on each run, the action checkout must contain the source
+(it does) — committing `dist/` is optional but speeds up cold starts.
+
+---
+
+## 10. Troubleshooting
+
+| Symptom                                                         | Cause / Fix                                                                                               |
+| --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `GitHub MCP server registered but not connected`                | Token rejected or lacks scope. Use a PAT with `repo`/`pull_requests` scope (see §6).                      |
+| `Missing GitHub authentication: set GITHUB_TOKEN…`              | No token in env. Pass `github-token` (Action) or export `GITHUB_TOKEN` (CLI).                             |
+| `GitHub provider selected but mcpServers.github is not enabled` | You set `mcpServers.github.enabled: false`. Remove it or set `true`.                                      |
+| No comments on a **fork** PR                                    | Default token is read‑only for forks; use a PAT (see §6).                                                 |
+| `BITBUCKET_USERNAME … not set` on a GitHub run                  | Should not happen — validation is provider‑aware. Confirm `--owner/--repo` are set so GitHub is detected. |
+| AI key errors                                                   | Set `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_AI_API_KEY` matching `ai-provider`.                  |
+
+---
+
+## 11. Known limitations / verify on first run
+
+- **Transport + auth are confirmed** against Curator's production setup: remote HTTP to
+  `api.githubcopilot.com/mcp/` with a Bearer **PAT**, 30s timeout + retry/backoff. ✅
+- **Hosted‑MCP tool surface needs a live confirmation.** The GitHub tool names and parameters
+  (`pull_request_read`, `pull_request_review_write`, `add_comment_to_pending_review`, …) follow
+  the official `github/github-mcp-server` API. Curator exercises the read/PR tools but not the
+  review‑comment tools, so the inline‑comment + submit‑review flow is the one part not yet
+  exercised in production. NeuroLink injects the server's real tool schemas into the model at
+  runtime, so minor naming differences self‑correct, but the **first** run against a real PR is
+  the definitive check. Use `--dry-run --verbose` locally first.
+- **Langfuse‑managed prompts** (if you configure a remote prompt) are currently provider‑agnostic;
+  the provider‑aware GitHub prompt applies on the default/local prompt path.
+- The default Actions token cannot review **fork** PRs (GitHub security) — use a PAT.
+
+---
+
+## 12. Security notes
+
+- No secrets are committed in this repo: `.env` is git‑ignored and `.env.example` contains only
+  placeholders.
+- Pass all tokens/keys via GitHub **secrets**, never inline in the workflow.
+- Yama's GitHub integration is **read + review‑comment only**; repo‑content‑mutating tools are
+  blocked.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,152 @@
+name: "Yama PR Review"
+description: "AI-powered PR review for GitHub with MCP tools"
+author: "Juspay Technologies"
+
+branding:
+  icon: "shield"
+  color: "blue"
+
+inputs:
+  github-token:
+    description: "GitHub token used by the GitHub MCP server for API access"
+    required: false
+    default: ${{ github.token }}
+  config-path:
+    description: "Path to the Yama config file"
+    required: false
+  dry-run:
+    description: "Run the review without posting comments or submitting the review"
+    required: false
+    default: "false"
+  ai-provider:
+    description: "AI provider to use (e.g. anthropic, openai, google-ai)"
+    required: false
+  ai-model:
+    description: "Model name for the selected AI provider"
+    required: false
+  focus-areas:
+    description: "Comma-separated focus areas for the review (e.g. security,performance)"
+    required: false
+  custom-prompt:
+    description: "Additional custom prompt instructions for the review"
+    required: false
+  verbose:
+    description: "Enable verbose logging"
+    required: false
+    default: "false"
+  skip-description-enhance:
+    description: "Run the review only and skip PR description enhancement"
+    required: false
+    default: "false"
+
+outputs:
+  decision:
+    description: "Review decision (APPROVED, CHANGES_REQUESTED, or BLOCKED)"
+    value: ${{ steps.review.outputs.decision }}
+  summary:
+    description: "Review summary text"
+    value: ${{ steps.review.outputs.summary }}
+  critical-issues:
+    description: "Number of critical issues found"
+    value: ${{ steps.review.outputs.critical-issues }}
+  major-issues:
+    description: "Number of major issues found"
+    value: ${{ steps.review.outputs.major-issues }}
+  minor-issues:
+    description: "Number of minor issues found"
+    value: ${{ steps.review.outputs.minor-issues }}
+  total-comments:
+    description: "Total number of inline comments posted by the review"
+    value: ${{ steps.review.outputs.total-comments }}
+
+# Composite action that runs the built Yama CLI (`node dist/cli/cli.js review`)
+# with the GitHub PR context wired through environment variables and CLI flags.
+#
+# Why composite instead of a bundled `node20` JavaScript action:
+# The orchestrator depends on @juspay/neurolink, which imports `interceptors`
+# from `undici`. The repository pins `undici` to the 5.x line for Node 20
+# runtime compatibility, but the `interceptors` named export only exists in
+# undici 6.x. As a result, `ncc` cannot statically bundle the action entry
+# (`Error: export 'interceptors' was not found in 'undici'`). Marking undici as
+# `--external` would build but ship a runner with no undici at all (node20
+# actions get no `npm install`), silently breaking the action at runtime.
+# Running the already-built CLI via a composite action avoids the bundler
+# entirely while preserving full review behavior and parity with the CLI path.
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+
+    - name: Install dependencies and build CLI
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: |
+        if [ ! -f "dist/cli/cli.js" ]; then
+          if [ -f "pnpm-lock.yaml" ]; then
+            corepack enable
+            pnpm install --frozen-lockfile
+            pnpm run build
+          else
+            npm ci
+            npm run build
+          fi
+        fi
+
+    - name: Run Yama review
+      id: review
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      env:
+        # GitHub MCP server authenticates via GITHUB_TOKEN.
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        # Surface AI provider/model selection to the orchestrator + NeuroLink.
+        AI_PROVIDER: ${{ inputs.ai-provider }}
+        AI_MODEL: ${{ inputs.ai-model }}
+        # GitHub PR context, consumed by ProviderDetector + the review request.
+        YAMA_ACTION_PATH: ${{ github.action_path }}
+        EVENT_PATH: ${{ github.event_path }}
+        REPO_OWNER: ${{ github.repository_owner }}
+        REPO_FULL: ${{ github.repository }}
+        CONFIG_PATH: ${{ inputs.config-path }}
+        FOCUS_AREAS: ${{ inputs.focus-areas }}
+        CUSTOM_PROMPT: ${{ inputs.custom-prompt }}
+        DRY_RUN: ${{ inputs.dry-run }}
+        VERBOSE: ${{ inputs.verbose }}
+        SKIP_DESC_ENHANCE: ${{ inputs.skip-description-enhance }}
+      run: |
+        set -euo pipefail
+
+        # Resolve PR number from the event payload.
+        PR_NUMBER="$(node -e 'try{const e=require(process.env.EVENT_PATH);const n=(e.pull_request&&e.pull_request.number)||(e.issue&&e.issue.number);process.stdout.write(n?String(n):"")}catch(_){process.stdout.write("")}')"
+
+        if [ -z "$PR_NUMBER" ]; then
+          echo "::warning::Action triggered outside of a pull request context. Skipping review."
+          echo "decision=SKIPPED" >> "$GITHUB_OUTPUT"
+          echo "summary=Not a pull request event" >> "$GITHUB_OUTPUT"
+          echo "critical-issues=0" >> "$GITHUB_OUTPUT"
+          echo "major-issues=0" >> "$GITHUB_OUTPUT"
+          echo "minor-issues=0" >> "$GITHUB_OUTPUT"
+          echo "total-comments=0" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        OWNER="${REPO_FULL%%/*}"
+        REPO="${REPO_FULL#*/}"
+
+        ARGS=(review --owner "$OWNER" --repo "$REPO" --pr "$PR_NUMBER")
+
+        [ -n "${CONFIG_PATH}" ] && ARGS+=(--config "$CONFIG_PATH")
+        [ -n "${FOCUS_AREAS}" ] && ARGS+=(--focus "$FOCUS_AREAS")
+        [ -n "${CUSTOM_PROMPT}" ] && ARGS+=(--prompt "$CUSTOM_PROMPT")
+        [ "${SKIP_DESC_ENHANCE}" = "true" ] && ARGS+=(--review-only)
+        [ "${DRY_RUN}" = "true" ] && ARGS+=(--dry-run)
+        [ "${VERBOSE}" = "true" ] && ARGS+=(--verbose)
+
+        echo "::group::Yama review (PR #$PR_NUMBER in $OWNER/$REPO)"
+        node "$YAMA_ACTION_PATH/dist/cli/cli.js" "${ARGS[@]}"
+        STATUS=$?
+        echo "::endgroup::"
+        exit $STATUS

--- a/examples/github-pr-review-workflow.yml
+++ b/examples/github-pr-review-workflow.yml
@@ -1,0 +1,42 @@
+# Example workflow — copy this into YOUR repository's .github/workflows/ to run
+# Yama on its PRs. It lives under examples/ (not .github/workflows/) so it does
+# NOT execute inside the Yama repo itself. Replace `juspay/yama@v1` with a
+# published tag and set the ANTHROPIC_API_KEY + GitHub PAT secrets first.
+# Full setup: GITHUB_SETUP.md
+name: Yama AI Review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: yama-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Don't leave the auto-injected GITHUB_TOKEN in .git/config; Yama
+          # uses its own PAT for the GitHub MCP endpoint (see below).
+          persist-credentials: false
+      - name: Yama Review
+        # Production users should pin to an immutable commit SHA
+        # (e.g. juspay/yama@<sha>) instead of a movable tag for supply-chain
+        # safety. The readable tag is kept here for example clarity.
+        uses: juspay/yama@v1
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          # A GitHub PAT (repo / pull_requests scope) — the hosted GitHub MCP
+          # endpoint needs a real PAT, not the ephemeral Actions GITHUB_TOKEN.
+          # See GITHUB_SETUP.md §6.
+          github-token: ${{ secrets.YAMA_GITHUB_TOKEN }}
+          ai-provider: anthropic
+          ai-model: claude-opus-4-8
+          focus-areas: security,performance

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   ],
   "scripts": {
     "build": "rimraf dist && tsc && tsc-alias",
+    "build:action": "npm run build",
     "dev": "tsx watch src/cli/cli.ts",
     "dev:run": "tsx src/cli/cli.ts",
     "mcp:git:server": "uvx mcp-server-git || npx -y @modelcontextprotocol/server-git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6180,6 +6180,7 @@ packages:
       {
         integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==,
       }
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
@@ -6187,7 +6188,7 @@ packages:
       {
         integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==,
       }
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
     resolution:
@@ -10362,6 +10363,7 @@ packages:
       {
         integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==,
       }
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
@@ -10369,6 +10371,7 @@ packages:
       {
         integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==,
       }
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -8,7 +8,11 @@ import { Command } from "commander";
 import dotenv from "dotenv";
 import { VERSION, createYama } from "../index.js";
 import { createLearningOrchestrator } from "../v2/core/LearningOrchestrator.js";
-import type { LocalReviewRequest, ReviewRequest } from "../index.js";
+import type {
+  LocalReviewRequest,
+  ReviewRequest,
+  ReviewResult,
+} from "../index.js";
 import type { LearnRequest } from "../v2/learning/types.js";
 
 // Load environment variables
@@ -57,6 +61,8 @@ function setupReviewCommand(): void {
     .option("--mode <mode>", "Review mode (pr|local)", "pr")
     .option("-w, --workspace <workspace>", "Bitbucket workspace")
     .option("-r, --repository <repository>", "Repository name")
+    .option("--owner <owner>", "GitHub owner/organization")
+    .option("--repo <repo>", "GitHub repository (alternative to --repository)")
     .option("-p, --pr <id>", "Pull request ID")
     .option("-b, --branch <branch>", "Branch name (finds PR automatically)")
     .option("--repo-path <path>", "Local repository path (local mode)")
@@ -129,11 +135,52 @@ function setupReviewCommand(): void {
           process.exit(result.decision === "BLOCKED" ? 1 : 0);
         }
 
-        if (!options.workspace || !options.repository) {
+        // Auto-detect provider and validate required parameters.
+        // --repo is GitHub-only; Bitbucket uses --repository so that
+        // 'yama review --workspace acme --repo service' is not misread as mixed.
+        const hasGitHub = options.owner || options.repo;
+        const hasBitbucket = options.workspace || options.repository;
+
+        if (hasGitHub && hasBitbucket) {
           console.error(
-            "❌ Error: --workspace and --repository are required in pr mode",
+            "❌ Error: Cannot mix GitHub (--owner/--repo) and Bitbucket (--workspace/--repository) parameters",
           );
           process.exit(1);
+        }
+
+        if (!hasGitHub && !hasBitbucket) {
+          console.error(
+            "❌ Error: Either GitHub (--owner and --repo) or Bitbucket (--workspace and --repository) parameters are required",
+          );
+          process.exit(1);
+        }
+
+        if (hasGitHub) {
+          if (!options.owner) {
+            console.error(
+              "❌ Error: --owner is required when using GitHub parameters",
+            );
+            process.exit(1);
+          }
+          if (!options.repo) {
+            console.error(
+              "❌ Error: --repo is required when using GitHub parameters",
+            );
+            process.exit(1);
+          }
+        } else {
+          if (!options.workspace) {
+            console.error(
+              "❌ Error: --workspace is required when using Bitbucket parameters",
+            );
+            process.exit(1);
+          }
+          if (!options.repository) {
+            console.error(
+              "❌ Error: --repository is required when using Bitbucket parameters",
+            );
+            process.exit(1);
+          }
         }
 
         if (!options.pr && !options.branch) {
@@ -154,9 +201,18 @@ function setupReviewCommand(): void {
 
         const request: ReviewRequest = {
           mode: "pr",
+          provider: hasGitHub ? "github" : "bitbucket",
+          owner: options.owner,
+          repo: options.repo,
           workspace: options.workspace,
           repository: options.repository,
           pullRequestId,
+          // GitHub SDK/prompt paths read prNumber; mirror pullRequestId for
+          // GitHub only so Bitbucket behavior stays unchanged.
+          prNumber:
+            hasGitHub && typeof pullRequestId === "number"
+              ? pullRequestId
+              : undefined,
           branch: options.branch,
           dryRun: globalOpts.dryRun || false,
           verbose: globalOpts.verbose || false,
@@ -166,7 +222,9 @@ function setupReviewCommand(): void {
           outputSchemaVersion: options.outputSchemaVersion,
         };
 
-        await yama.initialize(request.configPath);
+        // Thread the request into initialize so MCP servers are set up for the
+        // correct provider (GitHub vs Bitbucket) before review starts.
+        await yama.initialize(request.configPath, "pr", request);
 
         console.log("🚀 Starting autonomous AI review...\n");
 
@@ -195,6 +253,9 @@ function setupReviewCommand(): void {
           console.log(JSON.stringify(result, null, 2));
         }
 
+        // Surface outputs for the composite GitHub Action (provider-agnostic).
+        await writeGitHubOutputs(result);
+
         process.exit(result.decision === "BLOCKED" ? 1 : 0);
       } catch (error) {
         console.error("\n❌ Review failed:", (error as Error).message);
@@ -205,6 +266,40 @@ function setupReviewCommand(): void {
         process.exit(1);
       }
     });
+}
+
+/**
+ * Append PR review outputs to the GitHub Actions output file so a composite
+ * Action can expose them as step outputs. No-op outside GitHub Actions (when
+ * GITHUB_OUTPUT is unset). Provider-agnostic: works for Bitbucket too.
+ */
+async function writeGitHubOutputs(result: ReviewResult): Promise<void> {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) {
+    return;
+  }
+
+  const issues = result.statistics?.issuesFound;
+  const summary = (result.summary || "").trim();
+
+  const lines = [
+    `decision=${result.decision}`,
+    `summary<<EOF\n${summary}\nEOF`,
+    `critical-issues=${issues?.critical ?? 0}`,
+    `major-issues=${issues?.major ?? 0}`,
+    `minor-issues=${issues?.minor ?? 0}`,
+    `total-comments=${result.statistics?.totalComments ?? 0}`,
+  ];
+
+  try {
+    const fs = await import("fs/promises");
+    await fs.appendFile(outputPath, `${lines.join("\n")}\n`, "utf8");
+  } catch (error) {
+    console.error(
+      "⚠️  Failed to write GitHub Action outputs:",
+      (error as Error).message,
+    );
+  }
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,10 @@
 // Core Exports
 // ============================================================================
 
+// `YamaOrchestrator` is exported below as a class, which exposes it to SDK
+// consumers as BOTH a value and a type (with all of its public methods). A
+// separate `export type { YamaOrchestrator }` is intentionally omitted because
+// it would collide with this value export (TS2300: Duplicate identifier).
 export {
   YamaOrchestrator,
   createYama,

--- a/src/v2/config/ConfigLoader.ts
+++ b/src/v2/config/ConfigLoader.ts
@@ -71,9 +71,17 @@ export class ConfigLoader {
   }
 
   /**
-   * Validate configuration completeness and correctness
+   * Validate configuration completeness and correctness.
+   *
+   * @param mode      "pr" requires VCS credentials; "local" is SDK-first and skips them.
+   * @param provider  Detected VCS provider. When "github", Bitbucket env vars are
+   *                  NOT required (a GitHub token is required instead); otherwise
+   *                  Bitbucket credentials are validated as before.
    */
-  async validate(mode: "pr" | "local" = "pr"): Promise<void> {
+  async validate(
+    mode: "pr" | "local" = "pr",
+    provider?: "github" | "bitbucket",
+  ): Promise<void> {
     if (!this.config) {
       throw new ConfigurationError("No configuration to validate");
     }
@@ -91,15 +99,32 @@ export class ConfigLoader {
 
     // Local mode is SDK-first and does not require MCP credentials.
     if (mode === "pr") {
-      // Check environment variables for Bitbucket (required in PR mode)
-      if (!process.env.BITBUCKET_USERNAME) {
-        errors.push("BITBUCKET_USERNAME environment variable not set");
-      }
-      if (!process.env.BITBUCKET_TOKEN) {
-        errors.push("BITBUCKET_TOKEN environment variable not set");
-      }
-      if (!process.env.BITBUCKET_BASE_URL) {
-        errors.push("BITBUCKET_BASE_URL environment variable not set");
+      if (provider === "github") {
+        // GitHub provider: require a GitHub token instead of Bitbucket creds.
+        // Token resolution order mirrors MCPServerManager: GITHUB_TOKEN →
+        // GH_TOKEN → GITHUB_PERSONAL_ACCESS_TOKEN → GITHUB_ACCESS_TOKEN
+        // (GITHUB_ACCESS_TOKEN is the dedicated PAT used in Curator/DNV).
+        if (
+          !process.env.GITHUB_TOKEN &&
+          !process.env.GH_TOKEN &&
+          !process.env.GITHUB_PERSONAL_ACCESS_TOKEN &&
+          !process.env.GITHUB_ACCESS_TOKEN
+        ) {
+          errors.push(
+            "GitHub provider selected but no GitHub token found. Set GITHUB_TOKEN (or GH_TOKEN / GITHUB_PERSONAL_ACCESS_TOKEN / GITHUB_ACCESS_TOKEN).",
+          );
+        }
+      } else {
+        // Bitbucket provider (default): require Bitbucket credentials.
+        if (!process.env.BITBUCKET_USERNAME) {
+          errors.push("BITBUCKET_USERNAME environment variable not set");
+        }
+        if (!process.env.BITBUCKET_TOKEN) {
+          errors.push("BITBUCKET_TOKEN environment variable not set");
+        }
+        if (!process.env.BITBUCKET_BASE_URL) {
+          errors.push("BITBUCKET_BASE_URL environment variable not set");
+        }
       }
 
       if (this.config.mcpServers.jira.enabled) {

--- a/src/v2/config/DefaultConfig.ts
+++ b/src/v2/config/DefaultConfig.ts
@@ -51,6 +51,19 @@ export class DefaultConfig {
         bitbucket: {
           blockedTools: [],
         },
+        github: {
+          enabled: true,
+          url: "https://api.githubcopilot.com/mcp/",
+          transport: "http",
+          blockedTools: [
+            "push_files",
+            "create_or_update_file",
+            "create_branch",
+            "delete_file",
+            "create_pull_request_with_copilot",
+            "assign_copilot_to_issue",
+          ],
+        },
         jira: {
           enabled: false, // Opt-in: users must explicitly enable Jira integration
           blockedTools: [],

--- a/src/v2/core/LearningOrchestrator.ts
+++ b/src/v2/core/LearningOrchestrator.ts
@@ -18,6 +18,10 @@ import {
 } from "../learning/types.js";
 import { YamaConfig } from "../types/config.types.js";
 import {
+  getProviderToolset,
+  type VCSProviderName,
+} from "../providers/ProviderToolset.js";
+import {
   buildObservabilityConfigFromEnv,
   validateObservabilityConfig,
 } from "../utils/ObservabilityConfig.js";
@@ -242,6 +246,7 @@ export class LearningOrchestrator {
           const ownerId = MemoryManager.buildOwnerId(
             request.workspace,
             request.repository,
+            request.provider || "bitbucket",
           );
 
           await this.neurolink.generate({
@@ -324,17 +329,36 @@ export class LearningOrchestrator {
   private buildFetchCommentsInstructions(request: LearnRequest): string {
     const aiPatterns = this.config.knowledgeBase.aiAuthorPatterns.join(", ");
 
+    // Derive the PR-read tool name and identifier format from the provider
+    // toolset so a GitHub learn run asks for the tool it actually has.
+    // The learn flow's only provider signal is request.provider; default to
+    // bitbucket to preserve existing behavior.
+    const provider: VCSProviderName =
+      request.provider === "github" ? "github" : "bitbucket";
+    const toolset = getProviderToolset(provider);
+    const prReadTool = toolset.prReadToolName;
+
+    // Bitbucket: workspace/repository/pull_request_id (byte-identical to before).
+    // GitHub: owner/repo/pull_number — the same repository identifiers carried
+    // by the Bitbucket-shaped request, relabelled to GitHub's vocabulary.
+    const prDetails =
+      provider === "github"
+        ? `  <owner>${request.workspace}</owner>
+  <repo>${request.repository}</repo>
+  <pull_number>${request.pullRequestId}</pull_number>`
+        : `  <workspace>${request.workspace}</workspace>
+  <repository>${request.repository}</repository>
+  <pull_request_id>${request.pullRequestId}</pull_request_id>`;
+
     return `
 <task>Fetch and analyze ALL PR comments for learning extraction</task>
 
 <pr-details>
-  <workspace>${request.workspace}</workspace>
-  <repository>${request.repository}</repository>
-  <pull_request_id>${request.pullRequestId}</pull_request_id>
+${prDetails}
 </pr-details>
 
 <instructions>
-1. Use get_pull_request tool to fetch the PR details including all comments/activities
+1. Use ${prReadTool} tool to fetch the PR details including all comments/activities
 2. Look through ALL comments on the PR (both active and resolved if available)
 3. Identify AI-generated comments by:
    - Author patterns: ${aiPatterns}

--- a/src/v2/core/MCPServerManager.ts
+++ b/src/v2/core/MCPServerManager.ts
@@ -4,8 +4,54 @@
  */
 
 import { join } from "path";
-import { MCPServersConfig } from "../types/config.types.js";
+import { MCPServersConfig, GitHubConfig } from "../types/config.types.js";
 import { MCPServerError } from "../types/v2.types.js";
+
+/**
+ * Default remote HTTP endpoint for GitHub's hosted MCP server.
+ * Overridable via `mcpServers.github.url`.
+ */
+const DEFAULT_GITHUB_MCP_URL = "https://api.githubcopilot.com/mcp/";
+
+/**
+ * Default write tools blocked on the GitHub MCP server.
+ * Mirrors Curator's proven pattern: the AI never mutates the repo directly —
+ * the single write path is the review-comment / review-submit tools, which are
+ * intentionally NOT blocked here.
+ */
+const DEFAULT_GITHUB_BLOCKED_TOOLS: string[] = [
+  "push_files",
+  "create_or_update_file",
+  "create_branch",
+  "delete_file",
+  "create_pull_request_with_copilot",
+  "assign_copilot_to_issue",
+];
+
+/**
+ * Registration shape for the GitHub remote HTTP MCP server.
+ * Structural subset of NeuroLink's `MCPServerInfo` (transport/url/headers/
+ * blockedTools + optional stdio command/args), typed explicitly to avoid `any`
+ * for the new config object.
+ */
+interface GitHubMCPRegistration {
+  transport: "http" | "stdio";
+  url?: string;
+  headers?: Record<string, string>;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  blockedTools: string[];
+  /** Connection timeout (ms). The hosted remote endpoint is slow (~3-4s TLS). */
+  timeout?: number;
+  /** Retry/backoff for the remote HTTP endpoint (mirrors Curator's setup). */
+  retryConfig?: {
+    maxAttempts?: number;
+    initialDelay?: number;
+    maxDelay?: number;
+    backoffMultiplier?: number;
+  };
+}
 
 export class MCPServerManager {
   // MCP servers are managed entirely by NeuroLink
@@ -13,23 +59,36 @@ export class MCPServerManager {
   private initialized = false;
 
   /**
-   * Setup all MCP servers in NeuroLink
-   * Bitbucket is always enabled, Jira is optional based on config
+   * Setup MCP servers based on detected provider
+   * GitHub MCP OR Bitbucket MCP (not both) - whichever is needed
+   * Jira is optional for both
    */
   async setupMCPServers(
     neurolink: any,
     config: MCPServersConfig,
+    provider: "github" | "bitbucket" = "bitbucket",
   ): Promise<void> {
     if (this.initialized) {
       return;
     }
 
     console.log("🔌 Setting up MCP servers...");
+    console.log(`   📍 Provider: ${provider}`);
 
-    // Setup Bitbucket MCP (always enabled)
-    await this.setupBitbucketMCP(neurolink, config.bitbucket?.blockedTools);
+    // Setup provider-specific MCP (only one needed)
+    if (provider === "github") {
+      // Fail fast rather than passing an undefined/disabled config downstream.
+      if (!config.github || config.github.enabled === false) {
+        throw new MCPServerError(
+          "GitHub provider selected but mcpServers.github is not enabled",
+        );
+      }
+      await this.setupGitHubMCP(neurolink, config.github);
+    } else {
+      await this.setupBitbucketMCP(neurolink, config.bitbucket?.blockedTools);
+    }
 
-    // Setup Jira MCP (optional)
+    // Setup Jira MCP (optional, works with both providers)
     if (config.jira.enabled) {
       await this.setupJiraMCP(neurolink, config.jira.blockedTools);
     } else {
@@ -40,6 +99,29 @@ export class MCPServerManager {
 
     await this.logDiagnostics(neurolink);
     console.log("✅ MCP servers configured\n");
+  }
+
+  /**
+   * Reset PR-mode MCP setup so {@link setupMCPServers} can re-register for a
+   * different provider within the same process (e.g. one orchestrator instance
+   * reviewing a Bitbucket PR then a GitHub PR). Removes the previously-registered
+   * provider server (Bitbucket or GitHub) so the new provider's server takes its
+   * place, and clears the `initialized` guard. The optional Jira server is left
+   * in place — it is provider-agnostic and shared. Single-provider runs never
+   * call this, so their behaviour is unchanged.
+   */
+  async resetForProviderSwitch(
+    neurolink: any,
+    previousProvider: "github" | "bitbucket",
+  ): Promise<void> {
+    const serverName = previousProvider === "github" ? "github" : "bitbucket";
+    try {
+      await neurolink.removeExternalMCPServer?.(serverName);
+    } catch {
+      // Non-fatal: if removal fails the subsequent re-register will surface a
+      // clearer error. Proceed to allow re-setup.
+    }
+    this.initialized = false;
   }
 
   /**
@@ -208,6 +290,163 @@ export class MCPServerManager {
         `Failed to setup Bitbucket MCP server: ${(error as Error).message}`,
       );
     }
+  }
+
+  /**
+   * Setup GitHub MCP server.
+   *
+   * Registers GitHub's hosted REMOTE HTTP MCP server via NeuroLink, mirroring
+   * Curator's proven pattern (transport: "http" + Bearer auth header). The old
+   * `npx @github/github-mcp-server` package does not exist, so stdio is only
+   * supported for an explicitly-configured self-hosted / Docker server.
+   *
+   * URL + transport are config-driven (`mcpServers.github.{url,transport,command,args}`),
+   * defaulting to the remote HTTP endpoint.
+   */
+  private async setupGitHubMCP(
+    neurolink: any,
+    githubConfig?: GitHubConfig,
+  ): Promise<void> {
+    try {
+      console.log("   🔧 Registering GitHub MCP server...");
+
+      // Be robust to a possibly-undefined config: default URL + transport +
+      // blockedTools so registration still works if the caller passes nothing.
+      const transport = githubConfig?.transport ?? "http";
+      // ADDITIVE, not replacing: always enforce the default write-block denylist
+      // and union it with any user-provided entries, so a user-supplied
+      // `blockedTools` can only EXTEND the denylist — never un-block write tools
+      // like push_files / create_or_update_file.
+      const blockedTools = Array.from(
+        new Set([
+          ...DEFAULT_GITHUB_BLOCKED_TOOLS,
+          ...(githubConfig?.blockedTools ?? []),
+        ]),
+      );
+
+      // An explicit token is REQUIRED. gh CLI auth (hosts.yml) cannot supply a
+      // Bearer token for the remote HTTP transport, so we do not accept it as a
+      // substitute. The hosted endpoint (api.githubcopilot.com) expects a real
+      // GitHub PAT — the ephemeral Actions GITHUB_TOKEN may be rejected. Token
+      // resolution order mirrors Curator's proven setup (GITHUB_ACCESS_TOKEN):
+      //   GITHUB_TOKEN → GH_TOKEN → GITHUB_PERSONAL_ACCESS_TOKEN → GITHUB_ACCESS_TOKEN.
+      const ghToken =
+        process.env.GITHUB_TOKEN ||
+        process.env.GH_TOKEN ||
+        process.env.GITHUB_PERSONAL_ACCESS_TOKEN ||
+        process.env.GITHUB_ACCESS_TOKEN;
+
+      if (!ghToken) {
+        throw new MCPServerError(
+          "Missing GitHub authentication: set GITHUB_TOKEN (or GH_TOKEN / " +
+            "GITHUB_PERSONAL_ACCESS_TOKEN / GITHUB_ACCESS_TOKEN). The remote HTTP " +
+            "transport requires an explicit GitHub PAT; 'gh auth login' alone is " +
+            "not sufficient.",
+        );
+      }
+
+      const config: GitHubMCPRegistration =
+        transport === "stdio"
+          ? this.buildGitHubStdioConfig(githubConfig, ghToken, blockedTools)
+          : this.buildGitHubHttpConfig(githubConfig, ghToken, blockedTools);
+
+      await neurolink.addExternalMCPServer("github", config);
+
+      // Verify the server actually connected — NeuroLink resolves the promise
+      // even on timeout, so we must check the status explicitly (same pattern
+      // as the Bitbucket path).
+      const servers = await neurolink.listMCPServers();
+      const ghServer = (servers || []).find((s: any) => s.name === "github");
+      if (
+        !ghServer ||
+        ghServer.status !== "connected" ||
+        ghServer.tools?.length === 0
+      ) {
+        throw new MCPServerError(
+          `GitHub MCP server registered but not connected (status: ${ghServer?.status ?? "unknown"}, tools: ${ghServer?.tools?.length ?? 0}). Possible startup timeout.`,
+        );
+      }
+
+      console.log(
+        `   ✅ GitHub MCP server registered and tools available (transport: ${transport})`,
+      );
+      if (transport === "http") {
+        console.log(`   🌐 Remote endpoint: ${config.url}`);
+      }
+      console.log(`   🚫 Blocked write tools: ${blockedTools.join(", ")}`);
+    } catch (error) {
+      throw new MCPServerError(
+        `Failed to setup GitHub MCP server: ${(error as Error).message}`,
+      );
+    }
+  }
+
+  /**
+   * Build the remote HTTP GitHub MCP registration (default path).
+   * A Bearer token is required for the hosted endpoint.
+   */
+  private buildGitHubHttpConfig(
+    githubConfig: GitHubConfig | undefined,
+    ghToken: string | undefined,
+    blockedTools: string[],
+  ): GitHubMCPRegistration {
+    if (!ghToken) {
+      throw new MCPServerError(
+        "GitHub remote HTTP MCP server requires a token. Set GITHUB_TOKEN " +
+          "(or GH_TOKEN / GITHUB_PERSONAL_ACCESS_TOKEN / GITHUB_ACCESS_TOKEN); " +
+          "'gh auth login' alone is not sufficient for the remote transport.",
+      );
+    }
+
+    // The hosted endpoint is slow to connect (~3-4s TLS handshake + remote auth);
+    // a generous timeout + retry/backoff prevents spurious "not connected"
+    // failures. Values mirror Curator's production GitHub MCP registration.
+    return {
+      transport: "http",
+      url: githubConfig?.url ?? DEFAULT_GITHUB_MCP_URL,
+      headers: {
+        Authorization: `Bearer ${ghToken}`,
+      },
+      blockedTools,
+      timeout: 30000,
+      retryConfig: {
+        maxAttempts: 3,
+        initialDelay: 1000,
+        maxDelay: 10000,
+        backoffMultiplier: 2,
+      },
+    };
+  }
+
+  /**
+   * Build a self-hosted / Docker stdio GitHub MCP registration.
+   * Only used when `mcpServers.github.transport === "stdio"`; requires `command`.
+   */
+  private buildGitHubStdioConfig(
+    githubConfig: GitHubConfig | undefined,
+    ghToken: string | undefined,
+    blockedTools: string[],
+  ): GitHubMCPRegistration {
+    const command = githubConfig?.command;
+    if (!command) {
+      throw new MCPServerError(
+        "GitHub stdio transport requires 'mcpServers.github.command' " +
+          "(e.g. a self-hosted/Docker GitHub MCP server binary).",
+      );
+    }
+
+    return {
+      transport: "stdio",
+      command,
+      args: githubConfig?.args ?? [],
+      env: ghToken
+        ? {
+            GITHUB_PERSONAL_ACCESS_TOKEN: ghToken,
+            GITHUB_TOKEN: ghToken,
+          }
+        : undefined,
+      blockedTools,
+    };
   }
 
   /**

--- a/src/v2/core/YamaV2Orchestrator.ts
+++ b/src/v2/core/YamaV2Orchestrator.ts
@@ -13,6 +13,11 @@ import { LocalDiffSource } from "./LocalDiffSource.js";
 import type { LocalDiffContext } from "./LocalDiffSource.js";
 import { ContextExplorerService } from "../exploration/ContextExplorerService.js";
 import {
+  ProviderDetector,
+  type VCSProvider,
+} from "../utils/ProviderDetector.js";
+import { getProviderToolset } from "../providers/ProviderToolset.js";
+import {
   LocalReviewFinding,
   LocalReviewRequest,
   LocalReviewResult,
@@ -43,11 +48,16 @@ export class YamaOrchestrator {
   private config!: YamaConfig;
   private initialized = false;
   private mcpInitialized = false;
+  // Provider the PR-mode MCP servers were last set up for. Lets one orchestrator
+  // instance switch providers mid-process (Bitbucket PR then GitHub PR) by
+  // re-running setup when the detected provider no longer matches.
+  private mcpProvider: VCSProvider | null = null;
   private localGitMcpInitialized = false;
   private exploreToolRegistered = false;
   private currentToolContext: Record<string, unknown> | null = null;
   private initOptions: YamaInitOptions;
   private bootstrapStandardsCache: Map<string, string> = new Map();
+  private detectedProvider: VCSProvider = "bitbucket";
 
   constructor(options: YamaInitOptions = {}) {
     this.initOptions = options;
@@ -64,6 +74,7 @@ export class YamaOrchestrator {
   async initialize(
     configPath?: string,
     mode: ReviewMode = "pr",
+    request?: ReviewRequest,
   ): Promise<void> {
     try {
       if (!this.initialized) {
@@ -77,6 +88,30 @@ export class YamaOrchestrator {
         );
 
         this.showBanner();
+
+        // Step 1.5: Detect provider BEFORE MCP setup so the correct provider's
+        // MCP server is wired up. When the real request is threaded in, detect
+        // from it; otherwise fall back to a preliminary detection (for logging
+        // and env/config-default driven runs).
+        if (request) {
+          this.detectedProvider = ProviderDetector.detect(
+            request,
+            process.env,
+            this.config.defaultProvider,
+          );
+        } else {
+          const preliminaryRequest: ReviewRequest = {
+            mode: "pr",
+            workspace: "",
+            repository: "",
+          };
+          this.detectedProvider = ProviderDetector.detect(
+            preliminaryRequest,
+            process.env,
+            this.config.defaultProvider,
+          );
+        }
+        console.log(`🔌 Provider detected: ${this.detectedProvider}\n`);
 
         // Step 2: Initialize
         if (this.config.memory?.enabled) {
@@ -103,15 +138,38 @@ export class YamaOrchestrator {
       }
 
       // Step 4: Mode-specific setup
-      if (mode === "pr" && !this.mcpInitialized) {
-        await this.mcpManager.setupMCPServers(
-          this.neurolink,
-          this.config.mcpServers,
-        );
-        if (this.explorer && this.config.ai.explore.enabled) {
-          await this.explorer.initialize("pr");
+      if (mode === "pr") {
+        // If MCP was already set up for a DIFFERENT provider (one instance
+        // reviewing a Bitbucket PR then a GitHub PR), tear down the previous
+        // provider's server and re-register for the new one. Single-provider
+        // runs never hit this branch, so their behaviour is unchanged.
+        if (
+          this.mcpInitialized &&
+          this.mcpProvider !== null &&
+          this.mcpProvider !== this.detectedProvider
+        ) {
+          console.log(
+            `🔄 Provider changed (${this.mcpProvider} → ${this.detectedProvider}); re-registering MCP servers...`,
+          );
+          await this.mcpManager.resetForProviderSwitch(
+            this.neurolink,
+            this.mcpProvider,
+          );
+          this.mcpInitialized = false;
         }
-        this.mcpInitialized = true;
+
+        if (!this.mcpInitialized) {
+          await this.mcpManager.setupMCPServers(
+            this.neurolink,
+            this.config.mcpServers,
+            this.detectedProvider,
+          );
+          if (this.explorer && this.config.ai.explore.enabled) {
+            await this.explorer.initialize("pr");
+          }
+          this.mcpInitialized = true;
+          this.mcpProvider = this.detectedProvider;
+        }
       } else if (mode === "local" && !this.localGitMcpInitialized) {
         await this.mcpManager.setupLocalGitMCPServer(this.neurolink);
         if (this.explorer && this.config.ai.explore.enabled) {
@@ -120,8 +178,9 @@ export class YamaOrchestrator {
         this.localGitMcpInitialized = true;
       }
 
-      // Step 5: Mode-specific validation
-      await this.configLoader.validate(mode);
+      // Step 5: Mode-specific validation (provider-aware: GitHub runs skip the
+      // Bitbucket env requirement, Bitbucket runs are unchanged)
+      await this.configLoader.validate(mode, this.detectedProvider);
 
       console.log("✅ Yama initialized successfully\n");
       console.log("═".repeat(60) + "\n");
@@ -135,7 +194,14 @@ export class YamaOrchestrator {
    * Start autonomous AI review
    */
   async startReview(request: ReviewRequest): Promise<ReviewResult> {
-    await this.ensureInitialized("pr", request.configPath);
+    await this.ensureInitialized("pr", request.configPath, request);
+
+    // Detect the provider based on request and environment
+    this.detectedProvider = ProviderDetector.detect(
+      request,
+      process.env,
+      this.config.defaultProvider,
+    );
 
     const startTime = Date.now();
     const sessionId = this.sessionManager.createSession(request);
@@ -153,6 +219,7 @@ export class YamaOrchestrator {
         request,
         this.config,
         bootstrapStandards,
+        this.detectedProvider,
       );
 
       if (this.config.display.verboseToolCalls) {
@@ -320,7 +387,7 @@ export class YamaOrchestrator {
   async *streamReview(
     request: ReviewRequest,
   ): AsyncIterableIterator<ReviewUpdate> {
-    await this.ensureInitialized("pr", request.configPath);
+    await this.ensureInitialized("pr", request.configPath, request);
 
     const sessionId = this.sessionManager.createSession(request);
 
@@ -335,6 +402,7 @@ export class YamaOrchestrator {
         request,
         this.config,
         bootstrapStandards,
+        this.detectedProvider,
       );
 
       // Create tool context
@@ -390,7 +458,7 @@ export class YamaOrchestrator {
    * This allows the AI to use knowledge gained during review to write better descriptions
    */
   async startReviewAndEnhance(request: ReviewRequest): Promise<ReviewResult> {
-    await this.ensureInitialized("pr", request.configPath);
+    await this.ensureInitialized("pr", request.configPath, request);
 
     const startTime = Date.now();
     const sessionId = this.sessionManager.createSession(request);
@@ -413,6 +481,7 @@ export class YamaOrchestrator {
           request,
           this.config,
           bootstrapStandards,
+          this.detectedProvider,
         );
 
       if (this.config.display.verboseToolCalls) {
@@ -480,6 +549,7 @@ export class YamaOrchestrator {
           await this.promptBuilder.buildDescriptionEnhancementInstructions(
             request,
             this.config,
+            this.detectedProvider,
           );
 
         // Continue the SAME session - AI remembers everything from review
@@ -532,7 +602,7 @@ export class YamaOrchestrator {
    * Enhance PR description only (without full review)
    */
   async enhanceDescription(request: ReviewRequest): Promise<any> {
-    await this.ensureInitialized("pr", request.configPath);
+    await this.ensureInitialized("pr", request.configPath, request);
 
     const sessionId = this.sessionManager.createSession(request);
 
@@ -543,6 +613,7 @@ export class YamaOrchestrator {
         await this.promptBuilder.buildDescriptionEnhancementInstructions(
           request,
           this.config,
+          this.detectedProvider,
         );
 
       const toolContext = this.createToolContext(sessionId, request);
@@ -599,16 +670,29 @@ export class YamaOrchestrator {
   }
 
   private getUserId(request: ReviewRequest): string {
-    return `${request.workspace}-${request.repository}`.toLowerCase();
+    // Coalesce provider-specific identifiers: Bitbucket uses workspace/repository,
+    // GitHub uses owner/repo. Bitbucket behavior is unchanged when those are set.
+    const workspace = request.workspace || request.owner || "";
+    const repository = request.repository || request.repo || "";
+    return `${workspace}-${repository}`.toLowerCase();
   }
 
   private createToolContext(sessionId: string, request: ReviewRequest): any {
     return {
       sessionId,
       mode: "pr",
-      workspace: request.workspace,
-      repository: request.repository,
-      pullRequestId: request.pullRequestId,
+      // Carry the detected provider so explore_context / tool runtime context
+      // knows which provider's toolset to use (GitHub reviews otherwise saw
+      // provider=undefined and defaulted to Bitbucket).
+      provider: this.detectedProvider,
+      // Coalesce provider-specific identifiers (GitHub owner/repo, Bitbucket
+      // workspace/repository) into the existing context fields. No-op for
+      // Bitbucket where workspace/repository are already set.
+      workspace: request.workspace || request.owner,
+      repository: request.repository || request.repo,
+      // GitHub passes the PR number via prNumber; coalesce so the runtime
+      // context has a PR number for both providers.
+      pullRequestId: request.pullRequestId ?? request.prNumber,
       branch: request.branch,
       dryRun: request.dryRun || false,
       metadata: {
@@ -626,8 +710,12 @@ export class YamaOrchestrator {
     return {
       sessionId,
       mode: "local",
-      workspace: request.workspace,
-      repository: request.repository,
+      // Carry the detected provider for explore_context toolset selection.
+      provider: this.detectedProvider,
+      // Coalesce provider-specific identifiers (GitHub owner/repo, Bitbucket
+      // workspace/repository). No-op for Bitbucket where they are already set.
+      workspace: request.workspace || request.owner,
+      repository: request.repository || request.repo,
       dryRun: request.dryRun || false,
       metadata: {
         yamaVersion: "2.2.1",
@@ -664,7 +752,9 @@ export class YamaOrchestrator {
 
     return {
       mode: "pr",
-      prId: session.request.pullRequestId || 0,
+      // GitHub passes the PR number via prNumber; coalesce so GitHub reviews
+      // report the real PR number instead of 0.
+      prId: session.request.pullRequestId ?? session.request.prNumber ?? 0,
       decision,
       statistics,
       summary: this.extractSummary(aiResponse),
@@ -1027,33 +1117,26 @@ export class YamaOrchestrator {
     aiResponse: any,
     session: any,
   ): "APPROVED" | "CHANGES_REQUESTED" | "BLOCKED" {
-    // Derive final review state from tool calls.
-    // Supports both current Bitbucket MCP tools and legacy names.
+    // Derive final review state from tool calls, delegating provider-specific
+    // signal interpretation to the detected provider's toolset. The Bitbucket
+    // toolset replicates the previous hardcoded logic (set_review_status /
+    // set_pr_approval + legacy names) byte-for-byte.
     const toolCalls = session.toolCalls || [];
+    const ts = getProviderToolset(this.detectedProvider);
 
     let requestedChanges: boolean | undefined;
     let approved: boolean | undefined;
 
     for (const tc of toolCalls) {
-      const name = tc?.toolName;
-      const args = tc?.args || {};
+      const decision = ts.interpretDecision({
+        toolName: tc?.toolName,
+        args: tc?.args || {},
+      });
 
-      if (name === "set_review_status") {
-        if (typeof args.request_changes === "boolean") {
-          requestedChanges = args.request_changes;
-        }
-      } else if (name === "request_changes") {
+      if (decision === "BLOCKED") {
         requestedChanges = true;
-      } else if (name === "remove_requested_changes") {
-        requestedChanges = false;
-      } else if (name === "set_pr_approval") {
-        if (typeof args.approved === "boolean") {
-          approved = args.approved;
-        }
-      } else if (name === "approve_pull_request") {
+      } else if (decision === "APPROVED") {
         approved = true;
-      } else if (name === "unapprove_pull_request") {
-        approved = false;
       }
     }
 
@@ -1073,15 +1156,15 @@ export class YamaOrchestrator {
    */
   private calculateStatistics(session: any): ReviewStatistics {
     const toolCalls = session.toolCalls || [];
+    const ts = getProviderToolset(this.detectedProvider);
 
-    // Count file diffs read
-    const filesReviewed = toolCalls.filter(
-      (tc: any) => tc.toolName === "get_pull_request_diff",
-    ).length;
+    // Count the changed files actually reviewed. Provider-specific because the
+    // diff-tool semantics differ.
+    const filesReviewed = this.countFilesReviewed(toolCalls);
 
-    // Try to extract issue counts from comments
-    const commentCalls = toolCalls.filter(
-      (tc: any) => tc.toolName === "add_comment",
+    // Try to extract issue counts from comments (provider-specific comment tools)
+    const commentCalls = toolCalls.filter((tc: any) =>
+      ts.commentToolNames.includes(tc.toolName),
     );
     const issuesFound = this.extractIssueCountsFromComments(commentCalls);
 
@@ -1094,6 +1177,61 @@ export class YamaOrchestrator {
       cacheHits: 0,
       totalComments: commentCalls.length,
     };
+  }
+
+  /**
+   * Count the changed files actually reviewed, from the session tool calls.
+   *
+   * Bitbucket: get_pull_request_diff is called once per file by design, so the
+   * raw count of diff-tool calls already equals the files reviewed. This path is
+   * byte-for-byte identical to the previous behaviour.
+   *
+   * GitHub: pull_request_read is overloaded — the SAME tool name serves
+   * method="get" (PR shell), "get_files" (changed-file list) and "get_diff"
+   * (unified diff). Counting every pull_request_read call therefore inflates the
+   * number. Instead, count DISTINCT file paths the review actually touched, taken
+   * from the inline pending-review comments (add_comment_to_pending_review →
+   * args.path). Fall back to the number of distinct get_files/get_diff reads when
+   * no inline comments were posted (e.g. a clean approval), so a reviewed-but-
+   * clean PR is not reported as 0 files.
+   */
+  private countFilesReviewed(toolCalls: any[]): number {
+    const ts = getProviderToolset(this.detectedProvider);
+
+    if (this.detectedProvider !== "github") {
+      // Bitbucket (and any non-GitHub provider): one diff fetch per file.
+      return toolCalls.filter((tc: any) =>
+        ts.diffToolNames.includes(tc.toolName),
+      ).length;
+    }
+
+    // GitHub: prefer distinct paths from inline comments.
+    const commentedPaths = new Set<string>();
+    for (const tc of toolCalls) {
+      if (tc?.toolName !== "add_comment_to_pending_review") {
+        continue;
+      }
+      const path = tc?.args?.path;
+      if (typeof path === "string" && path.length > 0) {
+        commentedPaths.add(path);
+      }
+    }
+    if (commentedPaths.size > 0) {
+      return commentedPaths.size;
+    }
+
+    // Fallback for clean PRs with no inline comments: count the distinct
+    // changed-file / diff reads (pull_request_read with method get_files/get_diff)
+    // rather than every pull_request_read (which includes the single "get").
+    const diffReads = toolCalls.filter((tc: any) => {
+      if (!ts.diffToolNames.includes(tc?.toolName)) {
+        return false;
+      }
+      const method = tc?.args?.method;
+      return method === "get_files" || method === "get_diff";
+    }).length;
+
+    return diffReads;
   }
 
   /**
@@ -1358,6 +1496,10 @@ export class YamaOrchestrator {
           mode: runtimeMode,
           workspace: String(mergedContext.workspace || "local"),
           repository: String(mergedContext.repository || "repository"),
+          provider:
+            typeof mergedContext.provider === "string"
+              ? mergedContext.provider
+              : undefined,
           pullRequestId:
             typeof mergedContext.pullRequestId === "number"
               ? mergedContext.pullRequestId
@@ -1419,26 +1561,37 @@ export class YamaOrchestrator {
       return "";
     }
 
-    const cacheKey = `${request.workspace}/${request.repository}`.toLowerCase();
+    // Validate required parameters for bootstrap. Coalesce provider-specific
+    // identifiers so GitHub (owner/repo) also gets bootstrap standards; no-op
+    // for Bitbucket where workspace/repository are already set.
+    const workspace = (request.workspace || request.owner || "").trim();
+    const repository = (request.repository || request.repo || "").trim();
+
+    if (workspace.length === 0 || repository.length === 0) {
+      return "";
+    }
+
+    const cacheKey = `${workspace}/${repository}`.toLowerCase();
     const cached = this.bootstrapStandardsCache.get(cacheKey);
     if (cached !== undefined) {
       return cached;
     }
 
-    const task = `Bootstrap repo review standards for ${request.workspace}/${request.repository}. Inspect the last 15 merged pull requests on this repository. For each, collect inline and summary comments left by HUMAN reviewers (ignore bot authors like "Yama", "yama-bot", "yama-review", "euler.bot"). Focus on comments that asked for code changes, flagged bugs, pushed back on an approach, or cited a convention. Distill the recurring patterns and anti-patterns the human reviewers care about — especially things that a static config rule set would miss (naming, error-handling idioms, module boundaries, test expectations, migration rules, review etiquette). Return a concise bullet list of 10-20 patterns. Each bullet: one sentence stating the pattern, optionally one sentence of rationale. Do NOT include PR numbers, author names, or raw quotes — just distilled patterns.`;
+    const task = `Bootstrap repo review standards for ${workspace}/${repository}. Inspect the last 15 merged pull requests on this repository. For each, collect inline and summary comments left by HUMAN reviewers (ignore bot authors like "Yama", "yama-bot", "yama-review", "euler.bot"). Focus on comments that asked for code changes, flagged bugs, pushed back on an approach, or cited a convention. Distill the recurring patterns and anti-patterns the human reviewers care about — especially things that a static config rule set would miss (naming, error-handling idioms, module boundaries, test expectations, migration rules, review etiquette). Return a concise bullet list of 10-20 patterns. Each bullet: one sentence stating the pattern, optionally one sentence of rationale. Do NOT include PR numbers, author names, or raw quotes — just distilled patterns.`;
 
     try {
       console.log(
         `   🧭 Bootstrapping repo standards from recent PRs (one-time per process)...`,
       );
       const { result } = await this.explorer.explore(
-        { task, focus: [request.repository] },
+        { task, focus: [repository] },
         {
           sessionId,
           mode: "pr",
-          workspace: request.workspace,
-          repository: request.repository,
-          pullRequestId: request.pullRequestId,
+          provider: this.detectedProvider,
+          workspace,
+          repository,
+          pullRequestId: request.pullRequestId ?? request.prNumber,
           branch: request.branch,
           dryRun: request.dryRun || false,
           metadata: { bootstrap: true },
@@ -1489,8 +1642,9 @@ export class YamaOrchestrator {
   private async ensureInitialized(
     mode: ReviewMode = "pr",
     configPath?: string,
+    request?: ReviewRequest,
   ): Promise<void> {
-    await this.initialize(configPath, mode);
+    await this.initialize(configPath, mode, request);
   }
 
   /**

--- a/src/v2/exploration/ContextExplorerService.ts
+++ b/src/v2/exploration/ContextExplorerService.ts
@@ -16,6 +16,7 @@ import {
   buildObservabilityConfigFromEnv,
   validateObservabilityConfig,
 } from "../utils/ObservabilityConfig.js";
+import { getProviderToolset } from "../providers/ProviderToolset.js";
 import { ExplorerPromptBuilder } from "./ExplorerPromptBuilder.js";
 import { RulesContextLoader } from "./RulesContextLoader.js";
 import {
@@ -116,8 +117,7 @@ export class ContextExplorerService {
       ...this.getToolFilteringOptions(runtimeContext.mode),
       context: {
         sessionId: runtimeContext.sessionId,
-        userId:
-          `${runtimeContext.workspace}-${runtimeContext.repository}`.toLowerCase(),
+        userId: this.getUserId(runtimeContext),
         operation: "explore-context-research",
         metadata: runtimeContext.metadata || {},
       },
@@ -143,8 +143,7 @@ export class ContextExplorerService {
       disableTools: true,
       context: {
         sessionId: runtimeContext.sessionId,
-        userId:
-          `${runtimeContext.workspace}-${runtimeContext.repository}`.toLowerCase(),
+        userId: this.getUserId(runtimeContext),
         operation: "explore-context-extraction",
         metadata: runtimeContext.metadata || {},
       },
@@ -193,15 +192,59 @@ export class ContextExplorerService {
     input: ExploreContextInput,
     runtimeContext: ExploreRuntimeContext,
   ): string {
+    // Validate required string parameters
+    const task =
+      typeof input.task === "string" ? input.task.trim().toLowerCase() : "";
+    const workspace =
+      typeof runtimeContext.workspace === "string"
+        ? runtimeContext.workspace.trim()
+        : "";
+    const repository =
+      typeof runtimeContext.repository === "string"
+        ? runtimeContext.repository.trim()
+        : "";
+
+    if (!task) {
+      throw new Error("Invalid cache key: task must be a non-empty string");
+    }
+    if (!workspace || !repository) {
+      throw new Error(
+        "Invalid cache key: workspace and repository must be non-empty strings",
+      );
+    }
+
     return JSON.stringify({
       mode: runtimeContext.mode,
-      workspace: runtimeContext.workspace,
-      repository: runtimeContext.repository,
+      provider:
+        typeof runtimeContext.provider === "string"
+          ? runtimeContext.provider.trim().toLowerCase()
+          : "bitbucket",
+      workspace,
+      repository,
       pullRequestId: runtimeContext.pullRequestId || null,
-      branch: runtimeContext.branch || null,
-      task: input.task.toLowerCase(),
-      focus: (input.focus || []).map((item) => item.toLowerCase()),
+      branch:
+        typeof runtimeContext.branch === "string"
+          ? runtimeContext.branch.trim()
+          : null,
+      task,
+      focus: Array.isArray(input.focus)
+        ? input.focus
+            .filter((item): item is string => typeof item === "string")
+            .map((item) => item.trim().toLowerCase())
+        : [],
     });
+  }
+
+  private getUserId(runtimeContext: ExploreRuntimeContext): string {
+    const workspace =
+      typeof runtimeContext.workspace === "string"
+        ? runtimeContext.workspace.trim()
+        : "unknown";
+    const repository =
+      typeof runtimeContext.repository === "string"
+        ? runtimeContext.repository.trim()
+        : "unknown";
+    return `${workspace}-${repository}`.toLowerCase();
   }
 
   private getToolFilteringOptions(mode: "pr" | "local"): {
@@ -224,13 +267,26 @@ export class ContextExplorerService {
     }
   }
 
+  /**
+   * Provider-agnostic mutation block list for the read-only explore subagent.
+   * Derived once from each provider toolset's mutationToolNames (Bitbucket +
+   * GitHub) so the source of truth stays in ProviderToolset, not re-hardcoded
+   * here. Names are lower-cased for case-insensitive matching against the
+   * normalized tool name.
+   */
+  private static readonly MUTATION_TOOL_NAMES: ReadonlySet<string> = new Set(
+    (["bitbucket", "github"] as const).flatMap((provider) =>
+      getProviderToolset(provider).mutationToolNames.map((name) =>
+        name.toLowerCase(),
+      ),
+    ),
+  );
+
   private shouldExcludeTool(mode: "pr" | "local", toolName: string): boolean {
     const normalized = this.normalizeToolName(toolName);
 
     if (
-      /^(add_comment|set_pr_approval|set_review_status|approve_pull_request|unapprove_pull_request|request_changes|remove_requested_changes|update_pull_request|merge_pull_request|delete_branch)$/i.test(
-        normalized,
-      )
+      ContextExplorerService.MUTATION_TOOL_NAMES.has(normalized.toLowerCase())
     ) {
       return true;
     }
@@ -589,6 +645,7 @@ Rules:
     return this.memoryManager.readRepositoryMemory(
       runtimeContext.workspace,
       runtimeContext.repository,
+      runtimeContext.provider || "bitbucket",
     );
   }
 

--- a/src/v2/exploration/types.ts
+++ b/src/v2/exploration/types.ts
@@ -10,6 +10,7 @@ export interface ExploreRuntimeContext {
   mode: "pr" | "local";
   workspace: string;
   repository: string;
+  provider?: string; // "github" | "bitbucket" (defaults to "bitbucket" for backward compatibility)
   pullRequestId?: number;
   branch?: string;
   dryRun?: boolean;

--- a/src/v2/learning/types.ts
+++ b/src/v2/learning/types.ts
@@ -3,6 +3,8 @@
  * Type definitions for the knowledge base and learning extraction system
  */
 
+import type { VCSProviderName } from "../providers/ProviderToolset.js";
+
 // ============================================================================
 // Learning Categories
 // ============================================================================
@@ -104,6 +106,7 @@ export interface LearnRequest {
   workspace: string;
   repository: string;
   pullRequestId: number;
+  provider?: VCSProviderName; // "github" | "bitbucket" (defaults to "bitbucket" for backward compatibility)
   dryRun?: boolean;
   /** @deprecated Use commitMode instead */
   commit?: boolean;

--- a/src/v2/memory/MemoryManager.ts
+++ b/src/v2/memory/MemoryManager.ts
@@ -139,10 +139,34 @@ export class MemoryManager {
   }
 
   /**
-   * Build a deterministic owner ID from workspace and repository.
+   * Build a deterministic owner ID from provider, workspace, and repository.
+   * Isolates memory per platform to prevent collisions between same repo names
+   * on different platforms (e.g., "repo" on GitHub vs Bitbucket).
+   *
+   * Format:
+   *   - GitHub: github-{owner}-{repo}
+   *   - Bitbucket: bitbucket-{workspace}-{repo}
+   *
    * This value is passed as `context.userId` in generate() calls.
    */
-  static buildOwnerId(workspace: string, repository: string): string {
+  static buildOwnerId(
+    workspace: string,
+    repository: string,
+    provider: string = "bitbucket",
+  ): string {
+    const providerPrefix = provider.toLowerCase();
+    return `${providerPrefix}-${workspace}-${repository}`.toLowerCase();
+  }
+
+  /**
+   * Build the legacy (unprefixed) owner ID used before provider isolation.
+   *
+   * Format: {workspace}-{repository}
+   *
+   * Used as a read-time fallback so memory written before the provider-prefix
+   * upgrade keeps working. New writes always use the provider-prefixed key.
+   */
+  static buildLegacyOwnerId(workspace: string, repository: string): string {
     return `${workspace}-${repository}`.toLowerCase();
   }
 
@@ -165,13 +189,25 @@ export class MemoryManager {
   }
 
   /**
-   * Read persisted condensed memory for a workspace/repository pair.
+   * Read persisted condensed memory for a workspace/repository pair on a specific provider.
    */
   async readRepositoryMemory(
     workspace: string,
     repository: string,
+    provider: string = "bitbucket",
   ): Promise<string | null> {
-    return this.readMemory(MemoryManager.buildOwnerId(workspace, repository));
+    const prefixed = await this.readMemory(
+      MemoryManager.buildOwnerId(workspace, repository, provider),
+    );
+    if (prefixed !== null) {
+      return prefixed;
+    }
+
+    // Fall back to the legacy unprefixed key so memory written before the
+    // provider-prefix upgrade is not silently dropped after upgrading.
+    return this.readMemory(
+      MemoryManager.buildLegacyOwnerId(workspace, repository),
+    );
   }
 
   /**

--- a/src/v2/prompts/PromptBuilder.ts
+++ b/src/v2/prompts/PromptBuilder.ts
@@ -13,7 +13,14 @@ import { YamaConfig } from "../types/config.types.js";
 import { LocalReviewRequest, ReviewRequest } from "../types/v2.types.js";
 import type { LocalDiffContext } from "../core/LocalDiffSource.js";
 import { LangfusePromptManager } from "./LangfusePromptManager.js";
+import { buildReviewSystemPrompt } from "./ReviewSystemPrompt.js";
 import { KnowledgeBaseManager } from "../learning/KnowledgeBaseManager.js";
+import {
+  getProviderToolset,
+  type ProviderToolset,
+  type ReviewPromptParams,
+  type VCSProviderName,
+} from "../providers/ProviderToolset.js";
 
 export class PromptBuilder {
   private langfuseManager: LangfusePromptManager;
@@ -23,16 +30,77 @@ export class PromptBuilder {
   }
 
   /**
+   * Build the provider-agnostic params object the ProviderToolset consumes.
+   * Carries both Bitbucket (workspace/repository/pullRequestId) and GitHub
+   * (owner/repo/prNumber) identifiers plus the shared branch; each toolset
+   * reads only the fields it needs.
+   */
+  private toToolsetParams(request: ReviewRequest): ReviewPromptParams {
+    const params: ReviewPromptParams = {};
+
+    const workspace = (request.workspace || "").trim();
+    const repository = (request.repository || "").trim();
+    const branch = (request.branch || "N/A").trim();
+
+    params.workspace = workspace;
+    params.repository = repository;
+    params.branch = branch;
+
+    // Coalesce the PR identifier across both field names so the toolset always
+    // receives the PR number regardless of which one the caller populated.
+    // GitHub's identifierXml reads params.prNumber while Bitbucket's reads
+    // params.pullRequestId; CLI callers set request.pullRequestId even for
+    // GitHub, so without this a GitHub run would lose the PR number and fall
+    // back to 'find-by-branch'. No-op for existing Bitbucket behavior.
+    const resolvedPrNumber =
+      request.prNumber ??
+      (typeof request.pullRequestId === "number"
+        ? request.pullRequestId
+        : undefined);
+    const resolvedPullRequestId = request.pullRequestId ?? request.prNumber;
+
+    if (resolvedPullRequestId !== undefined) {
+      params.pullRequestId = resolvedPullRequestId;
+    }
+    if (request.owner !== undefined) {
+      params.owner = request.owner.trim();
+    }
+    // Coalesce the repo name across the GitHub-specific 'repo' field and the
+    // shared 'repository' field, mirroring the prNumber<->pullRequestId
+    // coalescing above. A GitHub caller may populate the shared 'repository'
+    // field instead of 'repo'; without this the toolset would receive GitHub
+    // identifiers with no repo name. No-op for existing Bitbucket behavior,
+    // which never sets request.repo.
+    const resolvedRepo = request.repo ?? request.repository;
+    if (resolvedRepo !== undefined) {
+      params.repo = resolvedRepo.trim();
+    }
+    if (resolvedPrNumber !== undefined) {
+      params.prNumber = resolvedPrNumber;
+    }
+
+    return params;
+  }
+
+  /**
    * Build complete review instructions for AI
    * Combines generic base prompt + project-specific config
    */
   async buildReviewInstructions(
     request: ReviewRequest,
     config: YamaConfig,
-    bootstrapStandards?: string | null,
+    bootstrapStandards: string | null | undefined,
+    provider: VCSProviderName,
   ): Promise<string> {
-    // Base system prompt - fetched from Langfuse or local fallback
-    const basePromptRaw = await this.langfuseManager.getReviewPrompt();
+    const toolset = getProviderToolset(provider);
+
+    // Base system prompt. Prefer a Langfuse-managed prompt when one is
+    // configured (provider-agnostic remote override); otherwise fall back to
+    // the provider-aware local prompt so the <tool-usage> section matches the
+    // active provider's tool idiom.
+    const basePromptRaw = this.langfuseManager.isEnabled()
+      ? await this.langfuseManager.getReviewPrompt()
+      : buildReviewSystemPrompt(toolset);
 
     // Project-specific configuration in XML format
     const projectConfig = this.buildProjectConfigXML(config, request);
@@ -50,8 +118,10 @@ export class PromptBuilder {
       exploreEnabled,
     );
 
+    const toolsetParams = this.toToolsetParams(request);
+
     const workflowBlock = PromptBuilder.stripDisabledSections(
-      this.buildReviewWorkflow(request),
+      this.buildReviewWorkflow(request, toolset, toolsetParams),
       exploreEnabled,
     );
 
@@ -84,10 +154,7 @@ ${bootstrapBlock}
 ${knowledgeBase ? `<learned-knowledge>\n${knowledgeBase}\n</learned-knowledge>` : ""}
 
 <review-task>
-  <workspace>${this.escapeXML(request.workspace)}</workspace>
-  <repository>${this.escapeXML(request.repository)}</repository>
-  <pull_request_id>${request.pullRequestId || "find-by-branch"}</pull_request_id>
-  <branch>${this.escapeXML(request.branch || "N/A")}</branch>
+${toolset.identifierXml(toolsetParams)}
   <mode>${request.dryRun ? "dry-run" : "live"}</mode>
 
 ${workflowBlock}
@@ -99,7 +166,11 @@ ${workflowBlock}
    * Per-PR workflow block. Standards-first, file-by-file, explore-on-uncertainty.
    * The agent stays autonomous; this just choreographs the order it should follow.
    */
-  private buildReviewWorkflow(request: ReviewRequest): string {
+  private buildReviewWorkflow(
+    request: ReviewRequest,
+    toolset: ProviderToolset,
+    params: ReviewPromptParams,
+  ): string {
     const modeLine = request.dryRun
       ? "DRY RUN MODE: simulate actions only, do not post real comments or change PR state."
       : "LIVE MODE: post real comments and make real decisions.";
@@ -107,40 +178,11 @@ ${workflowBlock}
       ? `\n  ADDITIONAL INSTRUCTIONS: ${this.escapeXML(request.prompt)}`
       : "";
 
+    // The numbered review steps (tool names + workflow prose) come from the
+    // provider toolset; the <instructions> wrapper and the dynamic mode/
+    // additional tail stay here so they apply to every provider unchanged.
     return `  <instructions>
-    Begin your autonomous review. Follow this order.
-
-    STEP 1 — Read project standards
-    Read the <project-standards> block above carefully. Treat any reviewer-expectation
-    entry with severity=BLOCKING as a blocking criterion for this PR. If the block is
-    missing or empty, fall back to <focus-areas> and <blocking-criteria>.
-
-    STEP 2 — Read the PR shell
-    Call get_pull_request once to get changed files, branch info, and existing comments.
-    Build a mental map of which files exist and which already have comments.
-    Do NOT request the full PR diff.
-
-    STEP 3 — Walk files one at a time
-    For each changed file, in order:
-      a. Call get_pull_request_diff(file_path=&lt;this file&gt;).
-      b. Cross-check the diff against project-standards and existing comments on this file.
-      c. If anything is non-trivial — multi-file impact, unfamiliar pattern, unclear intent,
-         history-dependent behavior — <!-- EXPLORE_BEGIN -->call explore_context with a precise
-         task and wait for its evidence before commenting<!-- EXPLORE_END --><!-- EXPLORE_DISABLED_BEGIN -->use search_code or get_file_content to verify before commenting<!-- EXPLORE_DISABLED_END -->.
-      d. For every confirmed issue, call add_comment immediately with line_number and
-         line_type from the diff JSON. Include a real-code suggestion for CRITICAL/MAJOR.
-      e. Move to the next file. Never request another file's diff before finishing the
-         current one. Never request a multi-file diff.
-
-    STEP 4 — Decision
-    After the last file, count issues by severity, apply <blocking-criteria>, and call
-    set_pr_approval(approved=true) OR set_review_status(request_changes=true).
-
-    STEP 5 — Summary comment
-    Post one summary comment with file count, issue counts by severity, and next steps.
-
-    Budget guidance: roughly 10 tool calls per file in the main loop. If you exceed
-    that on a single file, <!-- EXPLORE_BEGIN -->delegate the rest to explore_context<!-- EXPLORE_END --><!-- EXPLORE_DISABLED_BEGIN -->stop investigating<!-- EXPLORE_DISABLED_END --> and move on.
+${toolset.reviewWorkflowInstructions(params)}
 
     ${modeLine}${additional}
   </instructions>`;
@@ -365,7 +407,11 @@ ${loadedStandards.join("\n\n---\n\n")}
   async buildDescriptionEnhancementInstructions(
     request: ReviewRequest,
     config: YamaConfig,
+    provider: VCSProviderName,
   ): Promise<string> {
+    const toolset = getProviderToolset(provider);
+    const toolsetParams = this.toToolsetParams(request);
+
     // Base enhancement prompt - fetched from Langfuse or local fallback
     const basePrompt = await this.langfuseManager.getEnhancementPrompt();
 
@@ -380,25 +426,11 @@ ${enhancementConfigXML}
 </project-configuration>
 
 <enhancement-task>
-  <workspace>${this.escapeXML(request.workspace)}</workspace>
-  <repository>${this.escapeXML(request.repository)}</repository>
-  <pull_request_id>${request.pullRequestId || "find-by-branch"}</pull_request_id>
-  <branch>${this.escapeXML(request.branch || "N/A")}</branch>
+${toolset.identifierXml(toolsetParams)}
   <mode>${request.dryRun ? "dry-run" : "live"}</mode>
 
   <instructions>
-    Enhance the PR description now.
-
-    1. Call get_pull_request() to read current PR and description
-    2. Call get_pull_request_diff() to analyze code changes
-    3. Use search_code() to find configuration patterns, API changes
-    4. Extract information for each required section
-    5. Build enhanced description following section structure
-    6. Call update_pull_request() with enhanced description
-
-    CRITICAL: Return ONLY the enhanced description markdown.
-    Do NOT include meta-commentary or explanations.
-    Start directly with section content.
+${toolset.descriptionEnhancementInstructions(toolsetParams)}
 
     ${request.dryRun ? "DRY RUN MODE: Simulate only, do not actually update PR." : "LIVE MODE: Update the actual PR description."}
     ${request.prompt ? `ADDITIONAL INSTRUCTIONS: ${this.escapeXML(request.prompt)}` : ""}

--- a/src/v2/prompts/ReviewSystemPrompt.ts
+++ b/src/v2/prompts/ReviewSystemPrompt.ts
@@ -7,9 +7,38 @@
  *
  * Sections wrapped in <!-- EXPLORE_BEGIN --> ... <!-- EXPLORE_END --> markers
  * are stripped by PromptBuilder when config.ai.explore.enabled is false.
+ *
+ * The <tool-usage> section is the ONLY provider-specific part of this prompt.
+ * It is supplied by the ProviderToolset so the same review philosophy, severity
+ * rules and anti-patterns drive both Bitbucket and GitHub. For
+ * provider === "bitbucket" the rendered output is byte-identical to the
+ * historical hardcoded prompt (the toolset's Bitbucket strings were copied
+ * verbatim).
  */
 
-export const REVIEW_SYSTEM_PROMPT = `
+import {
+  getProviderToolset,
+  type ProviderToolset,
+  type VCSProviderName,
+} from "../providers/ProviderToolset.js";
+
+/**
+ * Render the base review system prompt for a given provider.
+ *
+ * Accepts either a provider name (the common case) or an already-resolved
+ * ProviderToolset. Only the <tool-usage> section varies by provider; every
+ * other block (identity, core rules, severity levels, anti-patterns) is shared
+ * verbatim.
+ */
+export function buildReviewSystemPrompt(
+  provider: VCSProviderName | ProviderToolset,
+): string {
+  const toolset: ProviderToolset =
+    typeof provider === "string" ? getProviderToolset(provider) : provider;
+
+  const toolUsageSection = toolset.systemPromptToolsSection();
+
+  return `
 <yama-review-system>
   <identity>
     <role>Autonomous Code Review Agent</role>
@@ -25,48 +54,7 @@ export const REVIEW_SYSTEM_PROMPT = `
     <rule id="avoid-duplicates">Check existing comments before posting. If a developer's reply is wrong, reply to it instead of duplicating.</rule>
   </core-rules>
 
-  <tool-usage>
-    <tool name="get_pull_request">
-      <use-when>Once at the start, to read PR metadata and existing comments.</use-when>
-    </tool>
-
-    <tool name="get_pull_request_diff">
-      <use-when>For ONE file at a time, immediately before reviewing it.</use-when>
-      <do-not-use-when>Never call this without a file_path argument. Never request the full PR diff.</do-not-use-when>
-    </tool>
-
-    <tool name="search_code">
-      <use-when>A single direct lookup answers your question (function definition, single file).</use-when>
-      <do-not-use-when>The investigation needs more than one call or spans multiple files — delegate to explore_context instead.</do-not-use-when>
-    </tool>
-
-    <tool name="get_file_content">
-      <use-when>You already know the path and need the file's contents.</use-when>
-    </tool>
-
-    <!-- EXPLORE_BEGIN -->
-    <tool name="explore_context">
-      <use-when>Multi-step research, multi-file tracing, history lookup, ambiguous behavior, or anything that would otherwise need 3+ tool calls in the main loop.</use-when>
-      <do-not-use-when>A single search_code or get_file_content would answer it. Delegating cheap lookups wastes a turn.</do-not-use-when>
-      <how>Pass a one-sentence research question as task and optional file paths/PR refs as focus. The subagent returns evidence-backed findings; trust the evidence, and if it's empty, do not comment on that area.</how>
-      <example positive>Diff adds a retry guard in PaymentProcessor → explore_context(task="Is this retry guard consistent with how other payment handlers retry, and does it match the convention from PR 842?", focus=["src/payments/", "PR 842"])</example>
-      <example negative>Don't: explore_context(task="What does validatePayment do?"). Do: search_code(search_query="function validatePayment").</example>
-    </tool>
-    <!-- EXPLORE_END -->
-
-    <tool name="add_comment">
-      <fields>file_path, line_number, line_type (ADDED|REMOVED|CONTEXT), comment_text, and suggestion (required for CRITICAL and MAJOR — must be real, executable code).</fields>
-      <do-not-use-when>You only have a code_snippet but no line_number/line_type from the diff JSON.</do-not-use-when>
-    </tool>
-
-    <tool name="set_pr_approval">
-      <use-when>No blocking issues found. Pass approved=true.</use-when>
-    </tool>
-
-    <tool name="set_review_status">
-      <use-when>Blocking criteria met. Pass request_changes=true.</use-when>
-    </tool>
-  </tool-usage>
+${toolUsageSection}
 
   <severity-levels>
     <level name="CRITICAL" emoji="🔒">Blocks the PR. MUST include a real-code suggestion. Security, data loss, auth flaws, hardcoded secrets.</level>
@@ -85,5 +73,20 @@ export const REVIEW_SYSTEM_PROMPT = `
   </anti-patterns>
 </yama-review-system>
 `;
+}
+
+/**
+ * Provider-aware alias matching the pinned signature `build(provider)`.
+ */
+export const build = buildReviewSystemPrompt;
+
+/**
+ * Bitbucket-rendered base review system prompt.
+ *
+ * Kept as a named constant for backward compatibility with consumers that
+ * expect a static fallback (e.g. LangfusePromptManager's Bitbucket fallback).
+ * This is byte-identical to the historical hardcoded prompt.
+ */
+export const REVIEW_SYSTEM_PROMPT = buildReviewSystemPrompt("bitbucket");
 
 export default REVIEW_SYSTEM_PROMPT;

--- a/src/v2/providers/ProviderToolset.ts
+++ b/src/v2/providers/ProviderToolset.ts
@@ -1,0 +1,460 @@
+/**
+ * ProviderToolset — the single source of truth for everything that differs
+ * between VCS providers (Bitbucket vs GitHub) when Yama drives an AI review.
+ *
+ * Every provider-specific string the AI sees (the <available_tools> section,
+ * the numbered review workflow, the PR-context identifier block, the
+ * description-enhancement steps) and every provider-specific signal Yama reads
+ * back (which tool call is a comment, a diff fetch, a repo mutation, or an
+ * approve/block decision) lives behind this interface.
+ *
+ * The Bitbucket toolset reproduces the CURRENT prompt wording verbatim, so
+ * behaviour for Bitbucket stays byte-identical. The GitHub toolset teaches the
+ * official github/github-mcp-server consolidated API and pending-review flow,
+ * keeping the same review philosophy and severity rules.
+ */
+
+export type VCSProviderName = "github" | "bitbucket";
+
+export interface ReviewPromptParams {
+  workspace?: string;
+  repository?: string;
+  pullRequestId?: number | string;
+  owner?: string;
+  repo?: string;
+  prNumber?: number;
+  branch?: string;
+}
+
+export interface ProviderToolCall {
+  toolName?: string;
+  args?: Record<string, unknown>;
+}
+
+export interface ProviderToolset {
+  readonly provider: VCSProviderName;
+  /** Tool name the AI calls to read a PR's metadata/comments
+   *  (Bitbucket: get_pull_request; GitHub: pull_request_read). */
+  readonly prReadToolName: string;
+  /** <pr_context> identifier block injected into review/enhancement prompts */
+  identifierXml(params: ReviewPromptParams): string;
+  /** The <available_tools> section listing the tools the AI may call (provider idiom) */
+  systemPromptToolsSection(): string;
+  /** Provider-specific numbered review workflow instructions (prose the AI follows) */
+  reviewWorkflowInstructions(params: ReviewPromptParams): string;
+  /** Provider-specific PR-description-enhancement workflow instructions */
+  descriptionEnhancementInstructions(params: ReviewPromptParams): string;
+  /** Tool names whose calls represent an inline/PR comment (statistics counting) */
+  readonly commentToolNames: string[];
+  /** Tool names representing diff/file retrieval (statistics counting) */
+  readonly diffToolNames: string[];
+  /** Plain tool names that mutate PR/repo state (explore_context block list) */
+  readonly mutationToolNames: string[];
+  /** Interpret a single tool call as an approve/block decision signal, else null.
+   *  Bitbucket: set_pr_approval/set_review_status (+ args). GitHub: pull_request_review_write with args.event. */
+  interpretDecision(call: ProviderToolCall): "APPROVED" | "BLOCKED" | null;
+}
+
+/**
+ * Escape XML special characters. Mirrors PromptBuilder.escapeXML so the
+ * identifier blocks emitted here are byte-identical to the current prompt.
+ */
+function escapeXML(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+// ============================================================================
+// Bitbucket toolset — reproduces the CURRENT prompt text VERBATIM
+// ============================================================================
+
+class BitbucketToolset implements ProviderToolset {
+  readonly provider: VCSProviderName = "bitbucket";
+
+  // get_pull_request reads PR metadata and existing comments today.
+  readonly prReadToolName = "get_pull_request";
+
+  // add_comment is the inline/PR comment tool today.
+  readonly commentToolNames: string[] = ["add_comment"];
+
+  // get_pull_request_diff is the per-file diff retrieval tool today.
+  readonly diffToolNames: string[] = ["get_pull_request_diff"];
+
+  // Plain Bitbucket mutation names currently blocked in
+  // ContextExplorerService.shouldExcludeTool. Copied verbatim from the regex
+  // alternation so explore_context cannot mutate PR/repo state.
+  readonly mutationToolNames: string[] = [
+    "add_comment",
+    "set_pr_approval",
+    "set_review_status",
+    "approve_pull_request",
+    "unapprove_pull_request",
+    "request_changes",
+    "remove_requested_changes",
+    "update_pull_request",
+    "merge_pull_request",
+    "delete_branch",
+  ];
+
+  /**
+   * <pr_context> identifier block — mirrors the <workspace>/<repository>/
+   * <pull_request_id>/<branch> fields PromptBuilder emits today (~lines
+   * 119-122), with the same escaping and the same "find-by-branch" fallback.
+   */
+  identifierXml(params: ReviewPromptParams): string {
+    const workspace = escapeXML((params.workspace || "").trim());
+    const repository = escapeXML((params.repository || "").trim());
+    const pullRequestId = params.pullRequestId || "find-by-branch";
+    const branch = escapeXML((params.branch || "N/A").trim());
+
+    return `  <workspace>${workspace}</workspace>
+  <repository>${repository}</repository>
+  <pull_request_id>${pullRequestId}</pull_request_id>
+  <branch>${branch}</branch>`;
+  }
+
+  /**
+   * The <available_tools>/<tool-usage> section. Reproduced verbatim from
+   * ReviewSystemPrompt.ts (the <tool-usage> block, lines 28-69).
+   */
+  systemPromptToolsSection(): string {
+    return `  <tool-usage>
+    <tool name="get_pull_request">
+      <use-when>Once at the start, to read PR metadata and existing comments.</use-when>
+    </tool>
+
+    <tool name="get_pull_request_diff">
+      <use-when>For ONE file at a time, immediately before reviewing it.</use-when>
+      <do-not-use-when>Never call this without a file_path argument. Never request the full PR diff.</do-not-use-when>
+    </tool>
+
+    <tool name="search_code">
+      <use-when>A single direct lookup answers your question (function definition, single file).</use-when>
+      <do-not-use-when>The investigation needs more than one call or spans multiple files — delegate to explore_context instead.</do-not-use-when>
+    </tool>
+
+    <tool name="get_file_content">
+      <use-when>You already know the path and need the file's contents.</use-when>
+    </tool>
+
+    <!-- EXPLORE_BEGIN -->
+    <tool name="explore_context">
+      <use-when>Multi-step research, multi-file tracing, history lookup, ambiguous behavior, or anything that would otherwise need 3+ tool calls in the main loop.</use-when>
+      <do-not-use-when>A single search_code or get_file_content would answer it. Delegating cheap lookups wastes a turn.</do-not-use-when>
+      <how>Pass a one-sentence research question as task and optional file paths/PR refs as focus. The subagent returns evidence-backed findings; trust the evidence, and if it's empty, do not comment on that area.</how>
+      <example positive>Diff adds a retry guard in PaymentProcessor → explore_context(task="Is this retry guard consistent with how other payment handlers retry, and does it match the convention from PR 842?", focus=["src/payments/", "PR 842"])</example>
+      <example negative>Don't: explore_context(task="What does validatePayment do?"). Do: search_code(search_query="function validatePayment").</example>
+    </tool>
+    <!-- EXPLORE_END -->
+
+    <tool name="add_comment">
+      <fields>file_path, line_number, line_type (ADDED|REMOVED|CONTEXT), comment_text, and suggestion (required for CRITICAL and MAJOR — must be real, executable code).</fields>
+      <do-not-use-when>You only have a code_snippet but no line_number/line_type from the diff JSON.</do-not-use-when>
+    </tool>
+
+    <tool name="set_pr_approval">
+      <use-when>No blocking issues found. Pass approved=true.</use-when>
+    </tool>
+
+    <tool name="set_review_status">
+      <use-when>Blocking criteria met. Pass request_changes=true.</use-when>
+    </tool>
+  </tool-usage>`;
+  }
+
+  /**
+   * Numbered review workflow. Reproduced verbatim from
+   * PromptBuilder.buildReviewWorkflow (the <instructions> body, lines 142-178),
+   * minus the dynamic modeLine/additional tail which the caller still appends.
+   */
+  reviewWorkflowInstructions(_params: ReviewPromptParams): string {
+    return `    Begin your autonomous review. Follow this order.
+
+    STEP 1 — Read project standards
+    Read the <project-standards> block above carefully. Treat any reviewer-expectation
+    entry with severity=BLOCKING as a blocking criterion for this PR. If the block is
+    missing or empty, fall back to <focus-areas> and <blocking-criteria>.
+
+    STEP 2 — Read the PR shell
+    Call get_pull_request once to get changed files, branch info, and existing comments.
+    Build a mental map of which files exist and which already have comments.
+    Do NOT request the full PR diff.
+
+    STEP 3 — Walk files one at a time
+    For each changed file, in order:
+      a. Call get_pull_request_diff(file_path=&lt;this file&gt;).
+      b. Cross-check the diff against project-standards and existing comments on this file.
+      c. If anything is non-trivial — multi-file impact, unfamiliar pattern, unclear intent,
+         history-dependent behavior — <!-- EXPLORE_BEGIN -->call explore_context with a precise
+         task and wait for its evidence before commenting<!-- EXPLORE_END --><!-- EXPLORE_DISABLED_BEGIN -->use search_code or get_file_content to verify before commenting<!-- EXPLORE_DISABLED_END -->.
+      d. For every confirmed issue, call add_comment immediately with line_number and
+         line_type from the diff JSON. Include a real-code suggestion for CRITICAL/MAJOR.
+      e. Move to the next file. Never request another file's diff before finishing the
+         current one. Never request a multi-file diff.
+
+    STEP 4 — Decision
+    After the last file, count issues by severity, apply <blocking-criteria>, and call
+    set_pr_approval(approved=true) OR set_review_status(request_changes=true).
+
+    STEP 5 — Summary comment
+    Post one summary comment with file count, issue counts by severity, and next steps.
+
+    Budget guidance: roughly 10 tool calls per file in the main loop. If you exceed
+    that on a single file, <!-- EXPLORE_BEGIN -->delegate the rest to explore_context<!-- EXPLORE_END --><!-- EXPLORE_DISABLED_BEGIN -->stop investigating<!-- EXPLORE_DISABLED_END --> and move on.`;
+  }
+
+  /**
+   * Description-enhancement workflow. Reproduced verbatim from
+   * PromptBuilder.buildDescriptionEnhancementInstructions (the <instructions>
+   * body, lines 421-437), minus the dynamic mode/additional tail.
+   */
+  descriptionEnhancementInstructions(_params: ReviewPromptParams): string {
+    return `    Enhance the PR description now.
+
+    1. Call get_pull_request() to read current PR and description
+    2. Call get_pull_request_diff() to analyze code changes
+    3. Use search_code() to find configuration patterns, API changes
+    4. Extract information for each required section
+    5. Build enhanced description following section structure
+    6. Call update_pull_request() with enhanced description
+
+    CRITICAL: Return ONLY the enhanced description markdown.
+    Do NOT include meta-commentary or explanations.
+    Start directly with section content.`;
+  }
+
+  /**
+   * Replicates the orchestrator's extractDecision logic
+   * (YamaV2Orchestrator.extractDecision, ~lines 1132-1163) for a single call.
+   * set_review_status(request_changes=true) -> BLOCKED;
+   * set_pr_approval(approved=true) -> APPROVED. Legacy names handled too.
+   */
+  interpretDecision(call: ProviderToolCall): "APPROVED" | "BLOCKED" | null {
+    const name = call.toolName;
+    const args = call.args || {};
+
+    if (name === "set_review_status") {
+      if (typeof args.request_changes === "boolean") {
+        return args.request_changes ? "BLOCKED" : null;
+      }
+      return null;
+    }
+    if (name === "request_changes") {
+      return "BLOCKED";
+    }
+    if (name === "remove_requested_changes") {
+      return null;
+    }
+    if (name === "set_pr_approval") {
+      if (typeof args.approved === "boolean") {
+        return args.approved ? "APPROVED" : null;
+      }
+      return null;
+    }
+    if (name === "approve_pull_request") {
+      return "APPROVED";
+    }
+    if (name === "unapprove_pull_request") {
+      return null;
+    }
+
+    return null;
+  }
+}
+
+// ============================================================================
+// GitHub toolset — teaches the github/github-mcp-server consolidated API
+// ============================================================================
+
+class GitHubToolset implements ProviderToolset {
+  readonly provider: VCSProviderName = "github";
+
+  // pull_request_read (method="get") reads PR metadata and existing comments.
+  readonly prReadToolName = "pull_request_read";
+
+  // Inline comments go through the pending-review batch; non-line PR comments
+  // through add_issue_comment.
+  readonly commentToolNames: string[] = [
+    "add_comment_to_pending_review",
+    "add_issue_comment",
+  ];
+
+  // pull_request_read serves PR meta, unified diff, and changed files.
+  readonly diffToolNames: string[] = ["pull_request_read"];
+
+  // Tools that mutate PR/repo state — review-write, comment-write, PR update,
+  // and the raw repo-mutation tools. Blocked for explore_context.
+  readonly mutationToolNames: string[] = [
+    "pull_request_review_write",
+    "add_comment_to_pending_review",
+    "add_issue_comment",
+    "update_pull_request",
+    "push_files",
+    "create_or_update_file",
+    "create_branch",
+    "delete_file",
+    "create_pull_request_with_copilot",
+    "assign_copilot_to_issue",
+  ];
+
+  /**
+   * <pr_context> identifier block for GitHub: owner / repo / pull_number.
+   */
+  identifierXml(params: ReviewPromptParams): string {
+    const owner = escapeXML((params.owner || "").trim());
+    const repo = escapeXML((params.repo || "").trim());
+    const pullNumber =
+      params.prNumber !== undefined ? params.prNumber : "find-by-branch";
+
+    return `  <owner>${owner}</owner>
+  <repo>${repo}</repo>
+  <pull_number>${pullNumber}</pull_number>`;
+  }
+
+  /**
+   * <tool-usage> section for the GitHub consolidated MCP API.
+   */
+  systemPromptToolsSection(): string {
+    return `  <tool-usage>
+    <tool name="pull_request_read">
+      <use-when>Read PR state. method="get" once at the start for PR metadata and existing comments; method="get_files" to list changed files; method="get_diff" for the unified diff. Always pass owner, repo, pullNumber.</use-when>
+    </tool>
+
+    <tool name="search_code">
+      <use-when>A single direct lookup answers your question (function definition, single file). Pass a query.</use-when>
+      <do-not-use-when>The investigation needs more than one call or spans multiple files — delegate to explore_context instead.</do-not-use-when>
+    </tool>
+
+    <tool name="get_file_contents">
+      <use-when>You already know the path and need the file's contents. Pass owner, repo, path, and optionally ref.</use-when>
+    </tool>
+
+    <!-- EXPLORE_BEGIN -->
+    <tool name="explore_context">
+      <use-when>Multi-step research, multi-file tracing, history lookup, ambiguous behavior, or anything that would otherwise need 3+ tool calls in the main loop.</use-when>
+      <do-not-use-when>A single search_code or get_file_contents would answer it. Delegating cheap lookups wastes a turn.</do-not-use-when>
+      <how>Pass a one-sentence research question as task and optional file paths/PR refs as focus. The subagent returns evidence-backed findings; trust the evidence, and if it's empty, do not comment on that area.</how>
+      <example positive>Diff adds a retry guard in PaymentProcessor → explore_context(task="Is this retry guard consistent with how other payment handlers retry, and does it match the convention from PR 842?", focus=["src/payments/", "PR 842"])</example>
+      <example negative>Don't: explore_context(task="What does validatePayment do?"). Do: search_code(query="function validatePayment").</example>
+    </tool>
+    <!-- EXPLORE_END -->
+
+    <tool name="pull_request_review_write">
+      <use-when>Open and close ONE pending review per PR. method="create" (owner, repo, pullNumber) opens the pending review BEFORE posting any inline comment. method="submit" (owner, repo, pullNumber, event, body) closes it: event="APPROVE" when clean, event="REQUEST_CHANGES" when blocking, event="COMMENT" otherwise. method="delete" discards an unsubmitted pending review.</use-when>
+      <do-not-use-when>Never submit before all inline comments are added. Never open more than one pending review per PR.</do-not-use-when>
+    </tool>
+
+    <tool name="add_comment_to_pending_review">
+      <fields>owner, repo, pullNumber, path, body, subjectType ("LINE"|"FILE"), and line (with optional side, startLine, startSide) for LINE comments. Each confirmed issue is one call. Include a real, executable code suggestion in body for CRITICAL and MAJOR.</fields>
+      <do-not-use-when>No pending review has been created yet, or you have no path/line for a LINE comment.</do-not-use-when>
+    </tool>
+
+    <tool name="add_issue_comment">
+      <fields>owner, repo, issue_number, body. Use for the general (non-line) PR summary comment.</fields>
+    </tool>
+  </tool-usage>`;
+  }
+
+  /**
+   * Numbered review workflow mirroring the Bitbucket steps but using the
+   * GitHub pending-review batch model. Same review philosophy and severity
+   * rules — only the tool calls differ.
+   */
+  reviewWorkflowInstructions(_params: ReviewPromptParams): string {
+    return `    Begin your autonomous review. Follow this order.
+
+    STEP 1 — Read project standards
+    Read the <project-standards> block above carefully. Treat any reviewer-expectation
+    entry with severity=BLOCKING as a blocking criterion for this PR. If the block is
+    missing or empty, fall back to <focus-areas> and <blocking-criteria>.
+
+    STEP 2 — Read the PR shell
+    Call pull_request_read(method="get", owner, repo, pullNumber) once to get PR
+    metadata and existing comments, then pull_request_read(method="get_files", ...)
+    to list the changed files. Build a mental map of which files exist and which
+    already have comments. Do NOT request the full PR diff yet.
+
+    STEP 3 — Open ONE pending review
+    Call pull_request_review_write(method="create", owner, repo, pullNumber) to open a
+    single pending review. Every inline comment in STEP 4 attaches to this review.
+
+    STEP 4 — Walk files one at a time
+    For each changed file, in order:
+      a. Call pull_request_read(method="get_diff", owner, repo, pullNumber) and work the
+         hunks for &lt;this file&gt; only. Finish this file before touching another.
+      b. Cross-check the diff against project-standards and existing comments on this file.
+      c. If anything is non-trivial — multi-file impact, unfamiliar pattern, unclear intent,
+         history-dependent behavior — <!-- EXPLORE_BEGIN -->call explore_context with a precise
+         task and wait for its evidence before commenting<!-- EXPLORE_END --><!-- EXPLORE_DISABLED_BEGIN -->use search_code or get_file_contents to verify before commenting<!-- EXPLORE_DISABLED_END -->.
+      d. For every confirmed issue, call add_comment_to_pending_review immediately with
+         path, line, subjectType="LINE", and body taken from the diff. Include a real-code
+         suggestion in body for CRITICAL/MAJOR.
+      e. Move to the next file. Never jump between files mid-review.
+
+    STEP 5 — Decision (submit the review)
+    After the last file, count issues by severity, apply <blocking-criteria>, and call
+    pull_request_review_write(method="submit", owner, repo, pullNumber, body=&lt;summary&gt;)
+    with event="APPROVE" when clean OR event="REQUEST_CHANGES" when blocking criteria are met.
+
+    STEP 6 — Summary comment
+    Use the submit body above for the summary (file count, issue counts by severity, next
+    steps). For an extra non-line note, call add_issue_comment(owner, repo, issue_number, body).
+
+    Budget guidance: roughly 10 tool calls per file in the main loop. If you exceed
+    that on a single file, <!-- EXPLORE_BEGIN -->delegate the rest to explore_context<!-- EXPLORE_END --><!-- EXPLORE_DISABLED_BEGIN -->stop investigating<!-- EXPLORE_DISABLED_END --> and move on.`;
+  }
+
+  /**
+   * Description-enhancement workflow using the GitHub consolidated API.
+   */
+  descriptionEnhancementInstructions(_params: ReviewPromptParams): string {
+    return `    Enhance the PR description now.
+
+    1. Call pull_request_read(method="get", owner, repo, pullNumber) to read current PR and description
+    2. Call pull_request_read(method="get_diff", owner, repo, pullNumber) to analyze code changes
+    3. Use search_code(query=...) to find configuration patterns, API changes
+    4. Extract information for each required section
+    5. Build enhanced description following section structure
+    6. Call update_pull_request(owner, repo, pullNumber, body=...) with enhanced description
+
+    CRITICAL: Return ONLY the enhanced description markdown.
+    Do NOT include meta-commentary or explanations.
+    Start directly with section content.`;
+  }
+
+  /**
+   * A submitted review carries the decision: APPROVE -> APPROVED,
+   * REQUEST_CHANGES -> BLOCKED, anything else (incl. COMMENT) -> null.
+   */
+  interpretDecision(call: ProviderToolCall): "APPROVED" | "BLOCKED" | null {
+    if (call.toolName !== "pull_request_review_write") {
+      return null;
+    }
+    const args = call.args || {};
+    if (args.method !== "submit") {
+      return null;
+    }
+    if (args.event === "APPROVE") {
+      return "APPROVED";
+    }
+    if (args.event === "REQUEST_CHANGES") {
+      return "BLOCKED";
+    }
+    return null;
+  }
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+const BITBUCKET_TOOLSET = new BitbucketToolset();
+const GITHUB_TOOLSET = new GitHubToolset();
+
+export function getProviderToolset(provider: VCSProviderName): ProviderToolset {
+  return provider === "github" ? GITHUB_TOOLSET : BITBUCKET_TOOLSET;
+}

--- a/src/v2/types/config.types.ts
+++ b/src/v2/types/config.types.ts
@@ -22,6 +22,12 @@ export interface YamaConfig {
   projectStandards?: ProjectStandardsConfig;
   monitoring: MonitoringConfig;
   performance: PerformanceConfig;
+  /**
+   * Optional explicit default VCS provider used as the lowest-priority
+   * fallback by ProviderDetector when neither the request nor the
+   * environment indicate a provider. Defaults to Bitbucket when unset.
+   */
+  defaultProvider?: "github" | "bitbucket";
 }
 
 // Backward-compatible alias.
@@ -97,16 +103,44 @@ export interface RedisConfig {
 // MCP Servers Configuration
 // ============================================================================
 
+export interface BitbucketConfig {
+  enabled?: boolean;
+  /** List of tool names to block from Bitbucket MCP server */
+  blockedTools?: string[];
+}
+
+export interface GitHubConfig {
+  enabled: boolean;
+  /** List of tool names to block from GitHub MCP server */
+  blockedTools?: string[];
+  /**
+   * Transport for the GitHub MCP server.
+   * Defaults to "http" (GitHub's hosted remote MCP server). Use "stdio" only
+   * for a self-hosted / Docker GitHub MCP server (requires `command`/`args`).
+   */
+  transport?: "http" | "stdio";
+  /**
+   * Endpoint for the remote HTTP GitHub MCP server.
+   * Defaults to "https://api.githubcopilot.com/mcp/". Override to point at a
+   * self-hosted / enterprise remote MCP endpoint.
+   */
+  url?: string;
+  /** Command to launch a self-hosted stdio GitHub MCP server (transport: "stdio"). */
+  command?: string;
+  /** Arguments for the self-hosted stdio GitHub MCP server command. */
+  args?: string[];
+}
+
+export interface JiraConfig {
+  enabled: boolean;
+  /** List of tool names to block from Jira MCP server */
+  blockedTools?: string[];
+}
+
 export interface MCPServersConfig {
-  bitbucket?: {
-    /** List of tool names to block from Bitbucket MCP server */
-    blockedTools?: string[];
-  };
-  jira: {
-    enabled: boolean;
-    /** List of tool names to block from Jira MCP server */
-    blockedTools?: string[];
-  };
+  bitbucket?: BitbucketConfig;
+  github?: GitHubConfig;
+  jira: JiraConfig;
 }
 
 // ============================================================================

--- a/src/v2/types/mcp.types.ts
+++ b/src/v2/types/mcp.types.ts
@@ -1,239 +1,129 @@
 /**
- * MCP Tool Response Type Definitions
- * Types for Bitbucket and Jira MCP tool responses
+ * MCP (Model Context Protocol) response type definitions.
+ *
+ * These describe the shapes Yama reads back from VCS MCP tool calls
+ * (Bitbucket / GitHub pull requests, diffs, code search, Jira issues).
+ *
+ * The fictional `NeuroLinkAPI`/`callTool` interface and the unused
+ * server-management helper types were removed when the dead VCSProvider
+ * classes were deleted — only these still-used response shapes (re-exported
+ * from src/index.ts) remain.
  */
 
-// ============================================================================
-// MCP Server Status Types
-// ============================================================================
-
-export interface MCPStatus {
-  totalServers: number;
-  totalTools: number;
-  servers: MCPServerStatus[];
-}
-
-export interface MCPServerStatus {
-  id: string;
-  connected: boolean;
-  tools: string[];
-  lastHealthCheck?: Date;
-  error?: string;
-}
-
-// ============================================================================
-// Bitbucket MCP Tool Response Types
-// ============================================================================
-
+/**
+ * Bitbucket/GitHub Pull Request response from a PR-read tool call
+ */
 export interface GetPullRequestResponse {
-  id: number;
-  title: string;
-  description: string;
-  author: {
-    name: string;
-    displayName: string;
-    emailAddress?: string;
-  };
-  state: "OPEN" | "MERGED" | "DECLINED";
-  source: {
-    branch: { name: string };
-    commit: { id: string };
-  };
-  destination: {
-    branch: { name: string };
-    commit: { id: string };
-  };
-  createdDate: string;
-  updatedDate: string;
-  reviewers: Reviewer[];
-  active_comments?: Comment[];
-  file_changes?: FileChange[];
-}
-
-export interface Reviewer {
-  user: {
-    name: string;
-    displayName: string;
-    emailAddress?: string;
-  };
-  approved: boolean;
-  status: "APPROVED" | "UNAPPROVED" | "NEEDS_WORK";
-}
-
-export interface Comment {
-  id: number;
-  text: string;
-  author: {
-    name: string;
-    displayName: string;
-  };
-  createdDate: string;
-  updatedDate: string;
-  anchor?: CommentAnchor;
-}
-
-export interface CommentAnchor {
-  filePath: string;
-  lineFrom: number;
-  lineTo: number;
-  lineType: "ADDED" | "REMOVED" | "CONTEXT";
-}
-
-export interface FileChange {
-  path: string;
-  file?: string;
-  type: "ADD" | "MODIFY" | "DELETE" | "RENAME";
-}
-
-export interface DiffLine {
-  source_line: number | null;
-  destination_line: number | null;
-  type: "ADDED" | "REMOVED" | "CONTEXT";
-  content: string;
-}
-
-export interface DiffHunk {
-  source_start: number;
-  source_length: number;
-  destination_start: number;
-  destination_length: number;
-  lines: DiffLine[];
-}
-
-export interface DiffFile {
-  file_path: string;
-  old_path?: string;
-  status: "added" | "modified" | "deleted" | "renamed";
-  hunks: DiffHunk[];
-}
-
-export interface GetPullRequestDiffResponse {
-  files: DiffFile[];
-  stats?: {
-    additions: number;
-    deletions: number;
-    files_changed: number;
-  };
-}
-
-export interface AddCommentRequest {
-  workspace: string;
-  repository: string;
-  pull_request_id: number;
-  comment_text: string;
-  file_path: string;
-  line_number: number;
-  line_type: "ADDED" | "REMOVED" | "CONTEXT";
-  suggestion?: string;
-  parent_comment_id?: number;
-}
-
-export interface AddCommentResponse {
-  id: number;
-  text: string;
-  author: string;
-  createdDate: string;
-  anchor?: CommentAnchor;
-}
-
-export interface UpdatePullRequestRequest {
-  workspace: string;
-  repository: string;
-  pull_request_id: number;
+  id?: number | string;
+  number?: number;
   title?: string;
   description?: string;
-  reviewers?: string[];
+  // Permissive to preserve Bitbucket/GitHub parity: callers may compare
+  // historical/raw provider states in any casing (e.g. "OPEN", "MERGED").
+  state?: string;
+  source?: {
+    branch?: {
+      name?: string;
+    };
+    repository?: {
+      full_slug?: string;
+    };
+  };
+  destination?: {
+    branch?: {
+      name?: string;
+    };
+    repository?: {
+      full_slug?: string;
+    };
+  };
+  head?: {
+    ref?: string;
+  };
+  base?: {
+    ref?: string;
+  };
+  user?: {
+    login?: string;
+  };
+  author?: {
+    username?: string;
+  };
+  created_on?: string;
+  createdAt?: string;
+  updated_on?: string;
+  updatedAt?: string;
+  links?: {
+    html?: {
+      href?: string;
+    };
+  };
+  html_url?: string;
+  [key: string]: unknown;
 }
 
-export interface GetFileContentResponse {
-  content: string;
-  path: string;
-  size: number;
-  encoding?: string;
+/**
+ * Pull request diff response from a diff-read tool call
+ */
+export interface GetPullRequestDiffResponse {
+  diffs?: Array<{
+    source?: {
+      path?: string;
+    };
+    destination?: {
+      path?: string;
+    };
+    lines?: Array<{
+      type?: string;
+      content?: string;
+      line_number?: number;
+      old_line_number?: number;
+    }>;
+  }>;
+  files?: Array<{
+    filename?: string;
+    patch?: string;
+    changes?: number;
+    additions?: number;
+    deletions?: number;
+  }>;
+  [key: string]: unknown;
 }
 
-export interface ListDirectoryContentResponse {
-  path: string;
-  items: DirectoryItem[];
-}
-
-export interface DirectoryItem {
-  type: "file" | "directory";
-  path: string;
-  name: string;
-  size?: number;
-}
-
-export interface SearchCodeResponse {
-  results: SearchResult[];
-  totalCount: number;
-}
-
-export interface SearchResult {
-  file: string;
-  line: number;
-  content: string;
-  matches: string[];
-}
-
-// ============================================================================
-// Jira MCP Tool Response Types
-// ============================================================================
-
+/**
+ * Jira issue response from an issue-read tool call
+ */
 export interface GetIssueResponse {
-  key: string;
-  id: string;
-  summary: string;
-  description: string;
-  status: {
-    name: string;
-    category: string;
+  key?: string;
+  id?: string;
+  fields?: {
+    summary?: string;
+    description?: string;
+    status?: {
+      name?: string;
+    };
+    issuetype?: {
+      name?: string;
+    };
+    [key: string]: unknown;
   };
-  issueType: {
-    name: string;
-    description: string;
-  };
-  priority: {
-    name: string;
-  };
-  assignee?: {
-    displayName: string;
-    emailAddress: string;
-  };
-  reporter: {
-    displayName: string;
-    emailAddress: string;
-  };
-  created: string;
-  updated: string;
-  customFields?: Record<string, any>;
+  [key: string]: unknown;
 }
 
-export interface SearchIssuesRequest {
-  jql: string;
-  maxResults?: number;
-  startAt?: number;
-}
-
-export interface SearchIssuesResponse {
-  issues: GetIssueResponse[];
-  total: number;
-  startAt: number;
-  maxResults: number;
-}
-
-export interface GetIssueCommentsResponse {
-  comments: JiraComment[];
-  total: number;
-}
-
-export interface JiraComment {
-  id: string;
-  author: {
-    displayName: string;
-    emailAddress: string;
-  };
-  body: string;
-  created: string;
-  updated: string;
+/**
+ * Code search response from a code-search tool call
+ */
+export interface SearchCodeResponse {
+  results?: Array<{
+    file?: {
+      path?: string;
+    };
+    path?: string;
+    lines?: Array<{
+      content?: string;
+      line_number?: number;
+    }>;
+    content?: string;
+  }>;
+  [key: string]: unknown;
 }

--- a/src/v2/types/v2.types.ts
+++ b/src/v2/types/v2.types.ts
@@ -9,10 +9,25 @@
 
 export interface ReviewRequest {
   mode: "pr";
-  workspace: string;
-  repository: string;
+
+  // Auto-detected or explicitly set
+  provider?: "github" | "bitbucket";
+
+  // Bitbucket parameters (backward compatible)
+  workspace?: string;
+  repository?: string;
+
+  // GitHub parameters (new)
+  owner?: string;
+  repo?: string;
+  prNumber?: number;
+
+  // Alternative: use pull request ID (Bitbucket) or issue number (GitHub)
   pullRequestId?: number;
+
+  // Both
   branch?: string;
+  cloneUrl?: string;
   dryRun?: boolean;
   verbose?: boolean;
   configPath?: string;

--- a/src/v2/utils/ProviderDetector.ts
+++ b/src/v2/utils/ProviderDetector.ts
@@ -1,0 +1,223 @@
+/**
+ * Provider Detection Utility
+ * Automatically detects GitHub vs Bitbucket from environment, CLI params, or URLs
+ */
+
+import type { ReviewRequest } from "../types/v2.types.js";
+
+export type VCSProvider = "github" | "bitbucket";
+
+export class ProviderDetector {
+  /**
+   * Detect VCS provider with intelligent fallback chain
+   * Priority: GitHub env → Request params → Clone URL → Config default → Bitbucket
+   */
+  static detect(
+    request: ReviewRequest,
+    env: NodeJS.ProcessEnv = process.env,
+    configDefault?: VCSProvider,
+  ): VCSProvider {
+    // 1. Explicit provider in request
+    if (request.provider) {
+      return request.provider;
+    }
+
+    // 2. GitHub Actions environment
+    if (
+      env.GITHUB_SERVER_URL ||
+      env.GITHUB_REPOSITORY ||
+      env.GITHUB_ACTION ||
+      env.GITHUB_ACTIONS === "true"
+    ) {
+      return "github";
+    }
+
+    // 3. GitHub CLI parameters
+    if (request.owner || request.prNumber !== undefined) {
+      // If owner is provided, it's GitHub
+      if (request.owner) {
+        return "github";
+      }
+    }
+
+    // 4. Bitbucket CLI parameters
+    if (request.workspace) {
+      return "bitbucket";
+    }
+
+    // 5. Clone URL detection
+    if (request.cloneUrl) {
+      return ProviderDetector.detectFromUrl(request.cloneUrl);
+    }
+
+    // 6. Config-level default
+    if (configDefault) {
+      return configDefault;
+    }
+
+    // 7. Fallback to Bitbucket (backward compatibility)
+    return "bitbucket";
+  }
+
+  /**
+   * Extract the hostname from a clone/remote URL.
+   * Supports SCP/SSH form (git@host:owner/repo, no scheme) and standard URLs.
+   * Returns a lowercased hostname, or '' if it cannot be determined.
+   */
+  private static extractHostname(url: string): string {
+    try {
+      // SCP/SSH form has no scheme: [user@]host:path (path is not //...)
+      if (!url.includes("://")) {
+        const scpMatch = url.match(/^(?:[^@/]+@)?([^/:]+):(?!\/)/);
+        if (scpMatch) {
+          return scpMatch[1].toLowerCase();
+        }
+      }
+
+      // Standard URL form. Prepend a scheme if missing so URL() can parse it.
+      const withScheme = url.includes("://") ? url : `https://${url}`;
+      return new URL(withScheme).hostname.toLowerCase();
+    } catch {
+      return "";
+    }
+  }
+
+  /**
+   * Detect provider from a clone/remote URL.
+   *
+   * Classification is based on the parsed HOSTNAME (not substring matching) to
+   * avoid spoofing via crafted paths or hosts such as
+   * "https://github.com.evil.com/...".
+   */
+  static detectFromUrl(url: string): VCSProvider {
+    const host = ProviderDetector.extractHostname(url);
+
+    // GitHub.com and GitHub Enterprise (e.g. github.enterprise.com).
+    // The first-label check covers Enterprise hosts whose first label is
+    // literally "github" (github.enterprise.com), while rejecting spoofs
+    // like "github.com.evil.com" where "github.com" is used as a sub-label.
+    if (
+      host === "github.com" ||
+      host.endsWith(".github.com") ||
+      ProviderDetector.firstLabelIs(host, "github")
+    ) {
+      return "github";
+    }
+
+    // Bitbucket.org and Bitbucket Server/Data Center variants
+    if (
+      host === "bitbucket.org" ||
+      host.endsWith(".bitbucket.org") ||
+      ProviderDetector.firstLabelIs(host, "bitbucket")
+    ) {
+      return "bitbucket";
+    }
+
+    // Default to Bitbucket if unclear (backward compatibility)
+    return "bitbucket";
+  }
+
+  /**
+   * Returns true when the host's first DNS label equals `label` AND the host
+   * is not a spoof where a public domain (e.g. "github.com") is embedded as a
+   * sub-label (e.g. "github.com.evil.com"). The latter is detected by a second
+   * label that is a common public TLD.
+   */
+  private static firstLabelIs(host: string, label: string): boolean {
+    const labels = host.split(".");
+    if (labels[0] !== label) {
+      return false;
+    }
+    // Reject "<label>.<tld>.<...>" spoofs (e.g. github.com.evil.com).
+    const tlds = new Set(["com", "org", "net", "io", "co", "dev"]);
+    if (labels.length > 2 && tlds.has(labels[1])) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Extract owner from GitHub URL or context
+   * github.com:owner/repo.git → owner
+   * https://github.com/owner/repo → owner
+   */
+  static extractGitHubOwner(url: string): string | null {
+    try {
+      // SSH format: git@github.com:owner/repo.git
+      const sshMatch = url.match(/git@github\.com:([^/]+)\//);
+      if (sshMatch) {
+        return sshMatch[1];
+      }
+
+      // HTTPS format: https://github.com/owner/repo
+      const httpsMatch = url.match(/github\.com\/([^/]+)\//);
+      if (httpsMatch) {
+        return httpsMatch[1];
+      }
+
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Extract repo name from GitHub URL
+   * github.com:owner/repo.git → repo
+   * https://github.com/owner/repo → repo
+   */
+  static extractGitHubRepo(url: string): string | null {
+    try {
+      // SSH format: git@github.com:owner/repo.git
+      const sshMatch = url.match(/\/([^/]+?)(?:\.git)?$/);
+      if (sshMatch) {
+        return sshMatch[1];
+      }
+
+      // HTTPS format: https://github.com/owner/repo
+      const httpsMatch = url.match(/\/([^/]+?)(?:\.git)?$/);
+      if (httpsMatch) {
+        return httpsMatch[1];
+      }
+
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Extract workspace from Bitbucket URL
+   * bitbucket.com:workspace/repo.git → workspace
+   */
+  static extractBitbucketWorkspace(url: string): string | null {
+    try {
+      // SSH format: git@bitbucket.org:workspace/repo.git
+      const match = url.match(/bitbucket[^:]*:([^/]+)\//);
+      if (match) {
+        return match[1];
+      }
+
+      // HTTPS format: https://bitbucket.org/workspace/repo
+      const httpsMatch = url.match(/bitbucket\.org\/([^/]+)\//);
+      if (httpsMatch) {
+        return httpsMatch[1];
+      }
+
+      return null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+/**
+ * Helper to detect provider from ReviewRequest
+ * Usage: const provider = detectProvider(request);
+ */
+export function detectProvider(
+  request: ReviewRequest,
+  configDefault?: VCSProvider,
+): VCSProvider {
+  return ProviderDetector.detect(request, process.env, configDefault);
+}

--- a/tests/unit/ProviderDetector.test.ts
+++ b/tests/unit/ProviderDetector.test.ts
@@ -1,0 +1,884 @@
+/**
+ * Comprehensive Unit Tests for ProviderDetector
+ * Tests detection logic for GitHub vs Bitbucket providers
+ */
+
+import {
+  ProviderDetector,
+  detectProvider,
+  type VCSProvider,
+} from "../../src/v2/utils/ProviderDetector.js";
+import type { ReviewRequest } from "../../src/v2/types/v2.types.js";
+
+describe("ProviderDetector", () => {
+  // ============================================================================
+  // Helper function to create minimal ReviewRequest
+  // ============================================================================
+  function createRequest(
+    overrides: Partial<ReviewRequest> = {},
+  ): ReviewRequest {
+    return {
+      mode: "pr",
+      ...overrides,
+    };
+  }
+
+  // ============================================================================
+  // Test Suite 1: GitHub Detection from Environment Variables
+  // ============================================================================
+  describe("GitHub detection from environment variables", () => {
+    let originalEnv: NodeJS.ProcessEnv;
+
+    beforeEach(() => {
+      originalEnv = { ...process.env };
+    });
+
+    afterEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    test("should detect GitHub from GITHUB_SERVER_URL env var", () => {
+      const env = {
+        GITHUB_SERVER_URL: "https://github.com",
+      };
+      const request = createRequest();
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github");
+    });
+
+    test("should detect GitHub from GITHUB_REPOSITORY env var", () => {
+      const env = {
+        GITHUB_REPOSITORY: "owner/repo",
+      };
+      const request = createRequest();
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github");
+    });
+
+    test("should detect GitHub from GITHUB_ACTIONS=true env var", () => {
+      const env = {
+        GITHUB_ACTIONS: "true",
+      };
+      const request = createRequest();
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github");
+    });
+
+    test("should not detect GitHub from GITHUB_ACTIONS=false env var", () => {
+      const env = {
+        GITHUB_ACTIONS: "false",
+      };
+      const request = createRequest();
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("bitbucket"); // Falls back to default
+    });
+
+    test("should detect GitHub from GITHUB_ACTION env var", () => {
+      const env = {
+        GITHUB_ACTION: "run",
+      };
+      const request = createRequest();
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github");
+    });
+
+    test("should detect GitHub with multiple GitHub env vars", () => {
+      const env = {
+        GITHUB_SERVER_URL: "https://github.com",
+        GITHUB_REPOSITORY: "owner/repo",
+        GITHUB_ACTIONS: "true",
+      };
+      const request = createRequest();
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github");
+    });
+  });
+
+  // ============================================================================
+  // Test Suite 2: GitHub Detection from Request Parameters
+  // ============================================================================
+  describe("GitHub detection from request parameters", () => {
+    test("should detect GitHub when owner parameter is provided", () => {
+      const env = {};
+      const request = createRequest({ owner: "github-user" });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github");
+    });
+
+    test("should detect GitHub when both owner and repo are provided", () => {
+      const env = {};
+      const request = createRequest({
+        owner: "github-user",
+        repo: "github-repo",
+        prNumber: 42,
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github");
+    });
+
+    test("should not detect GitHub from prNumber alone without owner", () => {
+      const env = {};
+      const request = createRequest({
+        prNumber: 42,
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("bitbucket"); // Falls back to default
+    });
+  });
+
+  // ============================================================================
+  // Test Suite 3: Bitbucket Detection from Request Parameters
+  // ============================================================================
+  describe("Bitbucket detection from request parameters", () => {
+    test("should detect Bitbucket when workspace parameter is provided", () => {
+      const env = {};
+      const request = createRequest({ workspace: "my-workspace" });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("bitbucket");
+    });
+
+    test("should detect Bitbucket when workspace and repository are provided", () => {
+      const env = {};
+      const request = createRequest({
+        workspace: "my-workspace",
+        repository: "my-repo",
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("bitbucket");
+    });
+  });
+
+  // ============================================================================
+  // Test Suite 4: GitHub Detection from Clone URLs
+  // ============================================================================
+  describe("GitHub detection from clone URLs", () => {
+    test("should detect GitHub from HTTPS clone URL", () => {
+      const env = {};
+      const request = createRequest({
+        cloneUrl: "https://github.com/owner/repo.git",
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github");
+    });
+
+    test("should detect GitHub from HTTPS clone URL without .git suffix", () => {
+      const env = {};
+      const request = createRequest({
+        cloneUrl: "https://github.com/owner/repo",
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github");
+    });
+
+    test("should detect GitHub from SSH clone URL", () => {
+      const env = {};
+      const request = createRequest({
+        cloneUrl: "git@github.com:owner/repo.git",
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github");
+    });
+
+    test("should detect GitHub from git+https URL", () => {
+      const env = {};
+      const request = createRequest({
+        cloneUrl: "git+https://github.com/owner/repo.git",
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github");
+    });
+
+    test("should detect GitHub from github. subdomain", () => {
+      const env = {};
+      const request = createRequest({
+        cloneUrl: "https://github.enterprise.com/owner/repo.git",
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github");
+    });
+
+    test("should detect GitHub from uppercase URL", () => {
+      const env = {};
+      const request = createRequest({
+        cloneUrl: "HTTPS://GITHUB.COM/OWNER/REPO.GIT",
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github");
+    });
+  });
+
+  // ============================================================================
+  // Test Suite 5: Bitbucket Detection from Clone URLs
+  // ============================================================================
+  describe("Bitbucket detection from clone URLs", () => {
+    test("should detect Bitbucket from HTTPS clone URL", () => {
+      const env = {};
+      const request = createRequest({
+        cloneUrl: "https://bitbucket.org/workspace/repo.git",
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("bitbucket");
+    });
+
+    test("should detect Bitbucket from HTTPS clone URL without .git suffix", () => {
+      const env = {};
+      const request = createRequest({
+        cloneUrl: "https://bitbucket.org/workspace/repo",
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("bitbucket");
+    });
+
+    test("should detect Bitbucket from SSH clone URL", () => {
+      const env = {};
+      const request = createRequest({
+        cloneUrl: "git@bitbucket.org:workspace/repo.git",
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("bitbucket");
+    });
+
+    test("should detect Bitbucket from generic bitbucket URL", () => {
+      const env = {};
+      const request = createRequest({
+        cloneUrl: "https://bitbucket.com/workspace/repo.git",
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("bitbucket");
+    });
+
+    test("should detect Bitbucket from uppercase URL", () => {
+      const env = {};
+      const request = createRequest({
+        cloneUrl: "HTTPS://BITBUCKET.ORG/WORKSPACE/REPO.GIT",
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("bitbucket");
+    });
+  });
+
+  // ============================================================================
+  // Test Suite 6: Priority and Fallback Logic
+  // ============================================================================
+  describe("Priority and fallback logic", () => {
+    test("should use explicit provider parameter over everything", () => {
+      const env = {
+        GITHUB_REPOSITORY: "owner/repo",
+      };
+      const request = createRequest({
+        provider: "bitbucket",
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("bitbucket");
+    });
+
+    test("should prefer GitHub env vars over request params", () => {
+      const env = {
+        GITHUB_SERVER_URL: "https://github.com",
+      };
+      const request = createRequest({
+        workspace: "my-workspace",
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github");
+    });
+
+    test("should prefer request owner param over clone URL", () => {
+      const env = {};
+      const request = createRequest({
+        owner: "github-user",
+        cloneUrl: "https://bitbucket.org/workspace/repo.git",
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github");
+    });
+
+    test("should prefer clone URL detection over config default", () => {
+      const env = {};
+      const request = createRequest({
+        cloneUrl: "https://github.com/owner/repo.git",
+      });
+
+      const result = ProviderDetector.detect(request, env, "bitbucket");
+
+      expect(result).toBe("github");
+    });
+
+    test("should use config default when no other indicators present", () => {
+      const env = {};
+      const request = createRequest();
+
+      const result = ProviderDetector.detect(request, env, "github");
+
+      expect(result).toBe("github");
+    });
+
+    test("should fallback to Bitbucket when no indicators present", () => {
+      const env = {};
+      const request = createRequest();
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("bitbucket");
+    });
+
+    test("should not use config default when explicit provider set", () => {
+      const env = {};
+      const request = createRequest({ provider: "bitbucket" });
+
+      const result = ProviderDetector.detect(request, env, "github");
+
+      expect(result).toBe("bitbucket");
+    });
+  });
+
+  // ============================================================================
+  // Test Suite 7: GitHub URL Extraction
+  // ============================================================================
+  describe("GitHub owner extraction", () => {
+    test("should extract owner from HTTPS GitHub URL", () => {
+      const url = "https://github.com/my-owner/my-repo";
+
+      const result = ProviderDetector.extractGitHubOwner(url);
+
+      expect(result).toBe("my-owner");
+    });
+
+    test("should extract owner from HTTPS GitHub URL with .git suffix", () => {
+      const url = "https://github.com/my-owner/my-repo.git";
+
+      const result = ProviderDetector.extractGitHubOwner(url);
+
+      expect(result).toBe("my-owner");
+    });
+
+    test("should extract owner from SSH GitHub URL", () => {
+      const url = "git@github.com:my-owner/my-repo.git";
+
+      const result = ProviderDetector.extractGitHubOwner(url);
+
+      expect(result).toBe("my-owner");
+    });
+
+    test("should extract owner with hyphens and underscores", () => {
+      const url = "https://github.com/my-owner_123/my-repo";
+
+      const result = ProviderDetector.extractGitHubOwner(url);
+
+      expect(result).toBe("my-owner_123");
+    });
+
+    test("should handle uppercase URL for owner extraction", () => {
+      const url = "HTTPS://GITHUB.COM/MY-OWNER/MY-REPO";
+
+      const result = ProviderDetector.extractGitHubOwner(url);
+
+      expect(result).toBeNull();
+    });
+
+    test("should return null for malformed GitHub URL", () => {
+      const url = "https://github.com/invalid-url";
+
+      const result = ProviderDetector.extractGitHubOwner(url);
+
+      expect(result).toBeNull();
+    });
+
+    test("should return null for non-GitHub URL", () => {
+      const url = "https://bitbucket.org/workspace/repo";
+
+      const result = ProviderDetector.extractGitHubOwner(url);
+
+      expect(result).toBeNull();
+    });
+
+    test("should return null for empty string", () => {
+      const result = ProviderDetector.extractGitHubOwner("");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("GitHub repo extraction", () => {
+    test("should extract repo from HTTPS GitHub URL", () => {
+      const url = "https://github.com/my-owner/my-repo";
+
+      const result = ProviderDetector.extractGitHubRepo(url);
+
+      expect(result).toBe("my-repo");
+    });
+
+    test("should extract repo from HTTPS GitHub URL with .git suffix", () => {
+      const url = "https://github.com/my-owner/my-repo.git";
+
+      const result = ProviderDetector.extractGitHubRepo(url);
+
+      expect(result).toBe("my-repo");
+    });
+
+    test("should extract repo from SSH GitHub URL", () => {
+      const url = "git@github.com:my-owner/my-repo.git";
+
+      const result = ProviderDetector.extractGitHubRepo(url);
+
+      expect(result).toBe("my-repo");
+    });
+
+    test("should extract repo with hyphens and numbers", () => {
+      const url = "https://github.com/owner/my-repo-123";
+
+      const result = ProviderDetector.extractGitHubRepo(url);
+
+      expect(result).toBe("my-repo-123");
+    });
+
+    test("should extract repo without .git suffix", () => {
+      const url = "git@github.com:owner/repo";
+
+      const result = ProviderDetector.extractGitHubRepo(url);
+
+      expect(result).toBe("repo");
+    });
+
+    test("should return null for malformed GitHub URL", () => {
+      const url = "https://github.com/owner/";
+
+      const result = ProviderDetector.extractGitHubRepo(url);
+
+      expect(result).toBeNull();
+    });
+
+    test("should return null for non-GitHub URL", () => {
+      const url = "https://bitbucket.org/workspace/repo";
+
+      const result = ProviderDetector.extractGitHubRepo(url);
+
+      expect(result).toBe("repo"); // Extracts from any URL with similar format
+    });
+
+    test("should return null for empty string", () => {
+      const result = ProviderDetector.extractGitHubRepo("");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ============================================================================
+  // Test Suite 8: Bitbucket URL Extraction
+  // ============================================================================
+  describe("Bitbucket workspace extraction", () => {
+    test("should extract workspace from HTTPS Bitbucket URL", () => {
+      const url = "https://bitbucket.org/my-workspace/my-repo";
+
+      const result = ProviderDetector.extractBitbucketWorkspace(url);
+
+      expect(result).toBe("my-workspace");
+    });
+
+    test("should extract workspace from HTTPS Bitbucket URL with .git suffix", () => {
+      const url = "https://bitbucket.org/my-workspace/my-repo.git";
+
+      const result = ProviderDetector.extractBitbucketWorkspace(url);
+
+      expect(result).toBe("my-workspace");
+    });
+
+    test("should extract workspace from SSH Bitbucket URL", () => {
+      const url = "git@bitbucket.org:my-workspace/my-repo.git";
+
+      const result = ProviderDetector.extractBitbucketWorkspace(url);
+
+      expect(result).toBe("my-workspace");
+    });
+
+    test("should extract workspace with hyphens and underscores", () => {
+      const url = "https://bitbucket.org/my-workspace_123/my-repo";
+
+      const result = ProviderDetector.extractBitbucketWorkspace(url);
+
+      expect(result).toBe("my-workspace_123");
+    });
+
+    test("should handle bitbucket.com domain", () => {
+      const url = "https://bitbucket.com/my-workspace/my-repo";
+
+      const result = ProviderDetector.extractBitbucketWorkspace(url);
+
+      // Note: The regex pattern requires a colon or specific domain format
+      // bitbucket.com HTTPS URLs require the specific HTTPS regex pattern
+      expect(result).toBeNull();
+    });
+
+    test("should return null for malformed Bitbucket URL", () => {
+      const url = "https://bitbucket.org/invalid-url";
+
+      const result = ProviderDetector.extractBitbucketWorkspace(url);
+
+      expect(result).toBeNull();
+    });
+
+    test("should return null for non-Bitbucket URL", () => {
+      const url = "https://github.com/owner/repo";
+
+      const result = ProviderDetector.extractBitbucketWorkspace(url);
+
+      expect(result).toBeNull();
+    });
+
+    test("should return null for empty string", () => {
+      const result = ProviderDetector.extractBitbucketWorkspace("");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ============================================================================
+  // Test Suite 9: detectFromUrl method
+  // ============================================================================
+  describe("detectFromUrl method", () => {
+    test("should detect GitHub from various GitHub URLs", () => {
+      const githubUrls = [
+        "https://github.com/owner/repo",
+        "git@github.com:owner/repo.git",
+        "https://github.enterprise.com/owner/repo",
+        "GIT@GITHUB.COM:OWNER/REPO.GIT",
+      ];
+
+      githubUrls.forEach((url) => {
+        expect(ProviderDetector.detectFromUrl(url)).toBe("github");
+      });
+    });
+
+    test("should detect Bitbucket from various Bitbucket URLs", () => {
+      const bitbucketUrls = [
+        "https://bitbucket.org/workspace/repo",
+        "git@bitbucket.org:workspace/repo.git",
+        "https://bitbucket.com/workspace/repo",
+        "GIT@BITBUCKET.ORG:WORKSPACE/REPO.GIT",
+      ];
+
+      bitbucketUrls.forEach((url) => {
+        expect(ProviderDetector.detectFromUrl(url)).toBe("bitbucket");
+      });
+    });
+
+    test("should default to Bitbucket for unknown URLs", () => {
+      const unknownUrls = [
+        "https://gitlab.com/owner/repo",
+        "https://example.com/repo",
+        "invalid-url",
+      ];
+
+      unknownUrls.forEach((url) => {
+        expect(ProviderDetector.detectFromUrl(url)).toBe("bitbucket");
+      });
+    });
+
+    test("should handle invalid URLs gracefully", () => {
+      expect(() => {
+        ProviderDetector.detectFromUrl(";;;:::");
+      }).not.toThrow();
+
+      expect(ProviderDetector.detectFromUrl(";;;:::")).toBe("bitbucket");
+    });
+
+    test("should NOT detect github from a spoofed host containing github.com in the domain", () => {
+      // host is github.com.evil.com — must not be classified as github
+      expect(
+        ProviderDetector.detectFromUrl("https://github.com.evil.com/foo"),
+      ).toBe("bitbucket");
+    });
+
+    test("should NOT detect github when github.com only appears in the URL path", () => {
+      expect(
+        ProviderDetector.detectFromUrl(
+          "https://evil.com/github.com/owner/repo",
+        ),
+      ).toBe("bitbucket");
+    });
+  });
+
+  // ============================================================================
+  // Test Suite 10: detectProvider helper function
+  // ============================================================================
+  describe("detectProvider helper function", () => {
+    let originalEnv: NodeJS.ProcessEnv;
+
+    beforeEach(() => {
+      originalEnv = { ...process.env };
+    });
+
+    afterEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    test("should detect GitHub provider using process.env", () => {
+      process.env.GITHUB_REPOSITORY = "owner/repo";
+
+      const request = createRequest();
+      const result = detectProvider(request);
+
+      expect(result).toBe("github");
+    });
+
+    test("should detect Bitbucket provider using process.env", () => {
+      // Clear GitHub env vars
+      delete process.env.GITHUB_SERVER_URL;
+      delete process.env.GITHUB_REPOSITORY;
+      delete process.env.GITHUB_ACTIONS;
+      delete process.env.GITHUB_ACTION;
+
+      const request = createRequest({ workspace: "my-workspace" });
+      const result = detectProvider(request);
+
+      expect(result).toBe("bitbucket");
+    });
+
+    test("should use config default with detectProvider", () => {
+      // Clear GitHub env vars
+      delete process.env.GITHUB_SERVER_URL;
+      delete process.env.GITHUB_REPOSITORY;
+      delete process.env.GITHUB_ACTIONS;
+      delete process.env.GITHUB_ACTION;
+
+      const request = createRequest();
+      const result = detectProvider(request, "github");
+
+      expect(result).toBe("github");
+    });
+
+    test("should fallback to Bitbucket with detectProvider", () => {
+      // Clear GitHub env vars
+      delete process.env.GITHUB_SERVER_URL;
+      delete process.env.GITHUB_REPOSITORY;
+      delete process.env.GITHUB_ACTIONS;
+      delete process.env.GITHUB_ACTION;
+
+      const request = createRequest();
+      const result = detectProvider(request);
+
+      expect(result).toBe("bitbucket");
+    });
+  });
+
+  // ============================================================================
+  // Test Suite 11: Edge Cases and Error Handling
+  // ============================================================================
+  describe("Edge cases and error handling", () => {
+    test("should handle null cloneUrl gracefully", () => {
+      const env = {};
+      // cloneUrl is typed `string | undefined`, but at runtime a provider
+      // payload can surface an explicit null. Inject the null via a typed
+      // override (no `as any`) to assert detect() tolerates it.
+      const override: Partial<ReviewRequest> = { cloneUrl: undefined };
+      (override as { cloneUrl: string | null }).cloneUrl = null;
+      const request = createRequest(override);
+
+      expect(() => {
+        ProviderDetector.detect(request, env);
+      }).not.toThrow();
+    });
+
+    test("should handle undefined workspace as not set", () => {
+      const env = {};
+      const request = createRequest({ workspace: undefined });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("bitbucket");
+    });
+
+    test("should handle undefined owner as not set", () => {
+      const env = {};
+      const request = createRequest({ owner: undefined });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("bitbucket");
+    });
+
+    test("should handle empty string owner as not set", () => {
+      const env = {};
+      const request = createRequest({ owner: "" });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("bitbucket");
+    });
+
+    test("should handle prNumber without owner", () => {
+      const env = {};
+      const request = createRequest({ prNumber: 42 });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("bitbucket");
+    });
+
+    test("should extract URLs with trailing slashes", () => {
+      const url = "https://github.com/owner/repo/";
+
+      const result = ProviderDetector.extractGitHubRepo(url);
+
+      // The regex /\/([^/]+?)(?:\.git)?$/ won't match empty string at end
+      expect(result).toBeNull();
+    });
+
+    test("should extract URLs with special characters in repo name", () => {
+      const url = "https://github.com/owner/my-repo-123_test";
+
+      const result = ProviderDetector.extractGitHubRepo(url);
+
+      expect(result).toBe("my-repo-123_test");
+    });
+
+    test("should handle multiple slashes in URL", () => {
+      const url = "https://github.com//owner//repo/";
+
+      expect(() => {
+        ProviderDetector.extractGitHubOwner(url);
+      }).not.toThrow();
+    });
+  });
+
+  // ============================================================================
+  // Test Suite 12: Real-world Scenarios
+  // ============================================================================
+  describe("Real-world scenarios", () => {
+    test("GitHub Actions CI environment", () => {
+      const env = {
+        GITHUB_ACTIONS: "true",
+        GITHUB_SERVER_URL: "https://github.com",
+        GITHUB_REPOSITORY: "myorg/myrepo",
+      };
+      const request = createRequest({ prNumber: 123 });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github");
+    });
+
+    test("Bitbucket Pipeline CI environment", () => {
+      const env = {
+        BITBUCKET_WORKSPACE: "myworkspace",
+      };
+      const request = createRequest({ workspace: "myworkspace" });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("bitbucket");
+    });
+
+    test("Local development with GitHub clone URL", () => {
+      const env = {};
+      const request = createRequest({
+        cloneUrl: "git@github.com:myorg/myrepo.git",
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github");
+    });
+
+    test("CLI invocation with explicit GitHub owner and repo", () => {
+      const env = {};
+      const request = createRequest({
+        owner: "myorg",
+        repo: "myrepo",
+        prNumber: 42,
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github");
+    });
+
+    test("CLI invocation with explicit Bitbucket workspace and repo", () => {
+      const env = {};
+      const request = createRequest({
+        workspace: "myworkspace",
+        repository: "myrepo",
+        pullRequestId: 42,
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("bitbucket");
+    });
+
+    test("Conflicting signals: GitHub env var vs Bitbucket clone URL", () => {
+      const env = {
+        GITHUB_REPOSITORY: "owner/repo",
+      };
+      const request = createRequest({
+        cloneUrl: "https://bitbucket.org/workspace/repo",
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github"); // GitHub env vars have priority
+    });
+
+    test("Conflicting signals: GitHub owner vs Bitbucket clone URL", () => {
+      const env = {};
+      const request = createRequest({
+        owner: "myowner",
+        cloneUrl: "https://bitbucket.org/workspace/repo",
+      });
+
+      const result = ProviderDetector.detect(request, env);
+
+      expect(result).toBe("github"); // owner parameter has priority
+    });
+  });
+});

--- a/tests/unit/ProviderToolset.test.ts
+++ b/tests/unit/ProviderToolset.test.ts
@@ -1,0 +1,517 @@
+/**
+ * Comprehensive Unit Tests for ProviderToolset
+ *
+ * Validates the provider-specific behaviour that the AI review loop depends on:
+ *  - decision interpretation (approve/block signal extraction)
+ *  - comment / diff / mutation tool-name registries
+ *  - the <pr_context> identifier blocks
+ *  - the <tool-usage> system-prompt section
+ *  - the numbered review workflow instructions
+ *
+ * All assertions are pure-function checks: no network, no time/clock reliance.
+ */
+
+import {
+  getProviderToolset,
+  type ProviderToolset,
+  type ProviderToolCall,
+} from "../../src/v2/providers/ProviderToolset.js";
+
+describe("ProviderToolset", () => {
+  // ==========================================================================
+  // Factory
+  // ==========================================================================
+  describe("getProviderToolset factory", () => {
+    test('returns a github toolset with provider="github"', () => {
+      const toolset = getProviderToolset("github");
+      expect(toolset.provider).toBe("github");
+    });
+
+    test('returns a bitbucket toolset with provider="bitbucket"', () => {
+      const toolset = getProviderToolset("bitbucket");
+      expect(toolset.provider).toBe("bitbucket");
+    });
+
+    test("returns a stable singleton instance per provider", () => {
+      expect(getProviderToolset("github")).toBe(getProviderToolset("github"));
+      expect(getProviderToolset("bitbucket")).toBe(
+        getProviderToolset("bitbucket"),
+      );
+      expect(getProviderToolset("github")).not.toBe(
+        getProviderToolset("bitbucket"),
+      );
+    });
+  });
+
+  // ==========================================================================
+  // GitHub: interpretDecision
+  // ==========================================================================
+  describe("GitHub interpretDecision", () => {
+    let toolset: ProviderToolset;
+
+    beforeEach(() => {
+      toolset = getProviderToolset("github");
+    });
+
+    test("submit with event=APPROVE -> APPROVED", () => {
+      const call: ProviderToolCall = {
+        toolName: "pull_request_review_write",
+        args: { method: "submit", event: "APPROVE" },
+      };
+      expect(toolset.interpretDecision(call)).toBe("APPROVED");
+    });
+
+    test("submit with event=REQUEST_CHANGES -> BLOCKED", () => {
+      const call: ProviderToolCall = {
+        toolName: "pull_request_review_write",
+        args: { method: "submit", event: "REQUEST_CHANGES" },
+      };
+      expect(toolset.interpretDecision(call)).toBe("BLOCKED");
+    });
+
+    test("submit with event=COMMENT -> null", () => {
+      const call: ProviderToolCall = {
+        toolName: "pull_request_review_write",
+        args: { method: "submit", event: "COMMENT" },
+      };
+      expect(toolset.interpretDecision(call)).toBeNull();
+    });
+
+    test("submit with an unrecognized event -> null", () => {
+      const call: ProviderToolCall = {
+        toolName: "pull_request_review_write",
+        args: { method: "submit", event: "SOMETHING_ELSE" },
+      };
+      expect(toolset.interpretDecision(call)).toBeNull();
+    });
+
+    test("submit with no event -> null", () => {
+      const call: ProviderToolCall = {
+        toolName: "pull_request_review_write",
+        args: { method: "submit" },
+      };
+      expect(toolset.interpretDecision(call)).toBeNull();
+    });
+
+    test("create method (not submit) -> null even with event", () => {
+      const call: ProviderToolCall = {
+        toolName: "pull_request_review_write",
+        args: { method: "create", event: "APPROVE" },
+      };
+      expect(toolset.interpretDecision(call)).toBeNull();
+    });
+
+    test("review write with missing args -> null", () => {
+      const call: ProviderToolCall = {
+        toolName: "pull_request_review_write",
+      };
+      expect(toolset.interpretDecision(call)).toBeNull();
+    });
+
+    test("non-review tool -> null", () => {
+      const call: ProviderToolCall = {
+        toolName: "add_comment_to_pending_review",
+        args: { method: "submit", event: "APPROVE" },
+      };
+      expect(toolset.interpretDecision(call)).toBeNull();
+    });
+
+    test("missing toolName -> null", () => {
+      const call: ProviderToolCall = {
+        args: { method: "submit", event: "APPROVE" },
+      };
+      expect(toolset.interpretDecision(call)).toBeNull();
+    });
+
+    test("does NOT interpret Bitbucket decision tools", () => {
+      expect(
+        toolset.interpretDecision({
+          toolName: "set_pr_approval",
+          args: { approved: true },
+        }),
+      ).toBeNull();
+      expect(
+        toolset.interpretDecision({
+          toolName: "set_review_status",
+          args: { request_changes: true },
+        }),
+      ).toBeNull();
+    });
+  });
+
+  // ==========================================================================
+  // Bitbucket: interpretDecision
+  // ==========================================================================
+  describe("Bitbucket interpretDecision", () => {
+    let toolset: ProviderToolset;
+
+    beforeEach(() => {
+      toolset = getProviderToolset("bitbucket");
+    });
+
+    test("set_pr_approval(approved=true) -> APPROVED", () => {
+      const call: ProviderToolCall = {
+        toolName: "set_pr_approval",
+        args: { approved: true },
+      };
+      expect(toolset.interpretDecision(call)).toBe("APPROVED");
+    });
+
+    test("set_pr_approval(approved=false) -> null", () => {
+      const call: ProviderToolCall = {
+        toolName: "set_pr_approval",
+        args: { approved: false },
+      };
+      expect(toolset.interpretDecision(call)).toBeNull();
+    });
+
+    test("set_pr_approval with non-boolean approved -> null", () => {
+      const call: ProviderToolCall = {
+        toolName: "set_pr_approval",
+        args: { approved: "true" },
+      };
+      expect(toolset.interpretDecision(call)).toBeNull();
+    });
+
+    test("set_pr_approval with no args -> null", () => {
+      const call: ProviderToolCall = { toolName: "set_pr_approval" };
+      expect(toolset.interpretDecision(call)).toBeNull();
+    });
+
+    test("set_review_status(request_changes=true) -> BLOCKED", () => {
+      const call: ProviderToolCall = {
+        toolName: "set_review_status",
+        args: { request_changes: true },
+      };
+      expect(toolset.interpretDecision(call)).toBe("BLOCKED");
+    });
+
+    test("set_review_status(request_changes=false) -> null", () => {
+      const call: ProviderToolCall = {
+        toolName: "set_review_status",
+        args: { request_changes: false },
+      };
+      expect(toolset.interpretDecision(call)).toBeNull();
+    });
+
+    test("set_review_status with non-boolean request_changes -> null", () => {
+      const call: ProviderToolCall = {
+        toolName: "set_review_status",
+        args: { request_changes: "yes" },
+      };
+      expect(toolset.interpretDecision(call)).toBeNull();
+    });
+
+    test("legacy approve_pull_request -> APPROVED", () => {
+      expect(
+        toolset.interpretDecision({ toolName: "approve_pull_request" }),
+      ).toBe("APPROVED");
+    });
+
+    test("legacy unapprove_pull_request -> null", () => {
+      expect(
+        toolset.interpretDecision({ toolName: "unapprove_pull_request" }),
+      ).toBeNull();
+    });
+
+    test("legacy request_changes -> BLOCKED", () => {
+      expect(toolset.interpretDecision({ toolName: "request_changes" })).toBe(
+        "BLOCKED",
+      );
+    });
+
+    test("legacy remove_requested_changes -> null", () => {
+      expect(
+        toolset.interpretDecision({ toolName: "remove_requested_changes" }),
+      ).toBeNull();
+    });
+
+    test("unrelated tool -> null", () => {
+      expect(
+        toolset.interpretDecision({
+          toolName: "get_pull_request",
+          args: { approved: true },
+        }),
+      ).toBeNull();
+    });
+
+    test("missing toolName -> null", () => {
+      expect(
+        toolset.interpretDecision({ args: { approved: true } }),
+      ).toBeNull();
+    });
+
+    test("does NOT interpret the GitHub review-write tool", () => {
+      expect(
+        toolset.interpretDecision({
+          toolName: "pull_request_review_write",
+          args: { method: "submit", event: "APPROVE" },
+        }),
+      ).toBeNull();
+    });
+  });
+
+  // ==========================================================================
+  // Tool-name registries
+  // ==========================================================================
+  describe("GitHub tool-name registries", () => {
+    let toolset: ProviderToolset;
+
+    beforeEach(() => {
+      toolset = getProviderToolset("github");
+    });
+
+    test("commentToolNames contains the pending-review and issue comment tools", () => {
+      expect(toolset.commentToolNames).toEqual(
+        expect.arrayContaining([
+          "add_comment_to_pending_review",
+          "add_issue_comment",
+        ]),
+      );
+    });
+
+    test("diffToolNames is the consolidated pull_request_read tool", () => {
+      expect(toolset.diffToolNames).toEqual(["pull_request_read"]);
+    });
+
+    test("mutationToolNames includes review-write and repo-mutation tools", () => {
+      expect(toolset.mutationToolNames).toEqual(
+        expect.arrayContaining([
+          "pull_request_review_write",
+          "add_comment_to_pending_review",
+          "add_issue_comment",
+          "update_pull_request",
+          "push_files",
+          "create_or_update_file",
+          "create_branch",
+          "delete_file",
+        ]),
+      );
+    });
+
+    test("mutationToolNames does NOT contain Bitbucket-only names", () => {
+      expect(toolset.mutationToolNames).not.toContain("set_pr_approval");
+      expect(toolset.mutationToolNames).not.toContain("merge_pull_request");
+    });
+  });
+
+  describe("Bitbucket tool-name registries", () => {
+    let toolset: ProviderToolset;
+
+    beforeEach(() => {
+      toolset = getProviderToolset("bitbucket");
+    });
+
+    test("commentToolNames is add_comment", () => {
+      expect(toolset.commentToolNames).toEqual(["add_comment"]);
+    });
+
+    test("diffToolNames is get_pull_request_diff", () => {
+      expect(toolset.diffToolNames).toEqual(["get_pull_request_diff"]);
+    });
+
+    test("mutationToolNames includes the blocked Bitbucket mutation names", () => {
+      expect(toolset.mutationToolNames).toEqual(
+        expect.arrayContaining([
+          "add_comment",
+          "set_pr_approval",
+          "set_review_status",
+          "approve_pull_request",
+          "unapprove_pull_request",
+          "request_changes",
+          "remove_requested_changes",
+          "update_pull_request",
+          "merge_pull_request",
+          "delete_branch",
+        ]),
+      );
+    });
+
+    test("mutationToolNames does NOT contain GitHub-only names", () => {
+      expect(toolset.mutationToolNames).not.toContain(
+        "pull_request_review_write",
+      );
+      expect(toolset.mutationToolNames).not.toContain("push_files");
+    });
+  });
+
+  // ==========================================================================
+  // identifierXml
+  // ==========================================================================
+  describe("GitHub identifierXml", () => {
+    let toolset: ProviderToolset;
+
+    beforeEach(() => {
+      toolset = getProviderToolset("github");
+    });
+
+    test("includes owner / repo / pull_number from params", () => {
+      const xml = toolset.identifierXml({
+        owner: "my-org",
+        repo: "my-repo",
+        prNumber: 42,
+      });
+      expect(xml).toContain("<owner>my-org</owner>");
+      expect(xml).toContain("<repo>my-repo</repo>");
+      expect(xml).toContain("<pull_number>42</pull_number>");
+    });
+
+    test("falls back to find-by-branch when prNumber is missing", () => {
+      const xml = toolset.identifierXml({ owner: "o", repo: "r" });
+      expect(xml).toContain("<pull_number>find-by-branch</pull_number>");
+    });
+
+    test("keeps pull_number 0 rather than falling back", () => {
+      const xml = toolset.identifierXml({ owner: "o", repo: "r", prNumber: 0 });
+      expect(xml).toContain("<pull_number>0</pull_number>");
+    });
+
+    test("does NOT emit Bitbucket identifier fields", () => {
+      const xml = toolset.identifierXml({
+        owner: "o",
+        repo: "r",
+        prNumber: 1,
+      });
+      expect(xml).not.toContain("<workspace>");
+      expect(xml).not.toContain("<pull_request_id>");
+    });
+
+    test("escapes XML special characters in owner/repo", () => {
+      const xml = toolset.identifierXml({
+        owner: "a&b",
+        repo: "<r>",
+        prNumber: 7,
+      });
+      expect(xml).toContain("<owner>a&amp;b</owner>");
+      expect(xml).toContain("<repo>&lt;r&gt;</repo>");
+    });
+  });
+
+  describe("Bitbucket identifierXml", () => {
+    let toolset: ProviderToolset;
+
+    beforeEach(() => {
+      toolset = getProviderToolset("bitbucket");
+    });
+
+    test("includes workspace / repository / pull_request_id / branch from params", () => {
+      const xml = toolset.identifierXml({
+        workspace: "ws",
+        repository: "repo",
+        pullRequestId: 99,
+        branch: "feature/x",
+      });
+      expect(xml).toContain("<workspace>ws</workspace>");
+      expect(xml).toContain("<repository>repo</repository>");
+      expect(xml).toContain("<pull_request_id>99</pull_request_id>");
+      expect(xml).toContain("<branch>feature/x</branch>");
+    });
+
+    test("falls back to find-by-branch when pullRequestId is missing", () => {
+      const xml = toolset.identifierXml({
+        workspace: "ws",
+        repository: "repo",
+      });
+      expect(xml).toContain(
+        "<pull_request_id>find-by-branch</pull_request_id>",
+      );
+    });
+
+    test("defaults branch to N/A when missing", () => {
+      const xml = toolset.identifierXml({
+        workspace: "ws",
+        repository: "repo",
+        pullRequestId: 1,
+      });
+      expect(xml).toContain("<branch>N/A</branch>");
+    });
+
+    test("does NOT emit GitHub identifier fields", () => {
+      const xml = toolset.identifierXml({
+        workspace: "ws",
+        repository: "repo",
+        pullRequestId: 1,
+      });
+      expect(xml).not.toContain("<owner>");
+      expect(xml).not.toContain("<pull_number>");
+    });
+
+    test("escapes XML special characters in workspace/repository", () => {
+      const xml = toolset.identifierXml({
+        workspace: "a&b",
+        repository: "<r>",
+        pullRequestId: 1,
+      });
+      expect(xml).toContain("<workspace>a&amp;b</workspace>");
+      expect(xml).toContain("<repository>&lt;r&gt;</repository>");
+    });
+  });
+
+  // ==========================================================================
+  // systemPromptToolsSection
+  // ==========================================================================
+  describe("GitHub systemPromptToolsSection", () => {
+    let section: string;
+
+    beforeEach(() => {
+      section = getProviderToolset("github").systemPromptToolsSection();
+    });
+
+    test("mentions the GitHub consolidated tools", () => {
+      expect(section).toContain("pull_request_read");
+      expect(section).toContain("add_comment_to_pending_review");
+      expect(section).toContain("pull_request_review_write");
+    });
+
+    test("does NOT mention Bitbucket-only tools", () => {
+      expect(section).not.toContain("get_pull_request_diff");
+      expect(section).not.toContain("set_pr_approval");
+    });
+  });
+
+  describe("Bitbucket systemPromptToolsSection", () => {
+    let section: string;
+
+    beforeEach(() => {
+      section = getProviderToolset("bitbucket").systemPromptToolsSection();
+    });
+
+    test("mentions the Bitbucket tools", () => {
+      expect(section).toContain("get_pull_request");
+      expect(section).toContain("add_comment");
+      expect(section).toContain("set_pr_approval");
+    });
+
+    test("does NOT mention GitHub-only tools", () => {
+      expect(section).not.toContain("pull_request_review_write");
+      expect(section).not.toContain("add_comment_to_pending_review");
+    });
+  });
+
+  // ==========================================================================
+  // reviewWorkflowInstructions
+  // ==========================================================================
+  describe("reviewWorkflowInstructions", () => {
+    test("GitHub references the pending-review submit flow", () => {
+      const instructions = getProviderToolset(
+        "github",
+      ).reviewWorkflowInstructions({});
+      // Opens a single pending review and submits it with a decision event.
+      expect(instructions).toContain("pending review");
+      expect(instructions).toContain('method="create"');
+      expect(instructions).toContain('method="submit"');
+      expect(instructions).toContain('event="APPROVE"');
+      expect(instructions).toContain('event="REQUEST_CHANGES"');
+    });
+
+    test("Bitbucket references the set_pr_approval / set_review_status decision", () => {
+      const instructions = getProviderToolset(
+        "bitbucket",
+      ).reviewWorkflowInstructions({});
+      expect(instructions).toContain("set_pr_approval");
+      expect(instructions).toContain("set_review_status");
+      // Bitbucket has no pending-review batch model.
+      expect(instructions).not.toContain("pending review");
+    });
+  });
+});

--- a/yama.config.github.example.yaml
+++ b/yama.config.github.example.yaml
@@ -1,0 +1,35 @@
+version: 2
+configType: "yama"
+
+ai:
+  provider: anthropic
+  model: claude-opus-4-1
+  temperature: 0.7
+  maxTokens: 4096
+
+mcpServers:
+  github:
+    enabled: true
+    # transport defaults to "http" (GitHub's hosted remote MCP server).
+    # Use "stdio" only for a self-hosted / Docker GitHub MCP server.
+    # transport: http
+    # url: https://api.githubcopilot.com/mcp/
+    # blockedTools EXTENDS (does not replace) the built-in write-block denylist
+    # (push_files, create_or_update_file, create_branch, delete_file,
+    # create_pull_request_with_copilot, assign_copilot_to_issue). Entries listed
+    # here are added on top of those defaults; the defaults can never be un-blocked.
+    # blockedTools:
+    #   - delete_file
+  jira:
+    enabled: false
+
+review:
+  focusAreas:
+    - security
+    - performance
+    - codeQuality
+    - testing
+    - documentation
+  maxIssues: 10
+  autoApprove: false
+  requireApproval: true


### PR DESCRIPTION
## What

Adds **GitHub** as a first-class VCS provider so Yama can review GitHub PRs the same way it reviews Bitbucket PRs — inline comments + a submitted review (Approve / Request changes). Bitbucket behaviour is unchanged.

## How

- **`ProviderToolset`** abstraction: the single source of everything that differs per provider (tool vocabulary, PR-identifier XML, review/enhancement workflow prose, and the post-processing signals for decisions/statistics). Bitbucket strings are reproduced verbatim — byte-identical prompts/behaviour.
- **GitHub MCP via remote HTTP** to `https://api.githubcopilot.com/mcp/` (Bearer PAT, 30s timeout + retry/backoff), mirroring Curator's production pattern. Repo-mutating tools are blocked; only review-comment / review-submit are allowed.
- **Zero-flag provider auto-detection** (env vars / CLI params / clone URL → Bitbucket default).
- **GitHub Action** (`action.yml`, composite) that runs the CLI on PRs, plus an example workflow.
- Provider-aware throughout: detection runs before MCP setup; `owner/repo/prNumber` coalesce with `workspace/repository/pullRequestId` in user-id, bootstrap standards, tool context, and prompt params; validation is provider-gated.

## Tokens / setup

The hosted GitHub MCP endpoint needs a real **GitHub PAT** (not the ephemeral Actions token). Yama accepts `GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_PERSONAL_ACCESS_TOKEN` / `GITHUB_ACCESS_TOKEN`. Full setup in **`GITHUB_SETUP.md`**.

## Tests / quality

- `type-check`, `lint` (0 errors), `build` all green; **200 unit tests pass** (incl. new `ProviderToolset` + `ProviderDetector` suites).
- No new `any` / `@ts-ignore`; dead provider code removed.
- Bitbucket parity verified (no regressions); GitHub-path bugs found via adversarial review were fixed.

## Not yet verified

The live GitHub review-comment / submit-review tool flow needs one run against a real PR + PAT (`--dry-run --verbose` first). Tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub support for automated PR reviews via GitHub Actions workflow
  * Automatic provider detection based on environment variables and repository context
  * GitHub token configuration with multiple environment variable options

* **Documentation**
  * Added comprehensive GitHub setup guide with prerequisites and configuration instructions
  * Expanded environment variable documentation for GitHub and Bitbucket configuration
  * Added GitHub configuration example file

* **Tests**
  * Added provider detection test suite
  * Added provider toolset validation test suite

<!-- end of auto-generated comment: release notes by coderabbit.ai -->