### PR TITLE
feat(bitbucket): add native PR task creation with conditional rules

### DIFF
--- a/src/v2/config/DefaultConfig.ts
+++ b/src/v2/config/DefaultConfig.ts
@@ -50,6 +50,12 @@ export class DefaultConfig {
       mcpServers: {
         bitbucket: {
           blockedTools: [],
+          taskCreation: {
+            enabled: false, // Opt-in: set to true on Bitbucket Server to convert comments to tasks
+            severities: ["CRITICAL", "MAJOR"],
+            taskKeyword: "[TASK]", // AI appends this to any comment body to escalate it to a task
+            conditionalTaskRules: [], // Per-repo rules: if PR touches X → create task saying Y
+          },
         },
         github: {
           enabled: true,

--- a/src/v2/core/MCPServerManager.ts
+++ b/src/v2/core/MCPServerManager.ts
@@ -105,6 +105,16 @@ export class MCPServerManager {
       console.log("   ⏭️  Jira MCP disabled in config");
     }
 
+    // Log Bitbucket task creation status when relevant
+    if (provider === "bitbucket" && config.bitbucket?.taskCreation?.enabled) {
+      const severities = (
+        config.bitbucket.taskCreation.severities ?? ["CRITICAL", "MAJOR"]
+      ).join(", ");
+      console.log(
+        `   📋 Bitbucket task creation ENABLED (severities: ${severities}) — requires Bitbucket Server`,
+      );
+    }
+
     this.initialized = true;
 
     await this.logDiagnostics(neurolink);

--- a/src/v2/core/YamaV2Orchestrator.ts
+++ b/src/v2/core/YamaV2Orchestrator.ts
@@ -29,6 +29,7 @@ import {
   TokenUsage,
   UnifiedReviewRequest,
   IssuesBySeverity,
+  CreatedTask,
 } from "../types/v2.types.js";
 import { YamaConfig, YamaInitOptions } from "../types/config.types.js";
 import {
@@ -750,6 +751,9 @@ export class YamaOrchestrator {
     // Calculate statistics from session tool calls
     const statistics = this.calculateStatistics(session);
 
+    // Collect any Jira tasks created during the review
+    const tasks = this.extractCreatedTasks(session);
+
     return {
       mode: "pr",
       // GitHub passes the PR number via prNumber; coalesce so GitHub reviews
@@ -766,6 +770,7 @@ export class YamaOrchestrator {
       },
       costEstimate: this.calculateCost(aiResponse.usage),
       sessionId,
+      ...(tasks.length > 0 ? { tasks } : {}),
     };
   }
 
@@ -1168,6 +1173,37 @@ export class YamaOrchestrator {
     );
     const issuesFound = this.extractIssueCountsFromComments(commentCalls);
 
+    // Count Bitbucket tasks created (convert_pr_item to_task + create_pr_task calls
+    // that returned a task id)
+    const tasksCreated = toolCalls.filter((tc: any) => {
+      if (tc?.toolName === "convert_pr_item") {
+        // convert_pr_item returns plain text on success (no JSON id); count any
+        // successful to_task call (no error string in result).
+        if (tc?.args?.direction !== "to_task") {
+          return false;
+        }
+        const res = tc?.result;
+        if (!res) {
+          return false;
+        }
+        // If result is a string, it's the success message (no error)
+        if (typeof res === "string") {
+          return !res.toLowerCase().includes("error");
+        }
+        // If result is an object, check it's not an error object
+        return !(res?.error ?? res?.isError);
+      }
+      if (tc?.toolName === "create_pr_task") {
+        // create_pr_task returns { message, task: { id, ... } }
+        return !!(
+          tc?.result?.task?.id ??
+          tc?.result?.id ??
+          tc?.result?.data?.id
+        );
+      }
+      return false;
+    }).length;
+
     return {
       filesReviewed,
       issuesFound,
@@ -1176,6 +1212,7 @@ export class YamaOrchestrator {
       toolCallsMade: toolCalls.length,
       cacheHits: 0,
       totalComments: commentCalls.length,
+      tasksCreated,
     };
   }
 
@@ -1272,6 +1309,199 @@ export class YamaOrchestrator {
    */
   private extractSummary(aiResponse: any): string {
     return aiResponse.content || aiResponse.text || "Review completed";
+  }
+
+  /**
+   * Extract Bitbucket tasks created during the review from the session tool calls.
+   *
+   * Two creation paths are tracked:
+   *   1. convert_pr_item(direction="to_task") — converts an inline comment into a task.
+   *      The result carries the task id; the source comment id is in args.id.
+   *   2. create_pr_task — creates a standalone PR-level task.
+   *      The result carries the task id and text.
+   *
+   * When the source comment body contains the configured task keyword (default "[TASK]"),
+   * the task is flagged as triggeredByKeyword=true.
+   */
+  private extractCreatedTasks(session: any): CreatedTask[] {
+    const toolCalls: any[] = session?.toolCalls ?? [];
+    const tasks: CreatedTask[] = [];
+    const taskKeyword =
+      this.config?.mcpServers?.bitbucket?.taskCreation?.taskKeyword ?? "[TASK]";
+
+    for (const tc of toolCalls) {
+      const toolName: string = tc?.toolName ?? "";
+
+      // ── Path 1: convert_pr_item(direction="to_task") ──────────────────────
+      if (toolName === "convert_pr_item") {
+        const args = tc?.args ?? {};
+        if (args?.direction !== "to_task") {
+          continue; // Only care about comment→task conversions
+        }
+        const result = tc?.result ?? {};
+        const rawId =
+          result?.id ?? result?.data?.id ?? result?.task?.id ?? args?.id;
+        if (rawId === null || rawId === undefined) {
+          continue;
+        }
+
+        const taskId = String(rawId);
+        const sourceCommentId =
+          typeof args?.id === "number" ? args.id : undefined;
+
+        // Infer severity from the closest preceding add_comment for this id
+        const { severity, commentText } =
+          this.inferSeverityAndTextFromCommentId(toolCalls, sourceCommentId);
+
+        // Check whether the AI used the keyword to escalate this comment
+        const triggeredByKeyword =
+          taskKeyword.length > 0 &&
+          typeof commentText === "string" &&
+          commentText.includes(taskKeyword);
+
+        const task: CreatedTask = {
+          taskId,
+          summary: result?.text ?? result?.data?.text ?? "Review finding",
+          severity,
+          sourceCommentId,
+        };
+        if (triggeredByKeyword) {
+          task.triggeredByKeyword = true;
+        }
+        tasks.push(task);
+        continue;
+      }
+
+      // ── Path 2: create_pr_task (standalone task) ──────────────────────────
+      if (toolName === "create_pr_task") {
+        const result = tc?.result ?? {};
+        const rawId = result?.id ?? result?.data?.id ?? result?.task?.id;
+        if (rawId === null || rawId === undefined) {
+          continue;
+        }
+
+        const taskId = String(rawId);
+        const args = tc?.args ?? {};
+        const text: string = args?.text ?? result?.text ?? "Review finding";
+
+        // Infer severity from the task text (the AI formats it with severity)
+        const severity = this.inferSeverityFromText(text);
+
+        // Check whether the task text contains the keyword (AI may include it)
+        const triggeredByKeyword =
+          taskKeyword.length > 0 && text.includes(taskKeyword);
+
+        // Check whether this create_pr_task was triggered by a conditional rule.
+        // Match by comparing the task text against each configured rule's createTask.text.
+        const matchedRule = (
+          this.config?.mcpServers?.bitbucket?.taskCreation
+            ?.conditionalTaskRules ?? []
+        ).find((rule) => rule.createTask.text === text);
+
+        // Parse file path and line from task text:
+        // The AI is instructed to format: "[SEVERITY] file:line — description"
+        const fileMatch = text.match(/([^\s[\]]+\.[a-zA-Z0-9]+):(\d+)/);
+
+        const task: CreatedTask = {
+          taskId,
+          summary:
+            text
+              .replace(/^\[.*?\]\s*/, "")
+              .split("—")[0]
+              ?.trim() ?? text,
+          severity,
+          filePath: fileMatch ? fileMatch[1] : undefined,
+          line: fileMatch ? parseInt(fileMatch[2], 10) : undefined,
+        };
+        if (triggeredByKeyword) {
+          task.triggeredByKeyword = true;
+        }
+        if (matchedRule) {
+          task.triggeredByRule = matchedRule.name;
+        }
+        tasks.push(task);
+      }
+    }
+
+    return tasks;
+  }
+
+  /**
+   * Walk backward through tool calls to find the add_comment that immediately
+   * preceded convert_pr_item for a given comment ID, and return both the
+   * inferred severity and the raw comment text (for keyword detection).
+   */
+  private inferSeverityAndTextFromCommentId(
+    toolCalls: any[],
+    commentId: number | undefined,
+  ): { severity: CreatedTask["severity"]; commentText: string } {
+    for (let i = toolCalls.length - 1; i >= 0; i--) {
+      const tc = toolCalls[i];
+      if (tc?.toolName !== "add_comment") {
+        continue;
+      }
+      const resultId =
+        tc?.result?.id ?? tc?.result?.data?.id ?? tc?.result?.comment?.id;
+      if (
+        commentId !== undefined &&
+        resultId !== null &&
+        resultId !== undefined &&
+        resultId !== commentId
+      ) {
+        continue;
+      }
+      const commentText: string = tc?.args?.comment_text ?? "";
+      return {
+        severity: this.inferSeverityFromText(commentText),
+        commentText,
+      };
+    }
+    return { severity: "MAJOR", commentText: "" };
+  }
+
+  /**
+   * @deprecated Use inferSeverityAndTextFromCommentId instead.
+   * Kept for backward compatibility with any callers that only need severity.
+   */
+  private inferSeverityFromCommentId(
+    toolCalls: any[],
+    commentId: number | undefined,
+  ): CreatedTask["severity"] {
+    return this.inferSeverityAndTextFromCommentId(toolCalls, commentId)
+      .severity;
+  }
+
+  /** Infer a severity level from a comment/task text containing emoji markers. */
+  private inferSeverityFromText(text: string): CreatedTask["severity"] {
+    if (
+      text.includes("🔒 CRITICAL") ||
+      text.includes("CRITICAL:") ||
+      text.includes("[CRITICAL]")
+    ) {
+      return "CRITICAL";
+    }
+    if (
+      text.includes("⚠️ MAJOR") ||
+      text.includes("MAJOR:") ||
+      text.includes("[MAJOR]")
+    ) {
+      return "MAJOR";
+    }
+    if (
+      text.includes("💡 MINOR") ||
+      text.includes("MINOR:") ||
+      text.includes("[MINOR]")
+    ) {
+      return "MINOR";
+    }
+    if (
+      text.includes("💬 SUGGESTION") ||
+      text.includes("SUGGESTION:") ||
+      text.includes("[SUGGESTION]")
+    ) {
+      return "SUGGESTION";
+    }
+    return "MAJOR"; // safe default for task-worthy findings
   }
 
   /**

--- a/src/v2/prompts/PromptBuilder.ts
+++ b/src/v2/prompts/PromptBuilder.ts
@@ -112,10 +112,18 @@ export class PromptBuilder {
     const knowledgeBase = await this.loadKnowledgeBase(config);
     const exploreEnabled = config.ai.explore.enabled;
 
-    // Strip explore_context references when the subagent is disabled.
+    // Bitbucket native task creation: enabled only when provider is bitbucket
+    // and bitbucket.taskCreation.enabled = true.
+    const taskCreationEnabled =
+      provider === "bitbucket" &&
+      config.mcpServers.bitbucket?.taskCreation?.enabled === true;
+
+    // Strip explore_context references when the subagent is disabled,
+    // and task creation references when that feature is disabled.
     const basePrompt = PromptBuilder.stripDisabledSections(
       basePromptRaw,
       exploreEnabled,
+      taskCreationEnabled,
     );
 
     const toolsetParams = this.toToolsetParams(request);
@@ -123,7 +131,12 @@ export class PromptBuilder {
     const workflowBlock = PromptBuilder.stripDisabledSections(
       this.buildReviewWorkflow(request, toolset, toolsetParams),
       exploreEnabled,
+      taskCreationEnabled,
     );
+
+    const taskCreationBlock = taskCreationEnabled
+      ? this.buildBitbucketTaskCreationBlock(config)
+      : "";
 
     const bootstrapBlock =
       bootstrapStandards && bootstrapStandards.trim().length > 0
@@ -157,6 +170,7 @@ ${knowledgeBase ? `<learned-knowledge>\n${knowledgeBase}\n</learned-knowledge>` 
 ${toolset.identifierXml(toolsetParams)}
   <mode>${request.dryRun ? "dry-run" : "live"}</mode>
 
+${taskCreationBlock}
 ${workflowBlock}
 </review-task>
     `.trim();
@@ -189,12 +203,16 @@ ${toolset.reviewWorkflowInstructions(params)}
   }
 
   /**
-   * Strip sections that depend on explore_context being enabled.
+   * Strip sections that depend on explore_context being enabled, and sections
+   * that depend on Bitbucket task creation being enabled.
    * Keeps the prompt single-source and avoids forking files for the disabled case.
    *
-   * - <!-- EXPLORE_BEGIN -->...<!-- EXPLORE_END --> is removed when explore is OFF.
-   * - <!-- EXPLORE_DISABLED_BEGIN -->...<!-- EXPLORE_DISABLED_END --> is removed when explore is ON.
-   * - The marker comments themselves are always stripped.
+   * Markers and their semantics:
+   *   <!-- EXPLORE_BEGIN -->...<!-- EXPLORE_END -->         — kept when explore ON, removed when OFF.
+   *   <!-- EXPLORE_DISABLED_BEGIN -->...<!-- EXPLORE_DISABLED_END --> — removed when explore ON.
+   *   <!-- TASK_CREATE_BEGIN -->...<!-- TASK_CREATE_END -->  — kept when task creation ON, removed when OFF.
+   *
+   * The marker comments themselves are always stripped.
    *
    * Implementation uses linear indexOf/slice instead of regex to avoid any
    * polynomial-backtracking risk on adversarial input.
@@ -202,11 +220,14 @@ ${toolset.reviewWorkflowInstructions(params)}
   static stripDisabledSections(
     prompt: string,
     exploreEnabled: boolean,
+    taskCreationEnabled: boolean = false,
   ): string {
     const EXPLORE_BEGIN = "<!-- EXPLORE_BEGIN -->";
     const EXPLORE_END = "<!-- EXPLORE_END -->";
     const EXPLORE_DISABLED_BEGIN = "<!-- EXPLORE_DISABLED_BEGIN -->";
     const EXPLORE_DISABLED_END = "<!-- EXPLORE_DISABLED_END -->";
+    const TASK_CREATE_BEGIN = "<!-- TASK_CREATE_BEGIN -->";
+    const TASK_CREATE_END = "<!-- TASK_CREATE_END -->";
 
     const stripBlock = (text: string, start: string, end: string): string => {
       let out = "";
@@ -231,20 +252,152 @@ ${toolset.reviewWorkflowInstructions(params)}
     const removeAll = (text: string, marker: string): string =>
       text.split(marker).join("");
 
+    // --- Explore sections ---
+    let result: string;
     if (exploreEnabled) {
-      let result = stripBlock(
-        prompt,
-        EXPLORE_DISABLED_BEGIN,
-        EXPLORE_DISABLED_END,
-      );
+      result = stripBlock(prompt, EXPLORE_DISABLED_BEGIN, EXPLORE_DISABLED_END);
       result = removeAll(result, EXPLORE_BEGIN);
       result = removeAll(result, EXPLORE_END);
-      return result;
+    } else {
+      result = stripBlock(prompt, EXPLORE_BEGIN, EXPLORE_END);
+      result = removeAll(result, EXPLORE_DISABLED_BEGIN);
+      result = removeAll(result, EXPLORE_DISABLED_END);
     }
-    let result = stripBlock(prompt, EXPLORE_BEGIN, EXPLORE_END);
-    result = removeAll(result, EXPLORE_DISABLED_BEGIN);
-    result = removeAll(result, EXPLORE_DISABLED_END);
+
+    // --- Task creation sections ---
+    if (taskCreationEnabled) {
+      // Keep the content inside TASK_CREATE markers, just remove the markers.
+      result = removeAll(result, TASK_CREATE_BEGIN);
+      result = removeAll(result, TASK_CREATE_END);
+    } else {
+      // Strip the entire TASK_CREATE block.
+      result = stripBlock(result, TASK_CREATE_BEGIN, TASK_CREATE_END);
+    }
+
     return result;
+  }
+
+  /**
+   * Build the <bitbucket-task-creation> XML block injected into <review-task>.
+   *
+   * Only emitted when bitbucket.taskCreation.enabled = true. Contains:
+   *  - Severity-based path: convert every qualifying comment into a task.
+   *  - Keyword-based path: AI appends taskKeyword to any comment to escalate it.
+   *  - Conditional rules: repo-specific "if PR touches X → create task Y" rules
+   *    evaluated once in STEP 2 before the file-by-file review starts.
+   */
+  private buildBitbucketTaskCreationBlock(config: YamaConfig): string {
+    const tc = config.mcpServers.bitbucket?.taskCreation;
+    if (!tc?.enabled) {
+      return "";
+    }
+
+    const severities = (tc.severities ?? ["CRITICAL", "MAJOR"]).join(", ");
+    const keyword = tc.taskKeyword ?? "[TASK]";
+    const keywordEnabled = keyword.length > 0;
+    const rules = tc.conditionalTaskRules ?? [];
+
+    const keywordPath = keywordEnabled
+      ? `
+      PATH 2 — Keyword-based (per-comment discretion):
+      For any inline comment at ANY severity level that you judge deserves a
+      developer action item — even MINOR or SUGGESTION — append "${keyword}" to
+      the comment_text body. Then follow the same convert_pr_item flow (steps
+      1-3 above). Use this sparingly for genuinely important non-critical findings
+      where you want the developer to explicitly acknowledge the issue.
+`
+      : "";
+
+    const onlyClause = keywordEnabled
+      ? `severities: ${severities}, or when the comment body contains "${keyword}"`
+      : `severities: ${severities}`;
+
+    const noTaskClause = keywordEnabled
+      ? `Do NOT call these tools for MINOR or SUGGESTION unless the comment body contains "${keyword}".`
+      : `Do NOT call convert_pr_item or create_pr_task for MINOR or SUGGESTION.`;
+
+    // Build the conditional rules section (only if rules are defined)
+    const conditionalRulesBlock =
+      rules.length > 0
+        ? `\n  <conditional-task-rules>
+    <!-- Evaluated ONCE in STEP 2, immediately after you read the changed files
+         list from get_pull_request. For each rule whose trigger is met, call
+         create_pr_task once with the configured task text. Never call a rule's
+         task more than once per review, and never evaluate these rules inside
+         explore_context. -->
+${rules
+  .map((rule) => {
+    const triggers: string[] = [];
+    if (rule.triggerWhen.always) {
+      triggers.push(
+        `<trigger-always>true — fire for every PR regardless of changes</trigger-always>`,
+      );
+    }
+    if (rule.triggerWhen.filesMatch && rule.triggerWhen.filesMatch.length > 0) {
+      triggers.push(
+        `<trigger-files-match>Fire if ANY changed file path matches (case-insensitive substring or glob): ${rule.triggerWhen.filesMatch.map((p) => `"${this.escapeXML(p)}"`).join(", ")}</trigger-files-match>`,
+      );
+    }
+    if (
+      rule.triggerWhen.diffContains &&
+      rule.triggerWhen.diffContains.length > 0
+    ) {
+      triggers.push(
+        `<trigger-diff-contains>Fire if ANY of these appear in the diff content or file paths (case-insensitive): ${rule.triggerWhen.diffContains.map((p) => `"${this.escapeXML(p)}"`).join(", ")}</trigger-diff-contains>`,
+      );
+    }
+    return `    <rule name="${this.escapeXML(rule.name)}"${rule.description ? ` description="${this.escapeXML(rule.description)}"` : ""}>
+${triggers.map((t) => `      ${t}`).join("\n")}
+      <task-text>${this.escapeXML(rule.createTask.text)}</task-text>
+    </rule>`;
+  })
+  .join("\n")}
+  </conditional-task-rules>`
+        : "";
+
+    return `  <bitbucket-task-creation>
+    <enabled>true</enabled>
+    <severities>${severities}</severities>${keywordEnabled ? `\n    <task-keyword>${keyword}</task-keyword>` : ""}
+    <instructions>
+      PART A — Conditional task rules (evaluated ONCE in STEP 2, before file review):
+      After reading the PR's changed files list, evaluate each rule in
+      &lt;conditional-task-rules&gt;. If a rule's trigger is met, call
+      create_pr_task(workspace, repository, pull_request_id, text="&lt;rule task-text&gt;")
+      immediately. Fire each rule at most once.
+
+      PART B — Comment-to-task conversion (evaluated in STEP 3 per comment):
+      Tasks are created after inline comments via two trigger paths:
+
+      PATH 1 — Severity-based (automatic):
+      For every inline comment you post with severity in [${severities}]:
+
+      1. Post the comment with add_comment as normal.
+      2. Immediately call create_pr_task(workspace, repository, pull_request_id,
+            text="[SEVERITY] &lt;file_path&gt;:&lt;line&gt; — &lt;brief issue description&gt;").
+         This is unconditional — do NOT depend on or wait for the add_comment id.
+      3. Optional enhancement: also call convert_pr_item with:
+         - workspace, repository, pull_request_id (same as the review context)
+         - id: the comment.id value from the add_comment response JSON (nested under "comment" object, NOT a top-level field)
+         - direction: "to_task"
+         If convert_pr_item errors, ignore it — create_pr_task in step 2 already satisfies the requirement.
+      Do NOT move to the next file until create_pr_task has been called.
+${keywordPath}
+       RECONCILIATION MODE: If you decide NOT to call add_comment for a CRITICAL/MAJOR
+       finding because an existing comment already covers it (seen in STEP 2's
+       get_pull_request response), you MUST still call create_pr_task for that finding
+       (and optionally convert_pr_item with the existing comment's id).
+       Do not skip task creation just because the comment is from a prior run.
+
+      If both methods fail:
+      - The PR comment was already posted — do NOT skip it.
+      - Do NOT abort or pause the review.
+      - Continue to the next file.
+
+      ONLY convert/create comment-derived tasks for ${onlyClause}.
+      ${noTaskClause}
+      Do NOT call these tools inside explore_context.
+    </instructions>
+  </bitbucket-task-creation>${conditionalRulesBlock}`;
   }
 
   /**

--- a/src/v2/prompts/ReviewSystemPrompt.ts
+++ b/src/v2/prompts/ReviewSystemPrompt.ts
@@ -63,6 +63,18 @@ ${toolUsageSection}
     <level name="SUGGESTION" emoji="💬">Informational. Optimizations and improvements.</level>
   </severity-levels>
 
+  <!-- TASK_CREATE_BEGIN -->
+  <task-creation-rules>
+    <rule>In STEP 2, after reading the changed files list, evaluate every rule in &lt;conditional-task-rules&gt; (if present). If a rule's trigger is met, call create_pr_task once with the rule's task-text before starting the file-by-file review. Never fire the same rule twice.</rule>
+    <rule>After posting an inline comment whose severity matches the configured task-creation severities, immediately call convert_pr_item with the comment id and direction="to_task" to convert it into a Bitbucket task.</rule>
+    <rule>If the configured task keyword (e.g. "[TASK]") is present in the comment body, also call convert_pr_item — this applies at ANY severity, not just the configured severities. Use the keyword sparingly for non-critical findings that still require explicit developer acknowledgement.</rule>
+    <rule>If convert_pr_item fails or is unavailable (Bitbucket Cloud), fall back to create_pr_task with the issue text — never skip task creation because one method failed.</rule>
+    <rule>If both task creation methods fail, post the PR comment without a task — never abort the review because task creation failed.</rule>
+    <rule>NEVER call convert_pr_item or create_pr_task for MINOR or SUGGESTION comments unless they are explicitly listed in the &lt;bitbucket-task-creation&gt; severities or the comment body contains the configured task keyword.</rule>
+    <rule>NEVER call task creation tools inside explore_context — task creation is only allowed in the main review loop.</rule>
+  </task-creation-rules>
+  <!-- TASK_CREATE_END -->
+
   <anti-patterns>
     <dont>Request all files upfront — use lazy loading, one file at a time.</dont>
     <dont>Batch comments until the end — comment immediately as you find issues.</dont>
@@ -70,6 +82,13 @@ ${toolUsageSection}
     <dont>Use a code_snippet field — always use line_number and line_type from the diff JSON.</dont>
     <dont>Jump between files — finish one file before starting another.</dont>
     <dont>Duplicate an existing comment — check first; reply if a developer's response is wrong.</dont>
+    <dont>Call add_comment without first confirming you have a line_number and line_type sourced directly from the diff JSON output — never guess or infer these values.</dont>
+    <!-- TASK_CREATE_BEGIN -->
+    <dont>Create a task for every comment — only for severities listed in the &lt;bitbucket-task-creation&gt; config block, or when you explicitly append the configured task keyword to a comment body.</dont>
+    <dont>Call convert_pr_item before add_comment returns a comment id — post the comment first, then convert it.</dont>
+    <dont>Append the task keyword to every MINOR or SUGGESTION comment — use it sparingly for genuinely important findings that need explicit developer acknowledgement.</dont>
+    <dont>Fire a conditional task rule more than once per review — check once in STEP 2 and do not re-evaluate the same rule during the file-by-file review.</dont>
+    <!-- TASK_CREATE_END -->
   </anti-patterns>
 </yama-review-system>
 `;

--- a/src/v2/providers/ProviderToolset.ts
+++ b/src/v2/providers/ProviderToolset.ts
@@ -98,6 +98,12 @@ class BitbucketToolset implements ProviderToolset {
     "update_pull_request",
     "merge_pull_request",
     "delete_branch",
+    // Task creation tools — must not be called inside explore_context
+    "convert_pr_item",
+    "create_pr_task",
+    "update_pr_task",
+    "delete_pr_task",
+    "set_pr_task_status",
   ];
 
   /**
@@ -154,7 +160,22 @@ class BitbucketToolset implements ProviderToolset {
     <tool name="add_comment">
       <fields>file_path, line_number, line_type (ADDED|REMOVED|CONTEXT), comment_text, and suggestion (required for CRITICAL and MAJOR — must be real, executable code).</fields>
       <do-not-use-when>You only have a code_snippet but no line_number/line_type from the diff JSON.</do-not-use-when>
+      <returns>JSON with shape { "message": "...", "comment": { "id": &lt;number&gt;, ... } }. The comment ID is at comment.id (NOT a top-level id field). For CRITICAL/MAJOR you MUST call create_pr_task immediately after — do not skip to the next file first.</returns>
+      <task-keyword>When task creation is enabled, you may append the configured task keyword (e.g. "[TASK]") to comment_text for ANY severity to escalate that comment to a Bitbucket task. Use sparingly for non-critical findings that still require explicit developer acknowledgement.</task-keyword>
     </tool>
+
+    <!-- TASK_CREATE_BEGIN -->
+    <tool name="create_pr_task">
+      <use-when>MANDATORY — call immediately after every add_comment for a CRITICAL or MAJOR finding (or any comment where you appended the task keyword). No conditions, no dependencies on the add_comment response. Also used for conditional task rules in STEP 2.</use-when>
+      <fields>workspace, repository, pull_request_id, text (include severity, file path, line number, and a brief description: e.g. "[CRITICAL] src/foo.ts:12 — explicit any type").</fields>
+    </tool>
+
+    <tool name="convert_pr_item">
+      <use-when>Optional enhancement — AFTER create_pr_task succeeds, also call convert_pr_item to link the task to the inline comment. Pass id=&lt;comment.id from the add_comment response&gt; and direction="to_task". If it errors, ignore — the create_pr_task already covers the requirement.</use-when>
+      <do-not-use-when>Task creation is not enabled, or the finding is MINOR/SUGGESTION without the task keyword.</do-not-use-when>
+      <fields>workspace, repository, pull_request_id, id (comment.id from the add_comment response JSON), direction="to_task".</fields>
+    </tool>
+    <!-- TASK_CREATE_END -->
 
     <tool name="set_pr_approval">
       <use-when>No blocking issues found. Pass approved=true.</use-when>
@@ -183,6 +204,16 @@ class BitbucketToolset implements ProviderToolset {
     Call get_pull_request once to get changed files, branch info, and existing comments.
     Build a mental map of which files exist and which already have comments.
     Do NOT request the full PR diff.
+    <!-- TASK_CREATE_BEGIN -->
+    After reading the changed files list, immediately evaluate each rule in
+    &lt;conditional-task-rules&gt; (if present in the task context):
+      - For each rule: check whether any changed file path matches the rule's
+        trigger-files-match patterns, OR whether the diff/file-path content
+        matches trigger-diff-contains patterns, OR whether trigger-always is true.
+      - If the rule fires, call create_pr_task(workspace, repository,
+          pull_request_id, text="&lt;rule task-text&gt;") ONCE for that rule.
+      - Never re-evaluate a rule during the file-by-file review.
+    <!-- TASK_CREATE_END -->
 
     STEP 3 — Walk files one at a time
     For each changed file, in order:
@@ -191,8 +222,29 @@ class BitbucketToolset implements ProviderToolset {
       c. If anything is non-trivial — multi-file impact, unfamiliar pattern, unclear intent,
          history-dependent behavior — <!-- EXPLORE_BEGIN -->call explore_context with a precise
          task and wait for its evidence before commenting<!-- EXPLORE_END --><!-- EXPLORE_DISABLED_BEGIN -->use search_code or get_file_content to verify before commenting<!-- EXPLORE_DISABLED_END -->.
-      d. For every confirmed issue, call add_comment immediately with line_number and
-         line_type from the diff JSON. Include a real-code suggestion for CRITICAL/MAJOR.
+      d. For every confirmed issue, validate then post:
+         VALIDATE BEFORE add_comment: confirm you have (1) a line_number taken
+         directly from the diff JSON output (never guessed), (2) a line_type of
+         ADDED/REMOVED/CONTEXT from the same diff JSON, and (3) a non-empty,
+         substantive comment_text. Only call add_comment when all three checks pass.
+         Include a real-code suggestion for CRITICAL/MAJOR.
+           <!-- TASK_CREATE_BEGIN -->
+           MANDATORY — task creation for CRITICAL/MAJOR comments:
+            For CRITICAL or MAJOR findings (or any comment where you appended the task keyword):
+            1. Immediately call create_pr_task(workspace, repository, pull_request_id,
+                 text="[SEVERITY] &lt;file_path&gt;:&lt;line&gt; — &lt;brief issue&gt;").
+               This is unconditional — do NOT wait for or depend on the add_comment id.
+            2. Optional: also call convert_pr_item(workspace, repository, pull_request_id,
+                 id=&lt;comment.id from the add_comment response JSON&gt;, direction="to_task")
+                 to link the task to the inline comment. If it errors, ignore — the
+                 create_pr_task in step 1 already satisfies the requirement.
+            Do NOT proceed to the next file until create_pr_task has been called.
+            Never skip create_pr_task for CRITICAL/MAJOR — it has no preconditions.
+            RECONCILIATION MODE — if you decide NOT to call add_comment because an existing
+            CRITICAL/MAJOR comment already covers this file/line, you MUST still call
+            create_pr_task (and optionally convert_pr_item with the existing comment id).
+            Do not skip task creation simply because the comment was posted in a prior run.
+           <!-- TASK_CREATE_END -->
       e. Move to the next file. Never request another file's diff before finishing the
          current one. Never request a multi-file diff.
 
@@ -202,6 +254,9 @@ class BitbucketToolset implements ProviderToolset {
 
     STEP 5 — Summary comment
     Post one summary comment with file count, issue counts by severity, and next steps.
+    <!-- TASK_CREATE_BEGIN -->
+    Include the number of tasks created in the summary (e.g., "3 tasks created for CRITICAL/MAJOR findings").
+    <!-- TASK_CREATE_END -->
 
     Budget guidance: roughly 10 tool calls per file in the main loop. If you exceed
     that on a single file, <!-- EXPLORE_BEGIN -->delegate the rest to explore_context<!-- EXPLORE_END --><!-- EXPLORE_DISABLED_BEGIN -->stop investigating<!-- EXPLORE_DISABLED_END --> and move on.`;

--- a/src/v2/types/config.types.ts
+++ b/src/v2/types/config.types.ts
@@ -107,6 +107,101 @@ export interface BitbucketConfig {
   enabled?: boolean;
   /** List of tool names to block from Bitbucket MCP server */
   blockedTools?: string[];
+  /**
+   * Native Bitbucket PR task creation.
+   * When enabled, review findings of the configured severities are converted
+   * from inline comments into Bitbucket tasks — checklist items that must be
+   * resolved before the PR can be merged.
+   * Requires Bitbucket Server (self-hosted); not available on Bitbucket Cloud.
+   */
+  taskCreation?: BitbucketTaskCreationConfig;
+}
+
+/**
+ * A single conditional task rule.
+ * When the AI detects that a PR satisfies the trigger conditions, it calls
+ * create_pr_task once with the configured text. Rules are evaluated in STEP 2
+ * (after reading the PR shell / changed files list), before the file-by-file
+ * review starts. Each rule fires at most once per review.
+ *
+ * Example (Lighthouse repo yama.config.json):
+ *   {
+ *     "name": "automation-test-required",
+ *     "triggerWhen": {
+ *       "filesMatch": ["automation/", "ai-tab/"],
+ *       "diffContains": ["slash command", "AI tab"]
+ *     },
+ *     "createTask": {
+ *       "text": "Attach automation test cases and video proof for this PR."
+ *     }
+ *   }
+ */
+export interface ConditionalTaskRule {
+  /**
+   * Unique identifier for this rule.
+   * Appears in ReviewResult.tasks[].triggeredByRule for traceability.
+   */
+  name: string;
+  /** Optional human-readable explanation of when / why this rule fires. */
+  description?: string;
+  /**
+   * Trigger conditions. The rule fires when ANY condition below is met.
+   * The AI evaluates these semantically against the changed files and diff.
+   */
+  triggerWhen: {
+    /**
+     * File path patterns (glob-style or substring, case-insensitive).
+     * The rule fires if ANY changed file path matches ANY entry in this list.
+     * Examples: ["automation/", "src/ai-tab/", "slash"]
+     */
+    filesMatch?: string[];
+    /**
+     * Text / code patterns (case-insensitive substring).
+     * The rule fires if ANY of these appear in the diff content OR changed file paths.
+     * Examples: ["slash command", "AI tab", "automation suite"]
+     */
+    diffContains?: string[];
+    /**
+     * Always fire this rule for every PR review, regardless of changed files.
+     * Useful for org-wide mandatory checklists.
+     */
+    always?: boolean;
+  };
+  /** The PR-level task to create when this rule fires. */
+  createTask: {
+    /** Full task text shown on the Bitbucket PR checklist. */
+    text: string;
+  };
+}
+
+/**
+ * Configuration for converting specific review comments into Bitbucket PR tasks.
+ * Tasks are native Bitbucket checklist items that block PR merging until resolved.
+ * Uses the convert_pr_item MCP tool (Bitbucket Server only).
+ */
+export interface BitbucketTaskCreationConfig {
+  /** Master switch. Requires Bitbucket Server. */
+  enabled: boolean;
+  /**
+   * Which comment severities are automatically converted to tasks.
+   * Defaults to ["CRITICAL", "MAJOR"]. Set explicitly to include MINOR.
+   */
+  severities?: Array<"CRITICAL" | "MAJOR" | "MINOR" | "SUGGESTION">;
+  /**
+   * Keyword the AI appends to any comment body to escalate that specific
+   * comment to a Bitbucket task, regardless of its severity level.
+   * Defaults to "[TASK]". Set to "" to disable keyword-based task creation
+   * and rely solely on the configured severities.
+   */
+  taskKeyword?: string;
+  /**
+   * Conditional task rules evaluated once per review (after reading the
+   * changed files list) before the file-by-file review starts.
+   * Each rule creates a PR-level task when its trigger conditions are met.
+   * This is the primary mechanism for repo-specific mandatory checklists
+   * (e.g. "if PR touches automation code → require test evidence").
+   */
+  conditionalTaskRules?: ConditionalTaskRule[];
 }
 
 export interface GitHubConfig {

--- a/src/v2/types/mcp.types.ts
+++ b/src/v2/types/mcp.types.ts
@@ -111,6 +111,20 @@ export interface GetIssueResponse {
 }
 
 /**
+ * Response from a Bitbucket create_pr_task or convert_pr_item tool call.
+ * The `id` field is the Bitbucket task ID used to later resolve / re-open the task.
+ */
+export interface CreateBitbucketTaskResponse {
+  /** The task ID assigned by Bitbucket. */
+  id?: number | string;
+  /** Human-readable task text (echoed back on creation). */
+  text?: string;
+  /** Task state: "OPEN" or "RESOLVED". */
+  state?: string;
+  [key: string]: unknown;
+}
+
+/**
  * Code search response from a code-search tool call
  */
 export interface SearchCodeResponse {

--- a/src/v2/types/v2.types.ts
+++ b/src/v2/types/v2.types.ts
@@ -57,6 +57,37 @@ export interface LocalReviewRequest {
 
 export type UnifiedReviewRequest = ReviewRequest | LocalReviewRequest;
 
+/**
+ * A native Bitbucket PR task created from a review finding.
+ * Populated when bitbucket.taskCreation.enabled = true and the AI converts
+ * a CRITICAL / MAJOR (or configured severity) comment into a task.
+ */
+export interface CreatedTask {
+  /** The Bitbucket task ID returned by convert_pr_item or create_pr_task. */
+  taskId: string;
+  /** Text / summary of the created task. */
+  summary: string;
+  /** Severity of the review finding that triggered task creation. */
+  severity: "CRITICAL" | "MAJOR" | "MINOR" | "SUGGESTION";
+  /** File path the finding relates to, if applicable. */
+  filePath?: string;
+  /** Line number the finding relates to, if applicable. */
+  line?: number;
+  /** ID of the source comment that was converted to a task (convert_pr_item flow). */
+  sourceCommentId?: number;
+  /**
+   * True when the task was triggered by the AI appending the configured task
+   * keyword (e.g. "[TASK]") to the comment body, rather than purely by severity.
+   */
+  triggeredByKeyword?: boolean;
+  /**
+   * Name of the ConditionalTaskRule that triggered this task (if applicable).
+   * Set when the task was created by evaluating a conditionalTaskRules entry
+   * rather than by comment severity or keyword.
+   */
+  triggeredByRule?: string;
+}
+
 export interface ReviewResult {
   mode?: ReviewMode;
   prId: number;
@@ -69,6 +100,11 @@ export interface ReviewResult {
   sessionId: string;
   descriptionEnhanced?: boolean;
   totalComments?: number;
+  /**
+   * Jira tasks created during the review.
+   * Only populated when jira.taskCreation.enabled = true.
+   */
+  tasks?: CreatedTask[];
 }
 
 export interface LocalReviewFinding {
@@ -118,6 +154,8 @@ export interface ReviewStatistics {
   toolCallsMade: number;
   cacheHits: number;
   totalComments: number;
+  /** Number of Jira tasks created during this review (0 when task creation is disabled). */
+  tasksCreated: number;
 }
 
 export interface IssuesBySeverity {


### PR DESCRIPTION
# Pull Request

## Description

Add native Bitbucket pr task creation with conditional rules per repo 
## Type of Change


- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔧 Build/CI configuration change
- [ ] 🔒 Security enhancement

## Changes Made

- Add BitbucketTaskCreationConfig and ConditionalTaskRule types to config.types.ts
- Add CreatedTask type and tasks/tasksCreated fields to v2.types.ts
- Add CreateBitbucketTaskResponse to mcp.types.ts
- Set default taskCreation config (disabled, CRITICAL/MAJOR, [TASK] keyword) in DefaultConfig.ts
- Log task creation status on MCP init in MCPServerManager.ts
- Register convert_pr_item and create_pr_task tools in ProviderToolset.ts
- Inject conditional-task-rules XML and severity/keyword task paths into prompts via PromptBuilder.ts
- Add TASK_CREATE_BEGIN/END gated rules and anti-patterns in ReviewSystemPrompt.ts
- Implement extractCreatedTasks, inferSeverityAndTextFromCommentId, and calculateStatistics in YamaV2Orchestrator.ts

## Platform Impact

- [x] Bitbucket
- [ ] GitHub
- [ ] GitLab
- [ ] All platforms
- [ ] No platform-specific changes

## AI Provider Impact

- [ ] OpenAI
- [ ] Anthropic
- [ ] Google AI
- [ ] All providers
- [x] No AI provider changes

## Component Impact

- [x] CLI
- [x] Core Engine
- [ ] API Integration
- [x] AI Features
- [ ] Security
- [x] Configuration
- [ ] Documentation
- [ ] Tests

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

### Test Environment

- OS:
- Node.js version:
- Package manager:

## Performance Impact

- [x] No performance impact
- [ ] Performance improvement
- [ ] Minor performance impact (acceptable)
- [ ] Significant performance impact (needs discussion)

## Security Considerations

- [x] No security impact
- [ ] Security improvement
- [ ] Requires security review
- [ ] Changes API key handling
- [ ] Changes authentication flow

## Breaking Changes
- None. The feature is fully opt-in. bitbucket.taskCreation.enabled defaults to false, so existing repos see no change in behaviour until they explicitly add the config block to their yama.config.json.

## Configuration Changes

- [ ] No configuration changes
- [ ] New environment variables added
- [x] Configuration schema updated
- [ ] Breaking configuration changes

- A new optional taskCreation block is added under bitbucket in yama.config.json. 
- When disabled (default), the task creation instruction blocks are stripped from all prompts via TASK_CREATE_BEGIN/END markers, identical to how EXPLORE_BEGIN/END works.

## Screenshots/Demo


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md if needed
- [ ] I have verified that sensitive data is not exposed

## Additional Notes
- convert_pr_item is the primary tool (converts an existing comment into a Bitbucket task, preserving the comment thread). create_pr_task is used as a fallback and for conditional rules.
- conditionalTaskRules are evaluated by the AI in Step 2 (after reading changed files), before any per-file review begins, so rule-triggered tasks are created once per PR regardless of how many files are reviewed.
- The triggeredByRule and triggeredByKeyword fields on CreatedTask allow downstream consumers (e.g. dashboards, Jira sync) to distinguish how each task originated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Bitbucket task creation during PR reviews with configurable severity levels and keyword-based escalation.
  * Added conditional task rules to automatically create tasks based on specific criteria.
  * Added task management tools (create, update, delete, set status).

* **Configuration**
  * New task creation configuration options for Bitbucket with enablement flag, severity filters, and conditional rules.

* **Reporting**
  * Added task creation count to review statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->