### PR TITLE
feat(action): support Vertex AI auth and add Yama self-review workflow

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -39,79 +39,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: 🤖 AI-Powered Code Review
-        uses: coderabbitai/openai-pr-reviewer@latest
-        with:
-          debug: false
-          review_simple_changes: true
-          review_comment_lgtm: true
-          openai_light_model: gpt-4o-mini
-          openai_heavy_model: gpt-4o
-          openai_timeout_ms: 120000
-          language: en-US
-          path_filters: |
-            src/**/*.ts
-            src/**/*.tsx
-            src/**/*.js
-            src/**/*.jsx
-            tests/**/*.ts
-            tests/**/*.tsx
-            scripts/**/*.js
-            scripts/**/*.cjs
-            .github/workflows/*.yml
-            *.md
-            package.json
-            tsconfig.json
-            eslint.config.js
-            !node_modules/**
-            !dist/**
-            !build/**
-            !coverage/**
-            !*.min.js
-            !*.bundle.js
-          system_message: |
-            You are an expert code reviewer for Yama (Yama), an enterprise-grade Pull Request automation toolkit with AI-powered code review capabilities.
-
-            FOCUS AREAS:
-            1. **Security**: Check for API key leaks, unsafe patterns, vulnerability risks
-            2. **Type Safety**: Ensure proper TypeScript usage, avoid 'any' types
-            3. **Code Quality**: Follow established patterns, proper error handling
-            4. **Performance**: Identify potential bottlenecks or inefficient code
-            5. **Documentation**: Verify JSDoc comments and inline documentation
-            6. **Testing**: Suggest test improvements or missing test cases
-            7. **Semantic Commits**: Verify commit messages follow type(scope): description format
-            8. **PR Automation**: Check for proper integration with Bitbucket/GitHub APIs
-
-            PROJECT CONTEXT:
-            - PR automation toolkit supporting Bitbucket, GitHub, GitLab
-            - AI-powered code review and description enhancement
-            - TypeScript with strict mode enabled
-            - Enterprise-grade security requirements
-            - Integration with multiple AI providers (OpenAI, Anthropic, etc.)
-
-            REVIEW GUIDELINES:
-            - Be constructive and educational
-            - Prioritize security and type safety issues
-            - Suggest specific improvements with code examples
-            - Focus on PR automation best practices
-            - Consider maintainability and scalability
-            - Check for proper logging instead of console statements
-
-            CRITICAL ITEMS TO FLAG:
-            - Any console.log statements in production code
-            - Missing or incorrect TypeScript types
-            - Potential security vulnerabilities in API integrations
-            - Non-semantic commit messages
-            - Missing error handling for external API calls
-            - Hardcoded secrets or API keys
-            - ESLint rule violations
-            - Missing tests for new PR automation features
-            - Improper handling of sensitive PR data
-
-            Provide constructive, actionable feedback with specific code examples.
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      # NOTE: The AI code-review step previously used `coderabbitai/openai-pr-reviewer`,
+      # which was removed upstream and no longer resolves on GitHub Actions
+      # (causing this job to fail on every PR). AI review is now handled by the
+      # dedicated `Yama Self Review` workflow (yama-self-review.yml). The remaining
+      # steps here keep build-rule validation + the status comment.
 
       - name: 🔍 Validate PR Against Build Rules
         run: |

--- a/.github/workflows/yama-self-review.yml
+++ b/.github/workflows/yama-self-review.yml
@@ -1,0 +1,77 @@
+# Yama dogfoods itself: reviews juspay/yama's own PRs using the local action.
+#
+# Required repository secrets (Settings → Secrets and variables → Actions):
+#   - YAMA_GITHUB_TOKEN : a GitHub PAT (repo / pull_requests scope) for the
+#                         hosted GitHub MCP endpoint (api.githubcopilot.com)
+#   - LITELLM_BASE_URL  : LiteLLM proxy base URL
+#   - LITELLM_API_KEY   : LiteLLM proxy API key
+# Until all three are set, the preflight job skips the review (the check stays green).
+name: Yama Self Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+concurrency:
+  group: yama-self-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+# Least privilege at the workflow level; only the review job is granted
+# pull-requests: write (it posts the review). preflight just reads.
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - id: check
+        env:
+          PAT: ${{ secrets.YAMA_GITHUB_TOKEN }}
+          LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
+          LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+        run: |
+          if [ -n "$PAT" ] && [ -n "$LITELLM_BASE_URL" ] && [ -n "$LITELLM_API_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Yama self-review skipped — set repo secrets YAMA_GITHUB_TOKEN, LITELLM_BASE_URL and LITELLM_API_KEY to enable."
+          fi
+
+  review:
+    needs: preflight
+    # Run only when secrets are configured and the PR is from this repo (forks
+    # have no access to secrets, so preflight already skips them).
+    if: >-
+      needs.preflight.outputs.enabled == 'true' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Yama Review
+        # `uses: ./` runs the action from THIS checkout — required to bootstrap the
+        # action (it doesn't exist on `main` until this PR merges). The job is gated
+        # to same-repo PRs (forks, which can't read secrets, are skipped), so only
+        # trusted collaborators reach it. After merge, pin this to the published
+        # action at a fixed ref (e.g. juspay/yama@<sha>) so PR-modified action code
+        # can't run with secrets.
+        uses: ./
+        with:
+          github-token: ${{ secrets.YAMA_GITHUB_TOKEN }}
+          ai-provider: litellm
+          ai-model: private-large
+          litellm-base-url: ${{ secrets.LITELLM_BASE_URL }}
+          litellm-api-key: ${{ secrets.LITELLM_API_KEY }}
+          focus-areas: security,performance,codeQuality
+          # Review only (skip PR-description enhancement) — the reviewer posts
+          # inline comments + a verdict; it does not rewrite PR descriptions.
+          skip-description-enhance: "true"

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,31 @@ inputs:
   ai-model:
     description: "Model name for the selected AI provider"
     required: false
+  anthropic-api-key:
+    description: "Anthropic API key (used when ai-provider: anthropic)"
+    required: false
+  openai-api-key:
+    description: "OpenAI API key (used when ai-provider: openai)"
+    required: false
+  google-ai-api-key:
+    description: "Google AI Studio API key (used when ai-provider: google-ai)"
+    required: false
+  google-vertex-project:
+    description: "GCP project ID for Vertex AI (auto-derived from the credentials JSON when omitted)"
+    required: false
+  google-vertex-location:
+    description: "Vertex AI location/region"
+    required: false
+    default: "us-central1"
+  google-application-credentials:
+    description: "Vertex AI service-account credentials JSON content (written to a temp file at runtime)"
+    required: false
+  litellm-base-url:
+    description: "LiteLLM proxy base URL (used when ai-provider: litellm)"
+    required: false
+  litellm-api-key:
+    description: "LiteLLM proxy API key (used when ai-provider: litellm)"
+    required: false
   focus-areas:
     description: "Comma-separated focus areas for the review (e.g. security,performance)"
     required: false
@@ -75,24 +100,31 @@ outputs:
 runs:
   using: "composite"
   steps:
+    # Pin pnpm to the version that generated pnpm-lock.yaml. Bare `corepack
+    # enable` picks an arbitrary pnpm whose `overrides` serialization differs
+    # from the lockfile (ERR_PNPM_LOCKFILE_CONFIG_MISMATCH on frozen install).
+    - name: Set up pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 10.14.0
+
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: "20"
+        # Node 24: NeuroLink's memory layer requires the `node:sqlite` built-in,
+        # which does not exist on Node 20 and is flag-gated on Node 22. Node 24
+        # ships node:sqlite without an experimental flag. actions/setup-node
+        # downloads and provisions this version on any runner, so it does not
+        # depend on the runner's pre-installed Node.
+        node-version: "24"
 
     - name: Install dependencies and build CLI
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
         if [ ! -f "dist/cli/cli.js" ]; then
-          if [ -f "pnpm-lock.yaml" ]; then
-            corepack enable
-            pnpm install --frozen-lockfile
-            pnpm run build
-          else
-            npm ci
-            npm run build
-          fi
+          pnpm install --frozen-lockfile
+          pnpm run build
         fi
 
     - name: Run Yama review
@@ -103,8 +135,33 @@ runs:
         # GitHub MCP server authenticates via GITHUB_TOKEN.
         GITHUB_TOKEN: ${{ inputs.github-token }}
         # Surface AI provider/model selection to the orchestrator + NeuroLink.
+        # Yama's ConfigLoader reads AI_PROVIDER/AI_MODEL; NeuroLink's own provider
+        # factory keys off NEUROLINK_PROVIDER/NEUROLINK_MODEL (defaults to 'vertex'
+        # otherwise). Set both so provider selection is unambiguous — this mirrors
+        # the proven euler-api-dashboard Jenkins setup.
         AI_PROVIDER: ${{ inputs.ai-provider }}
         AI_MODEL: ${{ inputs.ai-model }}
+        NEUROLINK_PROVIDER: ${{ inputs.ai-provider }}
+        NEUROLINK_MODEL: ${{ inputs.ai-model }}
+        # The explore/bootstrap subagent should use the same provider/model as the
+        # main review (otherwise it falls back to a config default like vertex and
+        # fails when only one provider's credentials are present).
+        AI_EXPLORE_PROVIDER: ${{ inputs.ai-provider }}
+        AI_EXPLORE_MODEL: ${{ inputs.ai-model }}
+        # AI provider credentials (pass the one matching ai-provider). Forwarded
+        # as env explicitly because step-level env does NOT propagate into a
+        # composite action's steps.
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+        OPENAI_API_KEY: ${{ inputs.openai-api-key }}
+        GOOGLE_AI_API_KEY: ${{ inputs.google-ai-api-key }}
+        GOOGLE_VERTEX_PROJECT: ${{ inputs.google-vertex-project }}
+        GOOGLE_VERTEX_LOCATION: ${{ inputs.google-vertex-location }}
+        VERTEX_CREDENTIALS_JSON: ${{ inputs.google-application-credentials }}
+        # LiteLLM proxy (self-hosted / custom models). LITELLM_MODEL mirrors
+        # ai-model so NeuroLink's litellm provider resolves the right model.
+        LITELLM_BASE_URL: ${{ inputs.litellm-base-url }}
+        LITELLM_API_KEY: ${{ inputs.litellm-api-key }}
+        LITELLM_MODEL: ${{ inputs.ai-model }}
         # GitHub PR context, consumed by ProviderDetector + the review request.
         YAMA_ACTION_PATH: ${{ github.action_path }}
         EVENT_PATH: ${{ github.event_path }}
@@ -135,6 +192,28 @@ runs:
 
         OWNER="${REPO_FULL%%/*}"
         REPO="${REPO_FULL#*/}"
+
+        # Vertex AI: materialize the service-account JSON to a temp file and
+        # point GOOGLE_APPLICATION_CREDENTIALS at it (NeuroLink uses ADC). The
+        # GCP project is derived from the JSON's project_id when not supplied.
+        if [ -n "${VERTEX_CREDENTIALS_JSON:-}" ]; then
+          CRED_FILE="$(mktemp "${RUNNER_TEMP:-/tmp}/vertex-creds-XXXXXX.json")"
+          # Delete the materialized service-account key when this step exits
+          # (success OR failure), so the credentials are never left on the runner.
+          trap 'rm -f "$CRED_FILE"' EXIT
+          # Write the secret from the environment via node — it is never passed
+          # as a shell/process argument, so it cannot appear in a process listing.
+          node -e 'require("fs").writeFileSync(process.argv[1], process.env.VERTEX_CREDENTIALS_JSON || "")' "$CRED_FILE"
+          chmod 600 "$CRED_FILE"
+          export GOOGLE_APPLICATION_CREDENTIALS="$CRED_FILE"
+          if [ -z "${GOOGLE_VERTEX_PROJECT:-}" ]; then
+            GOOGLE_VERTEX_PROJECT="$(node -e 'try{process.stdout.write(JSON.parse(require("fs").readFileSync(process.env.GOOGLE_APPLICATION_CREDENTIALS,"utf8")).project_id||"")}catch(_){process.stdout.write("")}')"
+            export GOOGLE_VERTEX_PROJECT
+            if [ -z "${GOOGLE_VERTEX_PROJECT}" ]; then
+              echo "::warning::Could not derive GOOGLE_VERTEX_PROJECT from the credentials JSON (missing or unreadable project_id). Pass the google-vertex-project input explicitly when using the Vertex provider."
+            fi
+          fi
+        fi
 
         ARGS=(review --owner "$OWNER" --repo "$REPO" --pr "$PR_NUMBER")
 

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     ],
     "overrides": {
       "@semantic-release/npm": "^13.1.2",
-      "undici": "^5.28.5"
+      "undici": "~7.22.0"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   "@semantic-release/npm": ^13.1.2
-  undici: ^5.28.5
+  undici: ~7.22.0
 
 importers:
   .:
@@ -1360,13 +1360,6 @@ packages:
       {
         integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==,
       }
-
-  "@fastify/busboy@2.1.1":
-    resolution:
-      {
-        integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==,
-      }
-    engines: { node: ">=14" }
 
   "@fastify/cors@11.2.0":
     resolution:
@@ -10248,12 +10241,12 @@ packages:
         integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==,
       }
 
-  undici@5.28.5:
+  undici@7.22.0:
     resolution:
       {
-        integrity: sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==,
+        integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==,
       }
-    engines: { node: ">=14.0" }
+    engines: { node: ">=20.18.1" }
 
   unicode-emoji-modifier-base@1.0.0:
     resolution:
@@ -10705,7 +10698,7 @@ snapshots:
   "@actions/http-client@3.0.0":
     dependencies:
       tunnel: 0.0.6
-      undici: 5.28.5
+      undici: 7.22.0
 
   "@actions/io@2.0.0": {}
 
@@ -11976,8 +11969,6 @@ snapshots:
       fast-uri: 3.1.0
     optional: true
 
-  "@fastify/busboy@2.1.1": {}
-
   "@fastify/cors@11.2.0":
     dependencies:
       fastify-plugin: 5.1.0
@@ -12585,7 +12576,7 @@ snapshots:
       pptxgenjs: 4.0.1
       redis: 5.11.0
       tar-stream: 3.1.8
-      undici: 5.28.5
+      undici: 7.22.0
       uuid: 13.0.0
       ws: 8.20.0
       xml2js: 0.6.2
@@ -17905,9 +17896,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@5.28.5:
-    dependencies:
-      "@fastify/busboy": 2.1.1
+  undici@7.22.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 

--- a/src/v2/core/MCPServerManager.ts
+++ b/src/v2/core/MCPServerManager.ts
@@ -34,6 +34,16 @@ const DEFAULT_GITHUB_BLOCKED_TOOLS: string[] = [
  * blockedTools + optional stdio command/args), typed explicitly to avoid `any`
  * for the new config object.
  */
+/**
+ * Minimal shape of an entry returned by NeuroLink's `listMCPServers()`,
+ * used to verify a server connected without resorting to `any`.
+ */
+interface MCPServerStatus {
+  name: string;
+  status?: string;
+  tools?: Array<{ name?: string }>;
+}
+
 interface GitHubMCPRegistration {
   transport: "http" | "stdio";
   url?: string;
@@ -352,24 +362,34 @@ export class MCPServerManager {
 
       await neurolink.addExternalMCPServer("github", config);
 
-      // Verify the server actually connected — NeuroLink resolves the promise
-      // even on timeout, so we must check the status explicitly (same pattern
-      // as the Bitbucket path).
-      const servers = await neurolink.listMCPServers();
-      const ghServer = (servers || []).find((s: any) => s.name === "github");
-      if (
-        !ghServer ||
-        ghServer.status !== "connected" ||
-        ghServer.tools?.length === 0
-      ) {
+      // The remote HTTP endpoint (api.githubcopilot.com) connects asynchronously
+      // — TLS handshake + auth + tool discovery take ~3-4s, and NeuroLink may only
+      // finish discovery lazily on the first generate() call. Poll briefly for a
+      // healthy status, but for the HTTP transport DO NOT hard-fail if it is not
+      // yet "connected": the tools are resolved when the review runs (this mirrors
+      // Curator's proven pattern). For a local stdio server we keep the strict
+      // check, since a local process should connect promptly.
+      const ghServer = await this.waitForMCPServer(neurolink, "github", 12000);
+      const connected =
+        ghServer?.status === "connected" && (ghServer?.tools?.length ?? 0) > 0;
+
+      if (transport === "stdio" && !connected) {
         throw new MCPServerError(
           `GitHub MCP server registered but not connected (status: ${ghServer?.status ?? "unknown"}, tools: ${ghServer?.tools?.length ?? 0}). Possible startup timeout.`,
         );
       }
 
-      console.log(
-        `   ✅ GitHub MCP server registered and tools available (transport: ${transport})`,
-      );
+      if (connected) {
+        console.log(
+          `   ✅ GitHub MCP server registered and tools available (transport: ${transport})`,
+        );
+      } else {
+        console.warn(
+          `   ⚠️  GitHub MCP server registered but not yet reporting connected ` +
+            `(status: ${ghServer?.status ?? "unknown"}, tools: ${ghServer?.tools?.length ?? 0}). ` +
+            `Remote tools are discovered on first use; continuing.`,
+        );
+      }
       if (transport === "http") {
         console.log(`   🌐 Remote endpoint: ${config.url}`);
       }
@@ -379,6 +399,33 @@ export class MCPServerManager {
         `Failed to setup GitHub MCP server: ${(error as Error).message}`,
       );
     }
+  }
+
+  /**
+   * Poll {@link listMCPServers} until the named server reports "connected" with
+   * at least one tool, or the timeout elapses. Returns the last-seen server
+   * entry (possibly not-yet-connected) so the caller can decide how to proceed.
+   *
+   * Bounded by `timeoutMs` via the loop condition — it cannot run indefinitely.
+   */
+  private async waitForMCPServer(
+    neurolink: any,
+    name: string,
+    timeoutMs: number,
+  ): Promise<MCPServerStatus | undefined> {
+    const deadline = Date.now() + timeoutMs;
+    let last: MCPServerStatus | undefined;
+    while (Date.now() < deadline) {
+      const servers: MCPServerStatus[] = await neurolink
+        .listMCPServers()
+        .catch(() => []);
+      last = (servers || []).find((server) => server.name === name);
+      if (last?.status === "connected" && (last.tools?.length ?? 0) > 0) {
+        return last;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    return last;
   }
 
   /**

--- a/src/v2/core/YamaV2Orchestrator.ts
+++ b/src/v2/core/YamaV2Orchestrator.ts
@@ -165,7 +165,7 @@ export class YamaOrchestrator {
             this.detectedProvider,
           );
           if (this.explorer && this.config.ai.explore.enabled) {
-            await this.explorer.initialize("pr");
+            await this.explorer.initialize("pr", this.detectedProvider);
           }
           this.mcpInitialized = true;
           this.mcpProvider = this.detectedProvider;

--- a/src/v2/exploration/ContextExplorerService.ts
+++ b/src/v2/exploration/ContextExplorerService.ts
@@ -16,7 +16,10 @@ import {
   buildObservabilityConfigFromEnv,
   validateObservabilityConfig,
 } from "../utils/ObservabilityConfig.js";
-import { getProviderToolset } from "../providers/ProviderToolset.js";
+import {
+  getProviderToolset,
+  type VCSProviderName,
+} from "../providers/ProviderToolset.js";
 import { ExplorerPromptBuilder } from "./ExplorerPromptBuilder.js";
 import { RulesContextLoader } from "./RulesContextLoader.js";
 import {
@@ -47,11 +50,18 @@ export class ContextExplorerService {
     this.neurolink = this.initializeNeurolink();
   }
 
-  async initialize(mode: "pr" | "local"): Promise<void> {
+  async initialize(
+    mode: "pr" | "local",
+    provider: VCSProviderName = "bitbucket",
+  ): Promise<void> {
     if (mode === "pr" && !this.prMcpInitialized) {
+      // The explore subagent gets its own MCP servers; they MUST match the
+      // detected provider, otherwise a GitHub run would try to start Bitbucket
+      // MCP (and fail on missing Bitbucket credentials).
       await this.mcpManager.setupMCPServers(
         this.neurolink,
         this.config.mcpServers,
+        provider,
       );
       this.prMcpInitialized = true;
       return;
@@ -67,7 +77,16 @@ export class ContextExplorerService {
     input: ExploreContextInput,
     runtimeContext: ExploreRuntimeContext,
   ): Promise<ExploreExecutionResult> {
-    await this.initialize(runtimeContext.mode);
+    // Pass the runtime provider through when it is a known VCS provider;
+    // otherwise fall back to the read-only default. VCSProviderName is the
+    // single source of truth for supported providers, so adding one there is
+    // all that's needed for the explore subagent to honour it.
+    const explorerProvider: VCSProviderName =
+      runtimeContext.provider === "github" ||
+      runtimeContext.provider === "bitbucket"
+        ? runtimeContext.provider
+        : "bitbucket";
+    await this.initialize(runtimeContext.mode, explorerProvider);
 
     const normalizedInput = this.normalizeInput(input);
     const cacheKey = this.buildCacheKey(normalizedInput, runtimeContext);

--- a/src/v2/providers/ProviderToolset.ts
+++ b/src/v2/providers/ProviderToolset.ts
@@ -321,7 +321,8 @@ class GitHubToolset implements ProviderToolset {
   systemPromptToolsSection(): string {
     return `  <tool-usage>
     <tool name="pull_request_read">
-      <use-when>Read PR state. method="get" once at the start for PR metadata and existing comments; method="get_files" to list changed files; method="get_diff" for the unified diff. Always pass owner, repo, pullNumber.</use-when>
+      <use-when>Read PR state by method: "get" for PR metadata; "get_review_comments" to load EXISTING inline review comments (each thread carries isResolved/isOutdated) so you never repeat an already-raised point; "get_reviews" for prior submitted reviews; "get_files" to list changed files; "get_diff" for the unified diff. Always pass owner, repo, pullNumber.</use-when>
+      <important>method="get" does NOT include review comments on GitHub — you MUST call method="get_review_comments" to see them.</important>
     </tool>
 
     <tool name="search_code">
@@ -372,11 +373,16 @@ class GitHubToolset implements ProviderToolset {
     entry with severity=BLOCKING as a blocking criterion for this PR. If the block is
     missing or empty, fall back to <focus-areas> and <blocking-criteria>.
 
-    STEP 2 — Read the PR shell
-    Call pull_request_read(method="get", owner, repo, pullNumber) once to get PR
-    metadata and existing comments, then pull_request_read(method="get_files", ...)
-    to list the changed files. Build a mental map of which files exist and which
-    already have comments. Do NOT request the full PR diff yet.
+    STEP 2 — Read the PR shell + EXISTING review comments
+    Call pull_request_read(method="get", owner, repo, pullNumber) for PR metadata,
+    then pull_request_read(method="get_review_comments", owner, repo, pullNumber) to
+    load existing inline review comments. (On GitHub, method="get" does NOT include
+    review comments — you MUST call get_review_comments.) Build a map of which
+    file+line locations already have comments. Treat any point an existing comment
+    already raises as ALREADY HANDLED: do NOT post a duplicate, and do NOT re-raise it
+    in your decision — especially threads marked isResolved or isOutdated. Then call
+    pull_request_read(method="get_files", ...) to list the changed files. Do NOT
+    request the full PR diff yet.
 
     STEP 3 — Open ONE pending review
     Call pull_request_review_write(method="create", owner, repo, pullNumber) to open a
@@ -396,9 +402,13 @@ class GitHubToolset implements ProviderToolset {
       e. Move to the next file. Never jump between files mid-review.
 
     STEP 5 — Decision (submit the review)
-    After the last file, count issues by severity, apply <blocking-criteria>, and call
-    pull_request_review_write(method="submit", owner, repo, pullNumber, body=&lt;summary&gt;)
-    with event="APPROVE" when clean OR event="REQUEST_CHANGES" when blocking criteria are met.
+    Count ONLY the NEW issues you raised this run — exclude any point already covered by
+    an existing review comment (from STEP 2), and exclude resolved/outdated threads. Apply
+    <blocking-criteria> to that NEW set only. A concern that was already raised and
+    answered/justified in an existing comment thread is NOT grounds to block again.
+    Then call pull_request_review_write(method="submit", owner, repo, pullNumber,
+    body=&lt;summary&gt;) with event="APPROVE" when there are no NEW blocking issues, or
+    event="REQUEST_CHANGES" only when NEW blocking criteria are met this run.
 
     STEP 6 — Summary comment
     Use the submit body above for the summary (file count, issue counts by severity, next


### PR DESCRIPTION
## What

Enables Yama to **review this repo's own PRs** (dogfooding) using **Vertex AI**, and fixes the always-failing legacy review workflow. Follow-up to #55 (GitHub provider support, shipped in v2.5.0).

## Changes

- **`action.yml` — first-class AI credential inputs.** The composite action previously forwarded `AI_PROVIDER`/`AI_MODEL` but **not** the AI credential (step-level `env` doesn't propagate into a composite action), so the AI provider couldn't authenticate. Added inputs and env forwarding for `anthropic-api-key` / `openai-api-key` / `google-ai-api-key`, plus **Vertex AI**: `google-vertex-project`, `google-vertex-location`, and `google-application-credentials` (service-account JSON). At runtime the JSON is written to a temp file → `GOOGLE_APPLICATION_CREDENTIALS`, and the project is auto-derived from the JSON's `project_id`. Mirrors NeuroLink's own action pattern.
- **`.github/workflows/yama-self-review.yml` (new).** Runs Yama on this repo's PRs via `uses: ./` with `ai-provider: vertex` / `gemini-2.5-pro`. A **preflight job skips gracefully (stays green)** until the required secrets are set, and skips fork PRs (which can't access secrets).
- **`.github/workflows/copilot-review.yml` — fix.** Removed the dead `coderabbitai/openai-pr-reviewer@latest` step (the action was removed upstream and failed on every PR). Build-rule validation + status-comment steps are kept; AI review is now handled by the self-review workflow.

## Required repository secrets

To enable the self-review (Settings → Secrets and variables → Actions):

| Secret | Value |
|--------|-------|
| `GCP_VERTEX_CREDENTIALS` | Vertex AI service-account JSON (the whole file) |
| `YAMA_GITHUB_TOKEN` | A GitHub PAT (`repo` / `pull_requests` scope) for the hosted GitHub MCP endpoint |

Until both exist, the self-review check passes (skipped).

## Notes
- Only YAML/action wiring changes — no TypeScript touched. 202 unit tests still green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecated OpenAI PR reviewer workflow step that no longer resolves in GitHub Actions
  * Extended workflow configuration to support multiple AI provider credentials (Anthropic, OpenAI, Google AI, and Vertex AI)
  * Introduced new automated self-review workflow for pull requests with configurable AI provider settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->