### PR TITLE
fix(v2): bump neurolink to 9.70.7 and fix review/config correctness bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "check:all": "npm run lint && npm run format --check && npm run validate && npm run validate:commit"
   },
   "dependencies": {
-    "@juspay/neurolink": "^9.42.0",
+    "@juspay/neurolink": "^9.70.7",
+    "@juspay/hippocampus": "^0.1.7",
     "langfuse": "^3.35.0",
     "@nexus2520/bitbucket-mcp-server": "2.0.4",
     "@nexus2520/jira-mcp-server": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,12 @@ overrides:
 importers:
   .:
     dependencies:
+      "@juspay/hippocampus":
+        specifier: ^0.1.7
+        version: 0.1.7(@juspay/neurolink@9.70.7)
       "@juspay/neurolink":
-        specifier: ^9.42.0
-        version: 9.42.0(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@types/node@20.19.9)(encoding@0.1.13)(react@19.1.0)
+        specifier: ^9.70.7
+        version: 9.70.7(@cfworker/json-schema@4.1.1)(@juspay/hippocampus@0.1.7)(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@types/node@20.19.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)
       "@nexus2520/bitbucket-mcp-server":
         specifier: 2.0.4
         version: 2.0.4(@cfworker/json-schema@4.1.1)(debug@4.4.1)(zod@4.3.6)
@@ -179,37 +182,10 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  "@ai-sdk/azure@3.0.49":
-    resolution:
-      {
-        integrity: sha512-wskgAL+OmrHG7by/iWIxEBQCEdc1mDudha/UZav46i0auzdFfsDB/k2rXZaC4/3nWSgMZkxr0W3ncyouEGX/eg==,
-      }
-    engines: { node: ">=18" }
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
   "@ai-sdk/gateway@3.0.83":
     resolution:
       {
         integrity: sha512-LvlWujbSdEkTBXBLFtF7GS6riXdHhH0O+DpDrCaNQvXeHmSF2jKsOg7JWXiCgygAHM5cWFAO3JYmZp83DjiuBQ==,
-      }
-    engines: { node: ">=18" }
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  "@ai-sdk/google-vertex@4.0.95":
-    resolution:
-      {
-        integrity: sha512-xL44fHlTtDM7RLkMTgyqMfkfthA38JS91bbMaHItObIhte1PAIY936ZV1PLl/Z9A/oBAXjHWbXo5xDoHzB7LEg==,
-      }
-    engines: { node: ">=18" }
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  "@ai-sdk/google@3.0.53":
-    resolution:
-      {
-        integrity: sha512-uz8tIlkDgQJG9Js2Wh9JHzd4kI9+hYJqf9XXJLx60vyN5mRIqhr49iwR5zGP5Gl8odp2PeR3Gh2k+5bh3Z1HHw==,
       }
     engines: { node: ">=18" }
     peerDependencies:
@@ -233,15 +209,6 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  "@ai-sdk/provider-utils@2.2.8":
-    resolution:
-      {
-        integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==,
-      }
-    engines: { node: ">=18" }
-    peerDependencies:
-      zod: ^3.23.8
-
   "@ai-sdk/provider-utils@4.0.21":
     resolution:
       {
@@ -250,13 +217,6 @@ packages:
     engines: { node: ">=18" }
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
-
-  "@ai-sdk/provider@1.1.3":
-    resolution:
-      {
-        integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==,
-      }
-    engines: { node: ">=18" }
 
   "@ai-sdk/provider@3.0.8":
     resolution:
@@ -271,6 +231,24 @@ packages:
         integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==,
       }
     engines: { node: ">=6.0.0" }
+
+  "@anthropic-ai/sdk@0.102.0":
+    resolution:
+      {
+        integrity: sha512-cThh3KcPW3lzkFyTz1cjyhJvOVw45NkLMoowO2ZJ/76CBz44ADUon+NsjEc/PypAkARs72Xu8qxTnx6PAOTQUQ==,
+      }
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  "@anthropic-ai/vertex-sdk@0.16.1":
+    resolution:
+      {
+        integrity: sha512-NQSJTmHFqJP32W4I+UyZ42ioUkd8avdye259Cs+P9yhi+XdI4wk7sDVnmVNNTiMtN08WXyELnAQPG2gcLQFXdQ==,
+      }
 
   "@aws-crypto/crc32@5.2.0":
     resolution:
@@ -890,6 +868,12 @@ packages:
         integrity: sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==,
       }
 
+  "@bufbuild/protobuf@1.10.1":
+    resolution:
+      {
+        integrity: sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==,
+      }
+
   "@cfworker/json-schema@4.1.1":
     resolution:
       {
@@ -1030,6 +1014,12 @@ packages:
         integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==,
       }
     engines: { node: ">=12" }
+
+  "@datastructures-js/deque@1.0.8":
+    resolution:
+      {
+        integrity: sha512-PSBhJ2/SmeRPRHuBv7i/fHWIdSC3JTyq56qb+Rq0wjOagi0/fdV5/B/3Md5zFZus/W6OkSPMaxMKKMNMrSmubg==,
+      }
 
   "@derhuerst/http-basic@8.2.4":
     resolution:
@@ -1403,6 +1393,76 @@ packages:
         integrity: sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==,
       }
 
+  "@ffmpeg-installer/darwin-arm64@4.1.5":
+    resolution:
+      {
+        integrity: sha512-hYqTiP63mXz7wSQfuqfFwfLOfwwFChUedeCVKkBtl/cliaTM7/ePI9bVzfZ2c+dWu3TqCwLDRWNSJ5pqZl8otA==,
+      }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@ffmpeg-installer/darwin-x64@4.1.0":
+    resolution:
+      {
+        integrity: sha512-Z4EyG3cIFjdhlY8wI9aLUXuH8nVt7E9SlMVZtWvSPnm2sm37/yC2CwjUzyCQbJbySnef1tQwGG2Sx+uWhd9IAw==,
+      }
+    cpu: [x64]
+    os: [darwin]
+
+  "@ffmpeg-installer/ffmpeg@1.1.0":
+    resolution:
+      {
+        integrity: sha512-Uq4rmwkdGxIa9A6Bd/VqqYbT7zqh1GrT5/rFwCwKM70b42W5gIjWeVETq6SdcL0zXqDtY081Ws/iJWhr1+xvQg==,
+      }
+
+  "@ffmpeg-installer/linux-arm64@4.1.4":
+    resolution:
+      {
+        integrity: sha512-dljEqAOD0oIM6O6DxBW9US/FkvqvQwgJ2lGHOwHDDwu/pX8+V0YsDL1xqHbj1DMX/+nP9rxw7G7gcUvGspSoKg==,
+      }
+    cpu: [arm64]
+    os: [linux]
+
+  "@ffmpeg-installer/linux-arm@4.1.3":
+    resolution:
+      {
+        integrity: sha512-NDf5V6l8AfzZ8WzUGZ5mV8O/xMzRag2ETR6+TlGIsMHp81agx51cqpPItXPib/nAZYmo55Bl2L6/WOMI3A5YRg==,
+      }
+    cpu: [arm]
+    os: [linux]
+
+  "@ffmpeg-installer/linux-ia32@4.1.0":
+    resolution:
+      {
+        integrity: sha512-0LWyFQnPf+Ij9GQGD034hS6A90URNu9HCtQ5cTqo5MxOEc7Rd8gLXrJvn++UmxhU0J5RyRE9KRYstdCVUjkNOQ==,
+      }
+    cpu: [ia32]
+    os: [linux]
+
+  "@ffmpeg-installer/linux-x64@4.1.0":
+    resolution:
+      {
+        integrity: sha512-Y5BWhGLU/WpQjOArNIgXD3z5mxxdV8c41C+U15nsE5yF8tVcdCGet5zPs5Zy3Ta6bU7haGpIzryutqCGQA/W8A==,
+      }
+    cpu: [x64]
+    os: [linux]
+
+  "@ffmpeg-installer/win32-ia32@4.1.0":
+    resolution:
+      {
+        integrity: sha512-FV2D7RlaZv/lrtdhaQ4oETwoFUsUjlUiasiZLDxhEUPdNDWcH1OU9K1xTvqz+OXLdsmYelUDuBS/zkMOTtlUAw==,
+      }
+    cpu: [ia32]
+    os: [win32]
+
+  "@ffmpeg-installer/win32-x64@4.1.0":
+    resolution:
+      {
+        integrity: sha512-Drt5u2vzDnIONf4ZEkKtFlbvwj6rI3kxw1Ck9fpudmtgaZIHD4ucsWB2lCZBXRxJgXR+2IMSti+4rtM4C4rXgg==,
+      }
+    cpu: [x64]
+    os: [win32]
+
   "@google-cloud/text-to-speech@6.4.0":
     resolution:
       {
@@ -1428,13 +1488,6 @@ packages:
     peerDependenciesMeta:
       "@modelcontextprotocol/sdk":
         optional: true
-
-  "@google/generative-ai@0.24.1":
-    resolution:
-      {
-        integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==,
-      }
-    engines: { node: ">=18.0.0" }
 
   "@grpc/grpc-js@1.13.4":
     resolution:
@@ -1465,6 +1518,15 @@ packages:
         integrity: sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==,
       }
 
+  "@hono/node-server@1.19.14":
+    resolution:
+      {
+        integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==,
+      }
+    engines: { node: ">=18.14.1" }
+    peerDependencies:
+      hono: ^4
+
   "@hono/node-server@1.19.9":
     resolution:
       {
@@ -1473,6 +1535,14 @@ packages:
     engines: { node: ">=18.14.1" }
     peerDependencies:
       hono: ^4
+
+  "@huggingface/hub@2.4.1":
+    resolution:
+      {
+        integrity: sha512-g/EJG091aIdP1whpSjhqBOL25/m60NKXhYGz3wqp7hLX57r4Fx7QVFfXRbtxI0ZMQjLQV3GYrPtldz38mvOr+w==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
 
   "@huggingface/inference@4.13.15":
     resolution:
@@ -1492,6 +1562,18 @@ packages:
     resolution:
       {
         integrity: sha512-nfV9luJbvwGQ/5oKXkKhCV9h4X7mwh1YaGG3ORd6UMLDSwr1OFSSatcBX0O9OtBtmNK19aGSjbLFqqgcIR6+IA==,
+      }
+
+  "@huggingface/tokenizers@0.1.3":
+    resolution:
+      {
+        integrity: sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==,
+      }
+
+  "@huggingface/transformers@4.2.0":
+    resolution:
+      {
+        integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==,
       }
 
   "@humanfs/core@0.19.1":
@@ -2095,33 +2177,36 @@ packages:
         integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==,
       }
 
-  "@juspay/hippocampus@0.1.4":
+  "@juspay/hippocampus@0.1.7":
     resolution:
       {
-        integrity: sha512-RaIvL1A6I+L9A5NscCccO/EKKarJkC0zaeQ3hnA4HqAHlCoNtYF5lisMcY2nmmZNxKJHamqvXIRHgB67aT9xJg==,
+        integrity: sha512-Xua/pNvLst0TUanMHOb30+ZxsvJ2wDg2IH6rqz4dsszEQrTPi9hObTLpPCQOH28u/mgthYVx6XxAxzcHyaxXpA==,
       }
     engines: { node: ">=18" }
     peerDependencies:
-      "@juspay/neurolink": ">=9.0.0"
+      "@juspay/neurolink": ">=9.70.0"
       better-sqlite3: ">=11.0.0"
     peerDependenciesMeta:
       better-sqlite3:
         optional: true
 
-  "@juspay/neurolink@9.42.0":
+  "@juspay/neurolink@9.70.7":
     resolution:
       {
-        integrity: sha512-w4Z8xk4Z4+xroa6SHPsh+u1ctOsOpCYBvmtMYB3eMuDxa5QbGw3p/gfN3zfFponZ5rGIu8LcF/7Uu7BKDr/Tew==,
+        integrity: sha512-oZMOB6G6WzHFJDk47z6unbBBm9yIhYMg+REpSCCG+bc1bVHnBXsi1i79MJMh3hGjc4N5lq4w10KdJL+dFUb1Gw==,
       }
     engines: { node: ">=20.18.1", npm: ">=10.0.0", pnpm: ">=8.0.0" }
     os: [darwin, linux, win32]
     hasBin: true
     peerDependencies:
+      "@juspay/hippocampus": ">=0.1.4"
       "@opentelemetry/api": ^1.9.0
       "@opentelemetry/sdk-trace-node": ^2.0.0
       react: ">=18.0.0"
       react-dom: ">=18.0.0"
     peerDependenciesMeta:
+      "@juspay/hippocampus":
+        optional: true
       react:
         optional: true
       react-dom:
@@ -2162,6 +2247,156 @@ packages:
       "@opentelemetry/core": ^2.0.1
       "@opentelemetry/exporter-trace-otlp-http": ">=0.202.0 <1.0.0"
       "@opentelemetry/sdk-trace-base": ^2.0.1
+
+  "@livekit/agents-plugin-cartesia@1.4.6":
+    resolution:
+      {
+        integrity: sha512-3YUhb8hG4pNna7H3OgtXQehz4VN0zA73bs8WTm9Syo0DvwX8A8oOTa0+ReXuEF9r9M3O+F/YlzGaFIZbF5v3rA==,
+      }
+    peerDependencies:
+      "@livekit/agents": 1.4.6
+      "@livekit/rtc-node": ^0.13.29
+      zod: ^3.25.76 || ^4.1.8
+
+  "@livekit/agents-plugin-deepgram@1.4.6":
+    resolution:
+      {
+        integrity: sha512-G8bU8apRV7yhLO+aztDhTV0W9EZv0JYeNdP30oll+6TQY0HLQhNfacodu7BQCfCwbHuLkSIMQpZL0rZxSqT2mA==,
+      }
+    peerDependencies:
+      "@livekit/agents": 1.4.6
+      "@livekit/rtc-node": ^0.13.29
+
+  "@livekit/agents-plugin-elevenlabs@1.4.6":
+    resolution:
+      {
+        integrity: sha512-qvd5Eksqs2CjsSjLyop7AEOZ4nyOngWRrE2Z3Anhu4dxWLFWAZiWefLnwSh+J5ehom+B59MAbB862Iw+reRFow==,
+      }
+    peerDependencies:
+      "@livekit/agents": 1.4.6
+      "@livekit/rtc-node": ^0.13.29
+
+  "@livekit/agents-plugin-livekit@1.4.6":
+    resolution:
+      {
+        integrity: sha512-0t1vkLC+Uy1r1ZRJonzckwgXSY0LBl3kIXBpH9WGvIiTU4ar9qepaXfhpO6Ma1oJMj73Vu9NU/QLI98fZ6LnJA==,
+      }
+    peerDependencies:
+      "@livekit/agents": 1.4.6
+
+  "@livekit/agents-plugin-silero@1.4.6":
+    resolution:
+      {
+        integrity: sha512-2iIp94FMc+m8oJYq/+9QPHEjfqtZkcLlPEdYgtvRsy8EHpR7FJwPv7EoXNq2r+O+7tlK3+dwHVBpiY/uhQrb/Q==,
+      }
+    peerDependencies:
+      "@livekit/agents": 1.4.6
+      "@livekit/rtc-node": ^0.13.29
+
+  "@livekit/agents-plugin-soniox@1.4.6":
+    resolution:
+      {
+        integrity: sha512-BWiA+Y6e7N2yqukQ42matuH1J+VZYDvYZV7gN+PqU0PxZrMoMBMlT3UMuRT/VEz7vxlGUY/KO5af7Bo7RpuwwQ==,
+      }
+    peerDependencies:
+      "@livekit/agents": 1.4.6
+      "@livekit/rtc-node": ^0.13.29
+
+  "@livekit/agents@1.4.6":
+    resolution:
+      {
+        integrity: sha512-PsSlss2Av1sd4LpjOwP5UCatuMnXUEkGgl1oBhwBmDKFoTwSsha2+iV5NIbxC3vRi4LJ7vcHwzAxlcTc1aZw2Q==,
+      }
+    hasBin: true
+    peerDependencies:
+      "@livekit/rtc-node": ^0.13.29
+      zod: ^3.25.76 || ^4.1.8
+
+  "@livekit/mutex@1.1.1":
+    resolution:
+      {
+        integrity: sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==,
+      }
+
+  "@livekit/protocol@1.46.6":
+    resolution:
+      {
+        integrity: sha512-upzlHP1vi/kZ/QqALZTFskQ0ifqc2f15RKucHYOsIHJsaXvEYanG75mAb7o+Yomfs4XhQ4BaRsdY+TFHXpaqrg==,
+      }
+
+  "@livekit/rtc-ffi-bindings-darwin-arm64@0.12.60":
+    resolution:
+      {
+        integrity: sha512-YHXqybkYfaTc3txJXXWoVogiSP3yKJdkaZlIlZ6IDMGnN9elUoHDYU+ZSn/rbdGu0pp4HUOzffXkbkItN735Bw==,
+      }
+    engines: { node: ">= 18" }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@livekit/rtc-ffi-bindings-darwin-x64@0.12.60":
+    resolution:
+      {
+        integrity: sha512-SkPPWE2/nb2BAXrCWP6+vaR2I4EeyG3Vv+csUaa1EvDVMbFqBHWqNVTQcx/ChgecbYB9dIFZHVYpfjbFkVd84g==,
+      }
+    engines: { node: ">= 18" }
+    cpu: [x64]
+    os: [darwin]
+
+  "@livekit/rtc-ffi-bindings-linux-arm64-gnu@0.12.60":
+    resolution:
+      {
+        integrity: sha512-8umeMn9p/VZ41EGty1qX9zPV5mfGxCioYKeUnALpf8AKqT/yXDjnog1VkS5f8gFX/zY7HDaeE+s60nZXaOZJbw==,
+      }
+    engines: { node: ">= 18" }
+    cpu: [arm64]
+    os: [linux]
+
+  "@livekit/rtc-ffi-bindings-linux-x64-gnu@0.12.60":
+    resolution:
+      {
+        integrity: sha512-ttWrR/e8Ghaa9I+LaStxK8lh+aA9QBz6Dge6eXyKwTrAMHwHEtL2Rnf1rHQTiwadeH7AoytpfWf5FZl/OelLaQ==,
+      }
+    engines: { node: ">= 18" }
+    cpu: [x64]
+    os: [linux]
+
+  "@livekit/rtc-ffi-bindings-win32-x64-msvc@0.12.60":
+    resolution:
+      {
+        integrity: sha512-HfOBEf3rmpsG7hU3/BM9x2jnkVwKFve2v3cyjxlk41d6OkCthYb+g/ULEPFBKPafYyepDwcd2c8MDo5fMM+4Zw==,
+      }
+    engines: { node: ">= 18" }
+    cpu: [x64]
+    os: [win32]
+
+  "@livekit/rtc-ffi-bindings@0.12.60":
+    resolution:
+      {
+        integrity: sha512-ZJD2DNoHfR8PzKeyDMH6i1zKpk7S4LlrQDIZvisxj6HPaJnKofzSssNMF8fpGFvVCZ844kbcOFogRPgHFno82w==,
+      }
+    engines: { node: ">= 18" }
+
+  "@livekit/rtc-node@0.13.29":
+    resolution:
+      {
+        integrity: sha512-3/mhTVW3zEa8u0l2UzLe74CyDxaz/1Fqrss+monBJARYHyMGMiDlnKAwDT2LiFkRy0xBjl2QY8Yldr0icfPUkw==,
+      }
+    engines: { node: ">= 18" }
+
+  "@livekit/throws-transformer@0.1.8":
+    resolution:
+      {
+        integrity: sha512-AaSwQfIaG6YArKOCO+5/DgI8HfL19oHdrkyI0LJJVCqGeZXzPsZIO/Nm/SKUHbT1ERGhF5c34X8CcVWeOePpIQ==,
+      }
+    hasBin: true
+    peerDependencies:
+      typescript: ">=4.7.0"
+
+  "@livekit/typed-emitter@3.0.0":
+    resolution:
+      {
+        integrity: sha512-9bl0k4MgBPZu3Qu3R3xy12rmbW17e3bE9yf4YY85gJIQ3ezLEj/uzpKHWBsLaDoL5Mozz8QCgggwIBudYQWeQg==,
+      }
 
   "@lukeed/ms@2.0.2":
     resolution:
@@ -2577,20 +2812,10 @@ packages:
         integrity: sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==,
       }
 
-  "@openrouter/ai-sdk-provider@2.3.3":
+  "@opentelemetry/api-logs@0.208.0":
     resolution:
       {
-        integrity: sha512-4fVteGkVedc7fGoA9+qJs4tpYwALezMq14m2Sjub3KmyRlksCbK+WJf67NPdGem8+NZrV2tAN42A1NU3+SiV3w==,
-      }
-    engines: { node: ">=18" }
-    peerDependencies:
-      ai: ^6.0.0
-      zod: ^3.25.0 || ^4.0.0
-
-  "@opentelemetry/api-logs@0.213.0":
-    resolution:
-      {
-        integrity: sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==,
+        integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==,
       }
     engines: { node: ">=8.0.0" }
 
@@ -2601,12 +2826,28 @@ packages:
       }
     engines: { node: ">=8.0.0" }
 
+  "@opentelemetry/api-logs@0.54.2":
+    resolution:
+      {
+        integrity: sha512-4MTVwwmLgUh5QrJnZpYo6YRO5IBLAggf2h8gWDblwRagDStY13aEvt7gGk3jewrMaPlHiF83fENhIx0HO97/cQ==,
+      }
+    engines: { node: ">=14" }
+
   "@opentelemetry/api@1.9.0":
     resolution:
       {
         integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==,
       }
     engines: { node: ">=8.0.0" }
+
+  "@opentelemetry/context-async-hooks@1.30.1":
+    resolution:
+      {
+        integrity: sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@opentelemetry/api": ">=1.0.0 <1.10.0"
 
   "@opentelemetry/context-async-hooks@2.2.0":
     resolution:
@@ -2626,19 +2867,28 @@ packages:
     peerDependencies:
       "@opentelemetry/api": ">=1.0.0 <1.10.0"
 
+  "@opentelemetry/core@1.27.0":
+    resolution:
+      {
+        integrity: sha512-yQPKnK5e+76XuiqUH/gKyS8wv/7qITd5ln56QkBTf3uggr0VkXOXfcaAuG330UfdYu83wsyoBwqwxigpIG+Jkg==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@opentelemetry/api": ">=1.0.0 <1.10.0"
+
+  "@opentelemetry/core@1.30.1":
+    resolution:
+      {
+        integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@opentelemetry/api": ">=1.0.0 <1.10.0"
+
   "@opentelemetry/core@2.2.0":
     resolution:
       {
         integrity: sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==,
-      }
-    engines: { node: ^18.19.0 || >=20.6.0 }
-    peerDependencies:
-      "@opentelemetry/api": ">=1.0.0 <1.10.0"
-
-  "@opentelemetry/core@2.6.0":
-    resolution:
-      {
-        integrity: sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
@@ -2662,6 +2912,15 @@ packages:
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
+  "@opentelemetry/exporter-logs-otlp-proto@0.54.2":
+    resolution:
+      {
+        integrity: sha512-agrzFbSNmIy6dhkyg41ERlEDUDqkaUJj2n/tVRFp9Tl+6wyNVPsqmwU5RWJOXpyK+lYH/znv6A47VpTeJF0lrw==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@opentelemetry/api": ^1.3.0
+
   "@opentelemetry/exporter-metrics-otlp-http@0.214.0":
     resolution:
       {
@@ -2671,19 +2930,46 @@ packages:
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/exporter-trace-otlp-http@0.213.0":
+  "@opentelemetry/exporter-trace-otlp-http@0.214.0":
     resolution:
       {
-        integrity: sha512-tnRmJD39aWrE/Sp7F6AbRNAjKHToDkAqBi6i0lESpGWz3G+f4bhVAV6mgSXH2o18lrDVJXo6jf9bAywQw43wRA==,
+        integrity: sha512-kIN8nTBMgV2hXzV/a20BCFilPZdAIMYYJGSgfMMRm/Xa+07y5hRDS2Vm12A/z8Cdu3Sq++ZvJfElokX2rkgGgw==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/otlp-exporter-base@0.213.0":
+  "@opentelemetry/exporter-trace-otlp-proto@0.54.2":
     resolution:
       {
-        integrity: sha512-MegxAP1/n09Ob2dQvY5NBDVjAFkZRuKtWKxYev1R2M8hrsgXzQGkaMgoEKeUOyQ0FUyYcO29UOnYdQWmWa0PXg==,
+        integrity: sha512-XSmm1N2wAhoWDXP1q/N6kpLebWaxl6VIADv4WA5QWKHLRpF3gLz5NAWNJBR8ygsvv8jQcrwnXgwfnJ18H3v1fg==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@opentelemetry/api": ^1.3.0
+
+  "@opentelemetry/instrumentation-pino@0.43.0":
+    resolution:
+      {
+        integrity: sha512-jlOOgbODWRRNknWXY1VLgmqgG0SO4kLgU3XnejjO/3De4OisroAsMGk+1cRB5AQ6WZ8WLAMkMyTShaOe6j2Asw==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@opentelemetry/api": ^1.3.0
+
+  "@opentelemetry/instrumentation@0.54.2":
+    resolution:
+      {
+        integrity: sha512-go6zpOVoZVztT9r1aPd79Fr3OWiD4N24bCPJsIKkBses8oyFo12F/Ew3UBTdIu6hsW4HC4MVEJygG6TEyJI/lg==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@opentelemetry/api": ^1.3.0
+
+  "@opentelemetry/otlp-exporter-base@0.208.0":
+    resolution:
+      {
+        integrity: sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
@@ -2698,10 +2984,19 @@ packages:
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/otlp-transformer@0.213.0":
+  "@opentelemetry/otlp-exporter-base@0.54.2":
     resolution:
       {
-        integrity: sha512-RSuAlxFFPjeK4d5Y6ps8L2WhaQI6CXWllIjvo5nkAlBpmq2XdYWEBGiAbOF4nDs8CX4QblJDv5BbMUft3sEfDw==,
+        integrity: sha512-NrNyxu6R/bGAwanhz1HI0aJWKR6xUED4TjCH4iWMlAfyRukGbI9Kt/Akd2sYLwRKNhfS+sKetKGCUQPMDyYYMA==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@opentelemetry/api": ^1.3.0
+
+  "@opentelemetry/otlp-transformer@0.208.0":
+    resolution:
+      {
+        integrity: sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
@@ -2716,19 +3011,55 @@ packages:
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
+  "@opentelemetry/otlp-transformer@0.54.2":
+    resolution:
+      {
+        integrity: sha512-2tIjahJlMRRUz0A2SeE+qBkeBXBFkSjR0wqJ08kuOqaL8HNGan5iZf+A8cfrfmZzPUuMKCyY9I+okzFuFs6gKQ==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@opentelemetry/api": ^1.3.0
+
+  "@opentelemetry/propagator-b3@1.30.1":
+    resolution:
+      {
+        integrity: sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@opentelemetry/api": ">=1.0.0 <1.10.0"
+
+  "@opentelemetry/propagator-jaeger@1.30.1":
+    resolution:
+      {
+        integrity: sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@opentelemetry/api": ">=1.0.0 <1.10.0"
+
+  "@opentelemetry/resources@1.27.0":
+    resolution:
+      {
+        integrity: sha512-jOwt2VJ/lUD5BLc+PMNymDrUCpm5PKi1E9oSVYAvz01U/VdndGmrtV3DU1pG4AwlYhJRHbHfOUIlpBeXCPw6QQ==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@opentelemetry/api": ">=1.0.0 <1.10.0"
+
+  "@opentelemetry/resources@1.30.1":
+    resolution:
+      {
+        integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@opentelemetry/api": ">=1.0.0 <1.10.0"
+
   "@opentelemetry/resources@2.2.0":
     resolution:
       {
         integrity: sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==,
-      }
-    engines: { node: ^18.19.0 || >=20.6.0 }
-    peerDependencies:
-      "@opentelemetry/api": ">=1.3.0 <1.10.0"
-
-  "@opentelemetry/resources@2.6.0":
-    resolution:
-      {
-        integrity: sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
@@ -2743,10 +3074,10 @@ packages:
     peerDependencies:
       "@opentelemetry/api": ">=1.3.0 <1.10.0"
 
-  "@opentelemetry/sdk-logs@0.213.0":
+  "@opentelemetry/sdk-logs@0.208.0":
     resolution:
       {
-        integrity: sha512-00xlU3GZXo3kXKve4DLdrAL0NAFUaZ9appU/mn00S/5kSUdAvyYsORaDUfR04Mp2CLagAOhrzfUvYozY/EZX2g==,
+        integrity: sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
@@ -2761,10 +3092,28 @@ packages:
     peerDependencies:
       "@opentelemetry/api": ">=1.4.0 <1.10.0"
 
-  "@opentelemetry/sdk-metrics@2.6.0":
+  "@opentelemetry/sdk-logs@0.54.2":
     resolution:
       {
-        integrity: sha512-CicxWZxX6z35HR83jl+PLgtFgUrKRQ9LCXyxgenMnz5A1lgYWfAog7VtdOvGkJYyQgMNPhXQwkYrDLujk7z1Iw==,
+        integrity: sha512-yIbYqDLS/AtBbPjCjh6eSToGNRMqW2VR8RrKEy+G+J7dFG7pKoptTH5T+XlKPleP9NY8JZYIpgJBlI+Osi0rFw==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@opentelemetry/api": ">=1.4.0 <1.10.0"
+
+  "@opentelemetry/sdk-metrics@1.27.0":
+    resolution:
+      {
+        integrity: sha512-JzWgzlutoXCydhHWIbLg+r76m+m3ncqvkCcsswXAQ4gqKS+LOHKhq+t6fx1zNytvLuaOUBur7EvWxECc4jPQKg==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@opentelemetry/api": ">=1.3.0 <1.10.0"
+
+  "@opentelemetry/sdk-metrics@2.2.0":
+    resolution:
+      {
+        integrity: sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
@@ -2779,19 +3128,28 @@ packages:
     peerDependencies:
       "@opentelemetry/api": ">=1.9.0 <1.10.0"
 
+  "@opentelemetry/sdk-trace-base@1.27.0":
+    resolution:
+      {
+        integrity: sha512-btz6XTQzwsyJjombpeqCX6LhiMQYpzt2pIYNPnw0IPO/3AhT6yjnf8Mnv3ZC2A4eRYOjqrg+bfaXg9XHDRJDWQ==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@opentelemetry/api": ">=1.0.0 <1.10.0"
+
+  "@opentelemetry/sdk-trace-base@1.30.1":
+    resolution:
+      {
+        integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@opentelemetry/api": ">=1.0.0 <1.10.0"
+
   "@opentelemetry/sdk-trace-base@2.2.0":
     resolution:
       {
         integrity: sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==,
-      }
-    engines: { node: ^18.19.0 || >=20.6.0 }
-    peerDependencies:
-      "@opentelemetry/api": ">=1.3.0 <1.10.0"
-
-  "@opentelemetry/sdk-trace-base@2.6.0":
-    resolution:
-      {
-        integrity: sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
@@ -2806,6 +3164,15 @@ packages:
     peerDependencies:
       "@opentelemetry/api": ">=1.3.0 <1.10.0"
 
+  "@opentelemetry/sdk-trace-node@1.30.1":
+    resolution:
+      {
+        integrity: sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      "@opentelemetry/api": ">=1.0.0 <1.10.0"
+
   "@opentelemetry/sdk-trace-node@2.2.0":
     resolution:
       {
@@ -2815,12 +3182,34 @@ packages:
     peerDependencies:
       "@opentelemetry/api": ">=1.0.0 <1.10.0"
 
+  "@opentelemetry/semantic-conventions@1.27.0":
+    resolution:
+      {
+        integrity: sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==,
+      }
+    engines: { node: ">=14" }
+
+  "@opentelemetry/semantic-conventions@1.28.0":
+    resolution:
+      {
+        integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==,
+      }
+    engines: { node: ">=14" }
+
   "@opentelemetry/semantic-conventions@1.40.0":
     resolution:
       {
         integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==,
       }
     engines: { node: ">=14" }
+
+  "@picovoice/cobra-node@3.0.3":
+    resolution:
+      {
+        integrity: sha512-bXJcj9VWOW5V/TMVPh6frMPfN1yfHOYk2FWJILWTQwe4nc/SoO+Rok4TkfUvME87+gWWTfpQr8EUIRqC8m4l0g==,
+      }
+    engines: { node: ">=18.0.0" }
+    cpu: ["!ia32", "!mips", "!ppc", "!ppc64"]
 
   "@pinojs/redact@0.4.0":
     resolution:
@@ -3509,6 +3898,12 @@ packages:
       }
     engines: { node: ">=18.0.0" }
 
+  "@stablelib/base64@1.0.1":
+    resolution:
+      {
+        integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==,
+      }
+
   "@standard-schema/spec@1.1.0":
     resolution:
       {
@@ -3678,10 +4073,22 @@ packages:
         integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==,
       }
 
+  "@types/pidusage@2.0.5":
+    resolution:
+      {
+        integrity: sha512-MIiyZI4/MK9UGUXWt0jJcCZhVw7YdhBuTOuqP/BjuLDLZ2PmmViMIQgZiWxtaMicQfAz/kMrZ5T7PKxFSkTeUA==,
+      }
+
   "@types/retry@0.12.0":
     resolution:
       {
         integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==,
+      }
+
+  "@types/shimmer@1.2.0":
+    resolution:
+      {
+        integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==,
       }
 
   "@types/stack-utils@2.0.3":
@@ -3824,6 +4231,13 @@ packages:
     engines: { node: ">=10.0.0" }
     deprecated: this version has critical issues, please update to the latest version
 
+  abort-controller@3.0.0:
+    resolution:
+      {
+        integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==,
+      }
+    engines: { node: ">=6.5" }
+
   abstract-logging@2.0.1:
     resolution:
       {
@@ -3843,6 +4257,14 @@ packages:
         integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==,
       }
     engines: { node: ">= 0.6" }
+
+  acorn-import-attributes@1.9.5:
+    resolution:
+      {
+        integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==,
+      }
+    peerDependencies:
+      acorn: ^8
 
   acorn-jsx@5.3.2:
     resolution:
@@ -4175,6 +4597,13 @@ packages:
         integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
       }
 
+  balanced-match@4.0.4:
+    resolution:
+      {
+        integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==,
+      }
+    engines: { node: 18 || 20 || >=22 }
+
   bare-events@2.8.2:
     resolution:
       {
@@ -4298,6 +4727,13 @@ packages:
       }
     engines: { node: ">=18" }
 
+  boolean@3.2.0:
+    resolution:
+      {
+        integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==,
+      }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   bottleneck@2.19.5:
     resolution:
       {
@@ -4321,6 +4757,13 @@ packages:
       {
         integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==,
       }
+
+  brace-expansion@5.0.6:
+    resolution:
+      {
+        integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==,
+      }
+    engines: { node: 18 || 20 || >=22 }
 
   braces@3.0.3:
     resolution:
@@ -4381,6 +4824,12 @@ packages:
         integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==,
       }
 
+  buffer@6.0.3:
+    resolution:
+      {
+        integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==,
+      }
+
   buffers@0.1.1:
     resolution:
       {
@@ -4429,6 +4878,13 @@ packages:
       }
     engines: { node: ">=6" }
 
+  camelcase-keys@9.1.3:
+    resolution:
+      {
+        integrity: sha512-Rircqi9ch8AnZscQcsA1C47NFdaO3wukpmIRzYcDOrmvgt78hM/sj5pZhZNec2NM12uk5vTwRHZ4anGcrC4ZTg==,
+      }
+    engines: { node: ">=16" }
+
   camelcase@5.3.1:
     resolution:
       {
@@ -4443,18 +4899,18 @@ packages:
       }
     engines: { node: ">=10" }
 
+  camelcase@8.0.0:
+    resolution:
+      {
+        integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==,
+      }
+    engines: { node: ">=16" }
+
   caniuse-lite@1.0.30001727:
     resolution:
       {
         integrity: sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==,
       }
-
-  canvas@3.2.2:
-    resolution:
-      {
-        integrity: sha512-duEt4h1HHu9sJZyVKfLRXR6tsKPY7cEELzxSRJkwddOXYvQT3P/+es98SV384JA0zMOZ5s+9gatnGfM6sL4Drg==,
-      }
-    engines: { node: ^18.12.0 || >= 20.9.0 }
 
   caseless@0.12.0:
     resolution:
@@ -4521,12 +4977,6 @@ packages:
         integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==,
       }
     engines: { node: ">= 8.10.0" }
-
-  chownr@1.1.4:
-    resolution:
-      {
-        integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==,
-      }
 
   ci-info@3.9.0:
     resolution:
@@ -4725,6 +5175,13 @@ packages:
       }
     engines: { node: ">=16" }
 
+  commander@12.1.0:
+    resolution:
+      {
+        integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==,
+      }
+    engines: { node: ">=18" }
+
   commander@13.1.0:
     resolution:
       {
@@ -4743,12 +5200,6 @@ packages:
     resolution:
       {
         integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==,
-      }
-
-  complex.js@2.4.2:
-    resolution:
-      {
-        integrity: sha512-qtx7HRhPGSCBtGiST4/WGHuW+zeaND/6Ld+db6PbrulIB1i2Ev/2UPiqcmpQNPSyfBKraC0EOvOKCB5dGZKt3g==,
       }
 
   compress-commons@4.1.2:
@@ -4971,6 +5422,12 @@ packages:
         integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==,
       }
 
+  dateformat@4.6.3:
+    resolution:
+      {
+        integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==,
+      }
+
   dayjs@1.11.19:
     resolution:
       {
@@ -5000,19 +5457,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  decimal.js@10.6.0:
-    resolution:
-      {
-        integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==,
-      }
-
-  decompress-response@6.0.0:
-    resolution:
-      {
-        integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==,
-      }
-    engines: { node: ">=10" }
 
   dedent@1.6.0:
     resolution:
@@ -5071,12 +5515,26 @@ packages:
         integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==,
       }
 
+  define-data-property@1.1.4:
+    resolution:
+      {
+        integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==,
+      }
+    engines: { node: ">= 0.4" }
+
   define-lazy-prop@3.0.0:
     resolution:
       {
         integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==,
       }
     engines: { node: ">=12" }
+
+  define-properties@1.2.1:
+    resolution:
+      {
+        integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==,
+      }
+    engines: { node: ">= 0.4" }
 
   delayed-stream@1.0.0:
     resolution:
@@ -5119,6 +5577,12 @@ packages:
       }
     engines: { node: ">=6" }
 
+  destr@2.0.5:
+    resolution:
+      {
+        integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==,
+      }
+
   destroy@1.2.0:
     resolution:
       {
@@ -5146,6 +5610,12 @@ packages:
         integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==,
       }
     engines: { node: ">=8" }
+
+  detect-node@2.1.0:
+    resolution:
+      {
+        integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==,
+      }
 
   diff-sequences@29.6.3:
     resolution:
@@ -5384,6 +5854,12 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  es6-error@4.1.1:
+    resolution:
+      {
+        integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==,
+      }
+
   esbuild@0.25.12:
     resolution:
       {
@@ -5403,12 +5879,6 @@ packages:
     resolution:
       {
         integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==,
-      }
-
-  escape-latex@1.2.0:
-    resolution:
-      {
-        integrity: sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==,
       }
 
   escape-string-regexp@1.0.5:
@@ -5523,6 +5993,13 @@ packages:
       }
     engines: { node: ">= 0.6" }
 
+  event-target-shim@5.0.1:
+    resolution:
+      {
+        integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==,
+      }
+    engines: { node: ">=6" }
+
   eventemitter3@5.0.1:
     resolution:
       {
@@ -5535,6 +6012,13 @@ packages:
         integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==,
       }
 
+  events@3.3.0:
+    resolution:
+      {
+        integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==,
+      }
+    engines: { node: ">=0.8.x" }
+
   eventsource-parser@3.0.3:
     resolution:
       {
@@ -5546,6 +6030,13 @@ packages:
     resolution:
       {
         integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==,
+      }
+    engines: { node: ">=18.0.0" }
+
+  eventsource-parser@3.1.0:
+    resolution:
+      {
+        integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==,
       }
     engines: { node: ">=18.0.0" }
 
@@ -5590,13 +6081,6 @@ packages:
         integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==,
       }
     engines: { node: ">= 0.8.0" }
-
-  expand-template@2.0.3:
-    resolution:
-      {
-        integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==,
-      }
-    engines: { node: ">=6" }
 
   expect@29.7.0:
     resolution:
@@ -5644,6 +6128,18 @@ packages:
     resolution:
       {
         integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==,
+      }
+
+  fast-copy@3.0.2:
+    resolution:
+      {
+        integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==,
+      }
+
+  fast-copy@4.0.3:
+    resolution:
+      {
+        integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==,
       }
 
   fast-csv@4.3.6:
@@ -5702,6 +6198,25 @@ packages:
         integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==,
       }
 
+  fast-redact@3.5.0:
+    resolution:
+      {
+        integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==,
+      }
+    engines: { node: ">=6" }
+
+  fast-safe-stringify@2.1.1:
+    resolution:
+      {
+        integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==,
+      }
+
+  fast-sha256@1.3.0:
+    resolution:
+      {
+        integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==,
+      }
+
   fast-string-truncated-width@3.0.3:
     resolution:
       {
@@ -5745,10 +6260,10 @@ packages:
         integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==,
       }
 
-  fastify@5.8.2:
+  fastify@5.8.5:
     resolution:
       {
-        integrity: sha512-lZmt3navvZG915IE+f7/TIVamxIwmBd+OMB+O9WBzcpIwOo6F0LTh0sluoMFk5VkrKTvvrwIaoJPkir4Z+jtAg==,
+        integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==,
       }
 
   fastq@1.19.1:
@@ -5881,6 +6396,12 @@ packages:
       }
     engines: { node: ">=16" }
 
+  flatbuffers@25.9.23:
+    resolution:
+      {
+        integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==,
+      }
+
   flatted@3.3.3:
     resolution:
       {
@@ -5921,6 +6442,13 @@ packages:
       }
     engines: { node: ">= 6" }
 
+  form-data@4.0.6:
+    resolution:
+      {
+        integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==,
+      }
+    engines: { node: ">= 6" }
+
   formdata-polyfill@4.0.10:
     resolution:
       {
@@ -5934,13 +6462,6 @@ packages:
         integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==,
       }
     engines: { node: ">= 0.6" }
-
-  fraction.js@5.2.2:
-    resolution:
-      {
-        integrity: sha512-uXBDv5knpYmv/2gLzWQ5mBHGBRk9wcKTeWu6GLTUEQfjCxO09uM/mHDrojlL+Q1mVGIIFo149Gba7od1XPgSzQ==,
-      }
-    engines: { node: ">= 12" }
 
   fresh@0.5.2:
     resolution:
@@ -6148,12 +6669,6 @@ packages:
         integrity: sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ==,
       }
 
-  github-from-package@0.0.0:
-    resolution:
-      {
-        integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==,
-      }
-
   glob-parent@5.1.2:
     resolution:
       {
@@ -6176,6 +6691,13 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@13.0.6:
+    resolution:
+      {
+        integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==,
+      }
+    engines: { node: 18 || 20 || >=22 }
+
   glob@7.2.3:
     resolution:
       {
@@ -6183,12 +6705,26 @@ packages:
       }
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
+  global-agent@3.0.0:
+    resolution:
+      {
+        integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==,
+      }
+    engines: { node: ">=10.0" }
+
   globals@14.0.0:
     resolution:
       {
         integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==,
       }
     engines: { node: ">=18" }
+
+  globalthis@1.0.4:
+    resolution:
+      {
+        integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   globby@11.1.0:
     resolution:
@@ -6271,6 +6807,12 @@ packages:
       }
     engines: { node: ">=14.0.0" }
 
+  guid-typescript@1.0.9:
+    resolution:
+      {
+        integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==,
+      }
+
   handlebars@4.7.8:
     resolution:
       {
@@ -6293,6 +6835,12 @@ packages:
       }
     engines: { node: ">=8" }
 
+  has-property-descriptors@1.0.2:
+    resolution:
+      {
+        integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==,
+      }
+
   has-symbols@1.1.0:
     resolution:
       {
@@ -6314,6 +6862,26 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  hasown@2.0.4:
+    resolution:
+      {
+        integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==,
+      }
+    engines: { node: ">= 0.4" }
+
+  heap-js@2.7.1:
+    resolution:
+      {
+        integrity: sha512-EQfezRg0NCZGNlhlDR3Evrw1FVL2G3LhU7EgPoxufQKruNBSYA8MiRPHeWbU+36o+Fhel0wMwM+sLEiBAlNLJA==,
+      }
+    engines: { node: ">=10.0.0" }
+
+  help-me@5.0.0:
+    resolution:
+      {
+        integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==,
+      }
+
   highlight.js@10.7.3:
     resolution:
       {
@@ -6324,6 +6892,13 @@ packages:
     resolution:
       {
         integrity: sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==,
+      }
+    engines: { node: ">=16.9.0" }
+
+  hono@4.12.25:
+    resolution:
+      {
+        integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==,
       }
     engines: { node: ">=16.9.0" }
 
@@ -6526,6 +7101,12 @@ packages:
         integrity: sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==,
       }
     engines: { node: ">=18.20" }
+
+  import-in-the-middle@1.15.0:
+    resolution:
+      {
+        integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==,
+      }
 
   import-local@3.2.0:
     resolution:
@@ -6913,12 +7494,6 @@ packages:
       }
     engines: { node: ">= 0.6.0" }
 
-  javascript-natural-sort@0.7.1:
-    resolution:
-      {
-        integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==,
-      }
-
   jest-changed-files@29.7.0:
     resolution:
       {
@@ -7126,11 +7701,24 @@ packages:
       node-notifier:
         optional: true
 
+  jose@5.10.0:
+    resolution:
+      {
+        integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==,
+      }
+
   jose@6.1.3:
     resolution:
       {
         integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==,
       }
+
+  joycon@3.1.1:
+    resolution:
+      {
+        integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==,
+      }
+    engines: { node: ">=10" }
 
   js-tokens@4.0.0:
     resolution:
@@ -7190,6 +7778,13 @@ packages:
         integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==,
       }
 
+  json-schema-to-ts@3.1.1:
+    resolution:
+      {
+        integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==,
+      }
+    engines: { node: ">=16" }
+
   json-schema-to-zod@2.8.0:
     resolution:
       {
@@ -7227,6 +7822,12 @@ packages:
         integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==,
       }
 
+  json-stringify-safe@5.0.1:
+    resolution:
+      {
+        integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==,
+      }
+
   json5@2.2.3:
     resolution:
       {
@@ -7252,6 +7853,13 @@ packages:
       {
         integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==,
       }
+
+  jsonrepair@3.14.0:
+    resolution:
+      {
+        integrity: sha512-tWPGKMZf/8UPim+fcW2EfcQ/d/7aKUrP6IECz9G3Tu6Q5dX0orSleqJ9z6sSw7qrQkjF8/Edo4DvsWBZ8H+HNg==,
+      }
+    hasBin: true
 
   jszip@3.10.1:
     resolution:
@@ -7391,6 +7999,13 @@ packages:
         integrity: sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==,
       }
     engines: { node: ">=18.0.0" }
+
+  livekit-server-sdk@2.15.4:
+    resolution:
+      {
+        integrity: sha512-L/Ynu5zH1Qjfifmk3LnymL2JpvtisMFCM2wf7iM6H42WZRx6yvRECXa0hiK9/zi7br8d1x/a7fQIw1yJ/bneOA==,
+      }
+    engines: { node: ">=18" }
 
   load-json-file@4.0.0:
     resolution:
@@ -7651,6 +8266,13 @@ packages:
     engines: { node: ">=12.0.0" }
     hasBin: true
 
+  map-obj@5.0.0:
+    resolution:
+      {
+        integrity: sha512-2L3MIgJynYrZ3TYMriLDLWocz15okFakV6J12HXvMXDHui2x/zgChzg1u9mFFGbbGWE+GsLpQByt4POb9Or+uA==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+
   marked-terminal@7.3.0:
     resolution:
       {
@@ -7676,20 +8298,19 @@ packages:
     engines: { node: ">= 12" }
     hasBin: true
 
+  matcher@3.0.0:
+    resolution:
+      {
+        integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==,
+      }
+    engines: { node: ">=10" }
+
   math-intrinsics@1.1.0:
     resolution:
       {
         integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==,
       }
     engines: { node: ">= 0.4" }
-
-  mathjs@15.1.1:
-    resolution:
-      {
-        integrity: sha512-rM668DTtpSzMVoh/cKAllyQVEbBApM5g//IMGD8vD7YlrIz9ITRr3SrdhjaDxcBNTdyETWwPebj2unZyHD7ZdA==,
-      }
-    engines: { node: ">= 18" }
-    hasBin: true
 
   media-typer@0.3.0:
     resolution:
@@ -7802,12 +8423,12 @@ packages:
       }
     engines: { node: ">=18" }
 
-  mimic-response@3.1.0:
+  minimatch@10.2.5:
     resolution:
       {
-        integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==,
+        integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==,
       }
-    engines: { node: ">=10" }
+    engines: { node: 18 || 20 || >=22 }
 
   minimatch@3.1.2:
     resolution:
@@ -7842,17 +8463,12 @@ packages:
       }
     engines: { node: ">=16 || 14 >=14.17" }
 
-  minisearch@7.2.0:
+  minipass@7.1.3:
     resolution:
       {
-        integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==,
+        integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==,
       }
-
-  mkdirp-classic@0.5.3:
-    resolution:
-      {
-        integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==,
-      }
+    engines: { node: ">=16 || 14 >=14.17" }
 
   mkdirp@0.5.6:
     resolution:
@@ -7868,6 +8484,12 @@ packages:
       }
     engines: { node: ">=10" }
     hasBin: true
+
+  module-details-from-path@1.0.4:
+    resolution:
+      {
+        integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==,
+      }
 
   mri@1.2.0:
     resolution:
@@ -7935,14 +8557,6 @@ packages:
         integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==,
       }
 
-  nanoid@3.3.11:
-    resolution:
-      {
-        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
-      }
-    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
-    hasBin: true
-
   nanoid@5.1.5:
     resolution:
       {
@@ -7950,12 +8564,6 @@ packages:
       }
     engines: { node: ^18 || >=20 }
     hasBin: true
-
-  napi-build-utils@2.0.0:
-    resolution:
-      {
-        integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==,
-      }
 
   natural-compare@1.4.0:
     resolution:
@@ -7989,23 +8597,10 @@ packages:
         integrity: sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==,
       }
 
-  node-abi@3.85.0:
-    resolution:
-      {
-        integrity: sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==,
-      }
-    engines: { node: ">=10" }
-
   node-abort-controller@3.1.1:
     resolution:
       {
         integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==,
-      }
-
-  node-addon-api@7.1.1:
-    resolution:
-      {
-        integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==,
       }
 
   node-cache@5.1.2:
@@ -8029,6 +8624,12 @@ packages:
         integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==,
       }
     engines: { node: ">=18" }
+
+  node-fetch-native@1.6.7:
+    resolution:
+      {
+        integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==,
+      }
 
   node-fetch@2.7.0:
     resolution:
@@ -8213,17 +8814,18 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  ollama-ai-provider@1.2.0:
+  object-keys@1.1.1:
     resolution:
       {
-        integrity: sha512-jTNFruwe3O/ruJeppI/quoOUxG7NA6blG3ZyQj3lei4+NnJo7bi3eIRWqlVpRlu/mbzbFXeJSBuYQWF6pzGKww==,
+        integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==,
       }
-    engines: { node: ">=18" }
-    peerDependencies:
-      zod: ^3.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
+    engines: { node: ">= 0.4" }
+
+  ofetch@1.5.1:
+    resolution:
+      {
+        integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==,
+      }
 
   on-exit-leak-free@2.1.2:
     resolution:
@@ -8266,12 +8868,51 @@ packages:
       }
     engines: { node: ">=18" }
 
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
+    resolution:
+      {
+        integrity: sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==,
+      }
+
+  onnxruntime-common@1.24.3:
+    resolution:
+      {
+        integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==,
+      }
+
+  onnxruntime-node@1.24.3:
+    resolution:
+      {
+        integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==,
+      }
+    os: [win32, darwin, linux]
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    resolution:
+      {
+        integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==,
+      }
+
   open@11.0.0:
     resolution:
       {
         integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==,
       }
     engines: { node: ">=20" }
+
+  openai@6.42.0:
+    resolution:
+      {
+        integrity: sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==,
+      }
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   option@0.2.4:
     resolution:
@@ -8529,12 +9170,6 @@ packages:
       }
     engines: { node: ">= 0.8" }
 
-  partial-json@0.1.7:
-    resolution:
-      {
-        integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==,
-      }
-
   path-exists@3.0.0:
     resolution:
       {
@@ -8589,6 +9224,13 @@ packages:
         integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==,
       }
     engines: { node: ">=16 || 14 >=14.18" }
+
+  path-scurry@2.0.2:
+    resolution:
+      {
+        integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==,
+      }
+    engines: { node: 18 || 20 || >=22 }
 
   path-to-regexp@8.3.0:
     resolution:
@@ -8661,6 +9303,13 @@ packages:
     engines: { node: ">=0.10" }
     hasBin: true
 
+  pidusage@4.0.1:
+    resolution:
+      {
+        integrity: sha512-yCH2dtLHfEBnzlHUJymR/Z1nN2ePG3m392Mv8TFlTP1B0xkpMQNHAnfkY0n2tAi6ceKO6YWhxYfZ96V4vVkh/g==,
+      }
+    engines: { node: ">=18" }
+
   pify@3.0.0:
     resolution:
       {
@@ -8675,10 +9324,42 @@ packages:
       }
     engines: { node: ">=6" }
 
+  pino-abstract-transport@1.2.0:
+    resolution:
+      {
+        integrity: sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==,
+      }
+
+  pino-abstract-transport@2.0.0:
+    resolution:
+      {
+        integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==,
+      }
+
   pino-abstract-transport@3.0.0:
     resolution:
       {
         integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==,
+      }
+
+  pino-pretty@11.3.0:
+    resolution:
+      {
+        integrity: sha512-oXwn7ICywaZPHmu3epHGU2oJX4nPmKvHvB/bwrJHlGcbEWaVcotkpyVHMKLKmiVryWYByNp0jpgAcXpFJDXJzA==,
+      }
+    hasBin: true
+
+  pino-pretty@13.1.3:
+    resolution:
+      {
+        integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==,
+      }
+    hasBin: true
+
+  pino-std-serializers@6.2.2:
+    resolution:
+      {
+        integrity: sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==,
       }
 
   pino-std-serializers@7.1.0:
@@ -8691,6 +9372,20 @@ packages:
     resolution:
       {
         integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==,
+      }
+    hasBin: true
+
+  pino@8.21.0:
+    resolution:
+      {
+        integrity: sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==,
+      }
+    hasBin: true
+
+  pino@9.14.0:
+    resolution:
+      {
+        integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==,
       }
     hasBin: true
 
@@ -8722,6 +9417,12 @@ packages:
       }
     engines: { node: ">=8" }
 
+  platform@1.3.6:
+    resolution:
+      {
+        integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==,
+      }
+
   plimit-lit@1.6.1:
     resolution:
       {
@@ -8741,15 +9442,6 @@ packages:
       {
         integrity: sha512-TeJISr8wouAuXw4C1F/mC33xbZs/FuEG6nH9FG1Zj+nuPcGMP5YRHl6X+j3HSUnS1f3at6k75ZZXPMZlA5Lj9A==,
       }
-
-  prebuild-install@7.1.3:
-    resolution:
-      {
-        integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==,
-      }
-    engines: { node: ">=10" }
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
-    hasBin: true
 
   prelude-ls@1.2.1:
     resolution:
@@ -8794,6 +9486,12 @@ packages:
         integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==,
       }
 
+  process-warning@3.0.0:
+    resolution:
+      {
+        integrity: sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==,
+      }
+
   process-warning@4.0.1:
     resolution:
       {
@@ -8805,6 +9503,13 @@ packages:
       {
         integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==,
       }
+
+  process@0.11.10:
+    resolution:
+      {
+        integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==,
+      }
+    engines: { node: ">= 0.6.0" }
 
   progress@2.0.3:
     resolution:
@@ -8918,6 +9623,13 @@ packages:
         integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==,
       }
 
+  quick-lru@6.1.2:
+    resolution:
+      {
+        integrity: sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==,
+      }
+    engines: { node: ">=12" }
+
   range-parser@1.2.1:
     resolution:
       {
@@ -9000,6 +9712,13 @@ packages:
       }
     engines: { node: ">= 6" }
 
+  readable-stream@4.7.0:
+    resolution:
+      {
+        integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==,
+      }
+    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+
   readdir-glob@1.1.3:
     resolution:
       {
@@ -9067,6 +9786,13 @@ packages:
         integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==,
       }
     engines: { node: ">=0.10.0" }
+
+  require-in-the-middle@7.5.2:
+    resolution:
+      {
+        integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==,
+      }
+    engines: { node: ">=8.6.0" }
 
   resolve-cwd@3.0.0:
     resolution:
@@ -9173,6 +9899,13 @@ packages:
       }
     hasBin: true
 
+  roarr@2.15.4:
+    resolution:
+      {
+        integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==,
+      }
+    engines: { node: ">=8.0" }
+
   router@2.2.0:
     resolution:
       {
@@ -9251,12 +9984,6 @@ packages:
         integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
       }
 
-  sax@1.4.3:
-    resolution:
-      {
-        integrity: sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==,
-      }
-
   saxes@5.0.1:
     resolution:
       {
@@ -9276,12 +10003,6 @@ packages:
         integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==,
       }
 
-  seedrandom@3.0.5:
-    resolution:
-      {
-        integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==,
-      }
-
   semantic-release@24.2.7:
     resolution:
       {
@@ -9289,6 +10010,12 @@ packages:
       }
     engines: { node: ">=20.8.1" }
     hasBin: true
+
+  semver-compare@1.0.0:
+    resolution:
+      {
+        integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==,
+      }
 
   semver-diff@4.0.0:
     resolution:
@@ -9333,6 +10060,13 @@ packages:
         integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==,
       }
     engines: { node: ">= 18" }
+
+  serialize-error@7.0.1:
+    resolution:
+      {
+        integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==,
+      }
+    engines: { node: ">=10" }
 
   serve-static@2.2.0:
     resolution:
@@ -9386,6 +10120,12 @@ packages:
         integrity: sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==,
       }
 
+  shimmer@1.2.1:
+    resolution:
+      {
+        integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==,
+      }
+
   side-channel-list@1.0.0:
     resolution:
       {
@@ -9434,18 +10174,6 @@ packages:
       }
     engines: { node: ">=6" }
 
-  simple-concat@1.0.1:
-    resolution:
-      {
-        integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==,
-      }
-
-  simple-get@4.0.1:
-    resolution:
-      {
-        integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==,
-      }
-
   sisteransi@1.0.5:
     resolution:
       {
@@ -9486,6 +10214,12 @@ packages:
         integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==,
       }
     engines: { node: ">=18" }
+
+  sonic-boom@3.8.1:
+    resolution:
+      {
+        integrity: sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==,
+      }
 
   sonic-boom@4.2.1:
     resolution:
@@ -9567,6 +10301,12 @@ packages:
         integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==,
       }
 
+  sprintf-js@1.1.3:
+    resolution:
+      {
+        integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==,
+      }
+
   stack-utils@2.0.6:
     resolution:
       {
@@ -9578,6 +10318,12 @@ packages:
     resolution:
       {
         integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==,
+      }
+
+  standardwebhooks@1.0.0:
+    resolution:
+      {
+        integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==,
       }
 
   statuses@1.5.0:
@@ -9749,6 +10495,13 @@ packages:
       }
     engines: { node: ">=8" }
 
+  strip-json-comments@5.0.3:
+    resolution:
+      {
+        integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==,
+      }
+    engines: { node: ">=14.16" }
+
   strnum@2.2.0:
     resolution:
       {
@@ -9816,12 +10569,6 @@ packages:
         integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==,
       }
     engines: { node: ">=20" }
-
-  tar-fs@2.1.4:
-    resolution:
-      {
-        integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==,
-      }
 
   tar-stream@2.2.0:
     resolution:
@@ -9896,6 +10643,18 @@ packages:
         integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==,
       }
 
+  thread-stream@2.7.0:
+    resolution:
+      {
+        integrity: sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==,
+      }
+
+  thread-stream@3.2.0:
+    resolution:
+      {
+        integrity: sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==,
+      }
+
   thread-stream@4.0.0:
     resolution:
       {
@@ -9921,12 +10680,6 @@ packages:
         integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==,
       }
     engines: { node: ">=12" }
-
-  tiny-emitter@2.1.0:
-    resolution:
-      {
-        integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==,
-      }
 
   tmp@0.0.33:
     resolution:
@@ -10001,6 +10754,12 @@ packages:
         integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==,
       }
     hasBin: true
+
+  ts-algebra@2.0.0:
+    resolution:
+      {
+        integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==,
+      }
 
   ts-api-utils@2.1.0:
     resolution:
@@ -10107,12 +10866,6 @@ packages:
     engines: { node: ">=18.0.0" }
     hasBin: true
 
-  tunnel-agent@0.6.0:
-    resolution:
-      {
-        integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==,
-      }
-
   tunnel@0.0.6:
     resolution:
       {
@@ -10133,6 +10886,13 @@ packages:
         integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==,
       }
     engines: { node: ">=4" }
+
+  type-fest@0.13.1:
+    resolution:
+      {
+        integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==,
+      }
+    engines: { node: ">=10" }
 
   type-fest@0.21.3:
     resolution:
@@ -10183,13 +10943,6 @@ packages:
       }
     engines: { node: ">= 0.6" }
 
-  typed-function@4.2.1:
-    resolution:
-      {
-        integrity: sha512-EGjWssW7Tsk4DGfE+5yluuljS1OGYWiI1J6e8puZz9nTMM51Oug8CD5Zo4gWMsOhq5BI+1bF+rWTm4Vbj3ivRA==,
-      }
-    engines: { node: ">= 18" }
-
   typedarray@0.0.6:
     resolution:
       {
@@ -10213,6 +10966,12 @@ packages:
       }
     engines: { node: ">=14.17" }
     hasBin: true
+
+  ufo@1.6.4:
+    resolution:
+      {
+        integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==,
+      }
 
   uglify-js@3.19.3:
     resolution:
@@ -10341,13 +11100,6 @@ packages:
     resolution:
       {
         integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==,
-      }
-    hasBin: true
-
-  uuid@13.0.0:
-    resolution:
-      {
-        integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==,
       }
     hasBin: true
 
@@ -10511,10 +11263,10 @@ packages:
       }
     engines: { node: ^12.13.0 || ^14.15.0 || >=16.0.0 }
 
-  ws@8.20.0:
+  ws@8.21.0:
     resolution:
       {
-        integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==,
+        integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==,
       }
     engines: { node: ">=10.0.0" }
     peerDependencies:
@@ -10533,24 +11285,10 @@ packages:
       }
     engines: { node: ">=20" }
 
-  xml2js@0.6.2:
-    resolution:
-      {
-        integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==,
-      }
-    engines: { node: ">=4.0.0" }
-
   xmlbuilder@10.1.1:
     resolution:
       {
         integrity: sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==,
-      }
-    engines: { node: ">=4.0" }
-
-  xmlbuilder@11.0.1:
-    resolution:
-      {
-        integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==,
       }
     engines: { node: ">=4.0" }
 
@@ -10708,35 +11446,11 @@ snapshots:
       "@ai-sdk/provider-utils": 4.0.21(zod@4.3.6)
       zod: 4.3.6
 
-  "@ai-sdk/azure@3.0.49(zod@4.3.6)":
-    dependencies:
-      "@ai-sdk/openai": 3.0.48(zod@4.3.6)
-      "@ai-sdk/provider": 3.0.8
-      "@ai-sdk/provider-utils": 4.0.21(zod@4.3.6)
-      zod: 4.3.6
-
   "@ai-sdk/gateway@3.0.83(zod@4.3.6)":
     dependencies:
       "@ai-sdk/provider": 3.0.8
       "@ai-sdk/provider-utils": 4.0.21(zod@4.3.6)
       "@vercel/oidc": 3.1.0
-      zod: 4.3.6
-
-  "@ai-sdk/google-vertex@4.0.95(zod@4.3.6)":
-    dependencies:
-      "@ai-sdk/anthropic": 3.0.64(zod@4.3.6)
-      "@ai-sdk/google": 3.0.53(zod@4.3.6)
-      "@ai-sdk/provider": 3.0.8
-      "@ai-sdk/provider-utils": 4.0.21(zod@4.3.6)
-      google-auth-library: 10.6.2
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - supports-color
-
-  "@ai-sdk/google@3.0.53(zod@4.3.6)":
-    dependencies:
-      "@ai-sdk/provider": 3.0.8
-      "@ai-sdk/provider-utils": 4.0.21(zod@4.3.6)
       zod: 4.3.6
 
   "@ai-sdk/mistral@3.0.27(zod@4.3.6)":
@@ -10751,23 +11465,12 @@ snapshots:
       "@ai-sdk/provider-utils": 4.0.21(zod@4.3.6)
       zod: 4.3.6
 
-  "@ai-sdk/provider-utils@2.2.8(zod@4.3.6)":
-    dependencies:
-      "@ai-sdk/provider": 1.1.3
-      nanoid: 3.3.11
-      secure-json-parse: 2.7.0
-      zod: 4.3.6
-
   "@ai-sdk/provider-utils@4.0.21(zod@4.3.6)":
     dependencies:
       "@ai-sdk/provider": 3.0.8
       "@standard-schema/spec": 1.1.0
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.1.0
       zod: 4.3.6
-
-  "@ai-sdk/provider@1.1.3":
-    dependencies:
-      json-schema: 0.4.0
 
   "@ai-sdk/provider@3.0.8":
     dependencies:
@@ -10777,6 +11480,22 @@ snapshots:
     dependencies:
       "@jridgewell/gen-mapping": 0.3.12
       "@jridgewell/trace-mapping": 0.3.29
+
+  "@anthropic-ai/sdk@0.102.0(zod@4.3.6)":
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.3.6
+
+  "@anthropic-ai/vertex-sdk@0.16.1(encoding@0.1.13)(zod@4.3.6)":
+    dependencies:
+      "@anthropic-ai/sdk": 0.102.0(zod@4.3.6)
+      google-auth-library: 9.15.1(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+      - zod
 
   "@aws-crypto/crc32@5.2.0":
     dependencies:
@@ -11074,6 +11793,7 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+    optional: true
 
   "@aws-sdk/core@3.973.25":
     dependencies:
@@ -11639,7 +12359,11 @@ snapshots:
 
   "@bcoe/v8-coverage@0.2.3": {}
 
-  "@borewit/text-codec@0.2.1": {}
+  "@borewit/text-codec@0.2.1":
+    optional: true
+
+  "@bufbuild/protobuf@1.10.1":
+    optional: true
 
   "@cfworker/json-schema@4.1.1":
     optional: true
@@ -11808,6 +12532,9 @@ snapshots:
     dependencies:
       "@jridgewell/trace-mapping": 0.3.9
 
+  "@datastructures-js/deque@1.0.8":
+    optional: true
+
   "@derhuerst/http-basic@8.2.4":
     dependencies:
       caseless: 0.12.0
@@ -11951,6 +12678,7 @@ snapshots:
       lodash.isequal: 4.5.0
       lodash.isfunction: 3.0.9
       lodash.isnil: 4.0.0
+    optional: true
 
   "@fast-csv/parse@4.3.6":
     dependencies:
@@ -11961,6 +12689,7 @@ snapshots:
       lodash.isnil: 4.0.0
       lodash.isundefined: 3.0.1
       lodash.uniq: 4.5.0
+    optional: true
 
   "@fastify/ajv-compiler@4.0.5":
     dependencies:
@@ -12004,6 +12733,42 @@ snapshots:
       toad-cache: 3.7.0
     optional: true
 
+  "@ffmpeg-installer/darwin-arm64@4.1.5":
+    optional: true
+
+  "@ffmpeg-installer/darwin-x64@4.1.0":
+    optional: true
+
+  "@ffmpeg-installer/ffmpeg@1.1.0":
+    optionalDependencies:
+      "@ffmpeg-installer/darwin-arm64": 4.1.5
+      "@ffmpeg-installer/darwin-x64": 4.1.0
+      "@ffmpeg-installer/linux-arm": 4.1.3
+      "@ffmpeg-installer/linux-arm64": 4.1.4
+      "@ffmpeg-installer/linux-ia32": 4.1.0
+      "@ffmpeg-installer/linux-x64": 4.1.0
+      "@ffmpeg-installer/win32-ia32": 4.1.0
+      "@ffmpeg-installer/win32-x64": 4.1.0
+    optional: true
+
+  "@ffmpeg-installer/linux-arm64@4.1.4":
+    optional: true
+
+  "@ffmpeg-installer/linux-arm@4.1.3":
+    optional: true
+
+  "@ffmpeg-installer/linux-ia32@4.1.0":
+    optional: true
+
+  "@ffmpeg-installer/linux-x64@4.1.0":
+    optional: true
+
+  "@ffmpeg-installer/win32-ia32@4.1.0":
+    optional: true
+
+  "@ffmpeg-installer/win32-x64@4.1.0":
+    optional: true
+
   "@google-cloud/text-to-speech@6.4.0":
     dependencies:
       google-gax: 5.0.6
@@ -12022,15 +12787,13 @@ snapshots:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
       protobufjs: 7.5.4
-      ws: 8.20.0
+      ws: 8.21.0
     optionalDependencies:
       "@modelcontextprotocol/sdk": 1.28.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
-
-  "@google/generative-ai@0.24.1": {}
 
   "@grpc/grpc-js@1.13.4":
     dependencies:
@@ -12054,6 +12817,11 @@ snapshots:
   "@hapi/bourne@3.0.0":
     optional: true
 
+  "@hono/node-server@1.19.14(hono@4.12.25)":
+    dependencies:
+      hono: 4.12.25
+    optional: true
+
   "@hono/node-server@1.19.9(hono@4.12.2)":
     dependencies:
       hono: 4.12.2
@@ -12061,6 +12829,11 @@ snapshots:
   "@hono/node-server@1.19.9(hono@4.12.9)":
     dependencies:
       hono: 4.12.9
+
+  "@huggingface/hub@2.4.1":
+    dependencies:
+      "@huggingface/tasks": 0.19.90
+    optional: true
 
   "@huggingface/inference@4.13.15":
     dependencies:
@@ -12070,6 +12843,18 @@ snapshots:
   "@huggingface/jinja@0.5.6": {}
 
   "@huggingface/tasks@0.19.90": {}
+
+  "@huggingface/tokenizers@0.1.3":
+    optional: true
+
+  "@huggingface/transformers@4.2.0":
+    dependencies:
+      "@huggingface/jinja": 0.5.6
+      "@huggingface/tokenizers": 0.1.3
+      onnxruntime-node: 1.24.3
+      onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
+      sharp: 0.34.5
+    optional: true
 
   "@humanfs/core@0.19.1": {}
 
@@ -12300,7 +13085,8 @@ snapshots:
     optionalDependencies:
       "@types/node": 20.19.9
 
-  "@ioredis/commands@1.5.1": {}
+  "@ioredis/commands@1.5.1":
+    optional: true
 
   "@isaacs/cliui@8.0.2":
     dependencies:
@@ -12504,43 +13290,39 @@ snapshots:
 
   "@js-sdsl/ordered-map@4.4.2": {}
 
-  "@juspay/hippocampus@0.1.4(@juspay/neurolink@9.42.0(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@types/node@20.19.9)(encoding@0.1.13)(react@19.1.0))":
+  "@juspay/hippocampus@0.1.7(@juspay/neurolink@9.70.7)":
     dependencies:
       "@aws-sdk/client-s3": 3.1004.0
-      "@juspay/neurolink": 9.42.0(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@types/node@20.19.9)(encoding@0.1.13)(react@19.1.0)
+      "@juspay/neurolink": 9.70.7(@cfworker/json-schema@4.1.1)(@juspay/hippocampus@0.1.7)(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@types/node@20.19.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)
       redis: 4.7.1
     transitivePeerDependencies:
       - aws-crt
 
-  "@juspay/neurolink@9.42.0(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@types/node@20.19.9)(encoding@0.1.13)(react@19.1.0)":
+  "@juspay/neurolink@9.70.7(@cfworker/json-schema@4.1.1)(@juspay/hippocampus@0.1.7)(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@types/node@20.19.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)":
     dependencies:
       "@ai-sdk/anthropic": 3.0.64(zod@4.3.6)
-      "@ai-sdk/azure": 3.0.49(zod@4.3.6)
-      "@ai-sdk/google": 3.0.53(zod@4.3.6)
-      "@ai-sdk/google-vertex": 4.0.95(zod@4.3.6)
       "@ai-sdk/mistral": 3.0.27(zod@4.3.6)
       "@ai-sdk/openai": 3.0.48(zod@4.3.6)
       "@ai-sdk/provider": 3.0.8
+      "@anthropic-ai/sdk": 0.102.0(zod@4.3.6)
+      "@anthropic-ai/vertex-sdk": 0.16.1(encoding@0.1.13)(zod@4.3.6)
       "@aws-sdk/client-bedrock": 3.1019.0
       "@aws-sdk/client-bedrock-runtime": 3.1019.0
-      "@aws-sdk/client-sagemaker": 3.1019.0
       "@aws-sdk/client-sagemaker-runtime": 3.1019.0
+      "@aws-sdk/credential-provider-node": 3.972.27
+      "@aws-sdk/types": 3.973.6
       "@google-cloud/text-to-speech": 6.4.0
       "@google-cloud/vertexai": 1.10.0(encoding@0.1.13)
       "@google/genai": 1.47.0(@modelcontextprotocol/sdk@1.28.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))
-      "@google/generative-ai": 0.24.1
       "@huggingface/inference": 4.13.15
-      "@juspay/hippocampus": 0.1.4(@juspay/neurolink@9.42.0(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@types/node@20.19.9)(encoding@0.1.13)(react@19.1.0))
-      "@langfuse/otel": 5.0.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))
       "@modelcontextprotocol/sdk": 1.28.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
-      "@openrouter/ai-sdk-provider": 2.3.3(ai@6.0.141(zod@4.3.6))(zod@4.3.6)
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/api-logs": 0.214.0
       "@opentelemetry/context-async-hooks": 2.6.1(@opentelemetry/api@1.9.0)
       "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.0)
       "@opentelemetry/exporter-logs-otlp-http": 0.214.0(@opentelemetry/api@1.9.0)
       "@opentelemetry/exporter-metrics-otlp-http": 0.214.0(@opentelemetry/api@1.9.0)
-      "@opentelemetry/exporter-trace-otlp-http": 0.213.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/exporter-trace-otlp-http": 0.214.0(@opentelemetry/api@1.9.0)
       "@opentelemetry/resources": 2.6.1(@opentelemetry/api@1.9.0)
       "@opentelemetry/sdk-logs": 0.214.0(@opentelemetry/api@1.9.0)
       "@opentelemetry/sdk-metrics": 2.6.1(@opentelemetry/api@1.9.0)
@@ -12549,54 +13331,63 @@ snapshots:
       "@opentelemetry/semantic-conventions": 1.40.0
       adm-zip: 0.5.16
       ai: 6.0.141(zod@4.3.6)
-      bullmq: 5.71.1
       chalk: 5.6.2
       croner: 9.1.0
       csv-parser: 3.2.0
       dotenv: 17.3.1
-      exceljs: 4.4.0
-      fluent-ffmpeg: 2.1.3
+      eventsource-parser: 3.1.0
       google-auth-library: 10.6.2
-      hono: 4.12.9
+      hono: 4.12.25
       inquirer: 13.3.2(@types/node@20.19.9)
       jose: 6.1.3
       json-schema-to-zod: 2.8.0
-      mammoth: 1.11.0
-      mathjs: 15.1.1
-      mediabunny: 1.40.1
-      minisearch: 7.2.0
-      music-metadata: 11.12.1
+      jsonrepair: 3.14.0
       nanoid: 5.1.5
-      ollama-ai-provider: 1.2.0(zod@4.3.6)
       open: 11.0.0
       ora: 9.3.0
       p-limit: 7.3.0
-      pdf-parse: 2.4.5
-      pdf-to-img: 5.0.0
-      pptxgenjs: 4.0.1
       redis: 5.11.0
       tar-stream: 3.1.8
       undici: 7.22.0
-      uuid: 13.0.0
-      ws: 8.20.0
-      xml2js: 0.6.2
+      ws: 8.21.0
       yargs: 18.0.0
       zod: 4.3.6
       zod-to-json-schema: 3.25.1(zod@4.3.6)
     optionalDependencies:
+      "@aws-sdk/client-sagemaker": 3.1019.0
       "@fastify/cors": 11.2.0
       "@fastify/rate-limit": 10.3.0
-      "@hono/node-server": 1.19.9(hono@4.12.9)
+      "@hono/node-server": 1.19.14(hono@4.12.25)
+      "@juspay/hippocampus": 0.1.7(@juspay/neurolink@9.70.7)
       "@koa/cors": 5.0.0
       "@koa/router": 15.3.1(koa@3.1.2)
-      canvas: 3.2.2
+      "@langfuse/otel": 5.0.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))
+      "@livekit/agents": 1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6)
+      "@livekit/agents-plugin-cartesia": 1.4.6(@livekit/agents@1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6))(@livekit/rtc-node@0.13.29)(zod@4.3.6)
+      "@livekit/agents-plugin-deepgram": 1.4.6(@livekit/agents@1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6))(@livekit/rtc-node@0.13.29)
+      "@livekit/agents-plugin-elevenlabs": 1.4.6(@livekit/agents@1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6))(@livekit/rtc-node@0.13.29)
+      "@livekit/agents-plugin-livekit": 1.4.6(@livekit/agents@1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6))
+      "@livekit/agents-plugin-silero": 1.4.6(@livekit/agents@1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6))(@livekit/rtc-node@0.13.29)
+      "@livekit/agents-plugin-soniox": 1.4.6(@livekit/agents@1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6))(@livekit/rtc-node@0.13.29)
+      "@livekit/rtc-node": 0.13.29
+      "@picovoice/cobra-node": 3.0.3
+      bullmq: 5.71.1
       cors: 2.8.5
+      exceljs: 4.4.0
       express: 5.2.1
       express-rate-limit: 8.2.1(express@5.2.1)
-      fastify: 5.8.2
+      fastify: 5.8.5
       ffmpeg-static: 5.3.0
+      fluent-ffmpeg: 2.1.3
       koa: 3.1.2
       koa-bodyparser: 4.4.1
+      livekit-server-sdk: 2.15.4
+      mammoth: 1.11.0
+      mediabunny: 1.40.1
+      music-metadata: 11.12.1
+      pdf-parse: 2.4.5
+      pdf-to-img: 5.0.0
+      pptxgenjs: 4.0.1
       react: 19.1.0
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -12606,11 +13397,11 @@ snapshots:
       - aws-crt
       - bare-abort-controller
       - bare-buffer
-      - better-sqlite3
       - bufferutil
       - encoding
       - react-native-b4a
       - supports-color
+      - typescript
       - utf-8-validate
 
   "@koa/cors@5.0.0":
@@ -12632,14 +13423,175 @@ snapshots:
   "@langfuse/core@5.0.1(@opentelemetry/api@1.9.0)":
     dependencies:
       "@opentelemetry/api": 1.9.0
+    optional: true
 
-  "@langfuse/otel@5.0.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))":
+  "@langfuse/otel@5.0.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))":
     dependencies:
       "@langfuse/core": 5.0.1(@opentelemetry/api@1.9.0)
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.0)
-      "@opentelemetry/exporter-trace-otlp-http": 0.213.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/exporter-trace-otlp-http": 0.214.0(@opentelemetry/api@1.9.0)
       "@opentelemetry/sdk-trace-base": 2.6.1(@opentelemetry/api@1.9.0)
+    optional: true
+
+  "@livekit/agents-plugin-cartesia@1.4.6(@livekit/agents@1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6))(@livekit/rtc-node@0.13.29)(zod@4.3.6)":
+    dependencies:
+      "@livekit/agents": 1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6)
+      "@livekit/rtc-node": 0.13.29
+      ws: 8.21.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    optional: true
+
+  "@livekit/agents-plugin-deepgram@1.4.6(@livekit/agents@1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6))(@livekit/rtc-node@0.13.29)":
+    dependencies:
+      "@livekit/agents": 1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6)
+      "@livekit/rtc-node": 0.13.29
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    optional: true
+
+  "@livekit/agents-plugin-elevenlabs@1.4.6(@livekit/agents@1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6))(@livekit/rtc-node@0.13.29)":
+    dependencies:
+      "@livekit/agents": 1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6)
+      "@livekit/mutex": 1.1.1
+      "@livekit/rtc-node": 0.13.29
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    optional: true
+
+  "@livekit/agents-plugin-livekit@1.4.6(@livekit/agents@1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6))":
+    dependencies:
+      "@huggingface/hub": 2.4.1
+      "@huggingface/transformers": 4.2.0
+      "@livekit/agents": 1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6)
+      onnxruntime-node: 1.24.3
+    optional: true
+
+  "@livekit/agents-plugin-silero@1.4.6(@livekit/agents@1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6))(@livekit/rtc-node@0.13.29)":
+    dependencies:
+      "@livekit/agents": 1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6)
+      "@livekit/rtc-node": 0.13.29
+      onnxruntime-node: 1.24.3
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    optional: true
+
+  "@livekit/agents-plugin-soniox@1.4.6(@livekit/agents@1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6))(@livekit/rtc-node@0.13.29)":
+    dependencies:
+      "@livekit/agents": 1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6)
+      "@livekit/rtc-node": 0.13.29
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    optional: true
+
+  "@livekit/agents@1.4.6(@livekit/rtc-node@0.13.29)(typescript@5.8.3)(zod@4.3.6)":
+    dependencies:
+      "@bufbuild/protobuf": 1.10.1
+      "@ffmpeg-installer/ffmpeg": 1.1.0
+      "@livekit/mutex": 1.1.1
+      "@livekit/protocol": 1.46.6
+      "@livekit/rtc-node": 0.13.29
+      "@livekit/throws-transformer": 0.1.8(typescript@5.8.3)
+      "@livekit/typed-emitter": 3.0.0
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/api-logs": 0.54.2
+      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/exporter-logs-otlp-proto": 0.54.2(@opentelemetry/api@1.9.0)
+      "@opentelemetry/exporter-trace-otlp-proto": 0.54.2(@opentelemetry/api@1.9.0)
+      "@opentelemetry/instrumentation-pino": 0.43.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/otlp-exporter-base": 0.208.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/resources": 1.30.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/sdk-logs": 0.54.2(@opentelemetry/api@1.9.0)
+      "@opentelemetry/sdk-trace-base": 1.30.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/sdk-trace-node": 1.30.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/semantic-conventions": 1.40.0
+      "@types/pidusage": 2.0.5
+      commander: 12.1.0
+      fluent-ffmpeg: 2.1.3
+      form-data: 4.0.6
+      heap-js: 2.7.1
+      json-schema: 0.4.0
+      jsonrepair: 3.14.0
+      livekit-server-sdk: 2.15.4
+      ofetch: 1.5.1
+      openai: 6.42.0(ws@8.21.0)(zod@4.3.6)
+      pidusage: 4.0.1
+      pino: 8.21.0
+      pino-pretty: 11.3.0
+      sharp: 0.34.5
+      ws: 8.21.0
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - typescript
+      - utf-8-validate
+    optional: true
+
+  "@livekit/mutex@1.1.1":
+    optional: true
+
+  "@livekit/protocol@1.46.6":
+    dependencies:
+      "@bufbuild/protobuf": 1.10.1
+    optional: true
+
+  "@livekit/rtc-ffi-bindings-darwin-arm64@0.12.60":
+    optional: true
+
+  "@livekit/rtc-ffi-bindings-darwin-x64@0.12.60":
+    optional: true
+
+  "@livekit/rtc-ffi-bindings-linux-arm64-gnu@0.12.60":
+    optional: true
+
+  "@livekit/rtc-ffi-bindings-linux-x64-gnu@0.12.60":
+    optional: true
+
+  "@livekit/rtc-ffi-bindings-win32-x64-msvc@0.12.60":
+    optional: true
+
+  "@livekit/rtc-ffi-bindings@0.12.60":
+    dependencies:
+      "@bufbuild/protobuf": 1.10.1
+    optionalDependencies:
+      "@livekit/rtc-ffi-bindings-darwin-arm64": 0.12.60
+      "@livekit/rtc-ffi-bindings-darwin-x64": 0.12.60
+      "@livekit/rtc-ffi-bindings-linux-arm64-gnu": 0.12.60
+      "@livekit/rtc-ffi-bindings-linux-x64-gnu": 0.12.60
+      "@livekit/rtc-ffi-bindings-win32-x64-msvc": 0.12.60
+    optional: true
+
+  "@livekit/rtc-node@0.13.29":
+    dependencies:
+      "@datastructures-js/deque": 1.0.8
+      "@livekit/mutex": 1.1.1
+      "@livekit/rtc-ffi-bindings": 0.12.60
+      "@livekit/typed-emitter": 3.0.0
+      pino: 9.14.0
+      pino-pretty: 13.1.3
+    optional: true
+
+  "@livekit/throws-transformer@0.1.8(typescript@5.8.3)":
+    dependencies:
+      glob: 13.0.6
+      typescript: 5.8.3
+    optional: true
+
+  "@livekit/typed-emitter@3.0.0":
+    optional: true
 
   "@lukeed/ms@2.0.2":
     optional: true
@@ -12801,6 +13753,7 @@ snapshots:
       "@napi-rs/canvas-linux-x64-gnu": 0.1.80
       "@napi-rs/canvas-linux-x64-musl": 0.1.80
       "@napi-rs/canvas-win32-x64-msvc": 0.1.80
+    optional: true
 
   "@napi-rs/canvas@0.1.86":
     optionalDependencies:
@@ -12910,20 +13863,26 @@ snapshots:
     dependencies:
       "@octokit/openapi-types": 25.1.0
 
-  "@openrouter/ai-sdk-provider@2.3.3(ai@6.0.141(zod@4.3.6))(zod@4.3.6)":
-    dependencies:
-      ai: 6.0.141(zod@4.3.6)
-      zod: 4.3.6
-
-  "@opentelemetry/api-logs@0.213.0":
+  "@opentelemetry/api-logs@0.208.0":
     dependencies:
       "@opentelemetry/api": 1.9.0
+    optional: true
 
   "@opentelemetry/api-logs@0.214.0":
     dependencies:
       "@opentelemetry/api": 1.9.0
 
+  "@opentelemetry/api-logs@0.54.2":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+    optional: true
+
   "@opentelemetry/api@1.9.0": {}
+
+  "@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+    optional: true
 
   "@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0)":
     dependencies:
@@ -12933,12 +13892,19 @@ snapshots:
     dependencies:
       "@opentelemetry/api": 1.9.0
 
-  "@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0)":
+  "@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0)":
     dependencies:
       "@opentelemetry/api": 1.9.0
-      "@opentelemetry/semantic-conventions": 1.40.0
+      "@opentelemetry/semantic-conventions": 1.27.0
+    optional: true
 
-  "@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0)":
+  "@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/semantic-conventions": 1.28.0
+    optional: true
+
+  "@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0)":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.40.0
@@ -12957,6 +13923,18 @@ snapshots:
       "@opentelemetry/otlp-transformer": 0.214.0(@opentelemetry/api@1.9.0)
       "@opentelemetry/sdk-logs": 0.214.0(@opentelemetry/api@1.9.0)
 
+  "@opentelemetry/exporter-logs-otlp-proto@0.54.2(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/api-logs": 0.54.2
+      "@opentelemetry/core": 1.27.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/otlp-exporter-base": 0.54.2(@opentelemetry/api@1.9.0)
+      "@opentelemetry/otlp-transformer": 0.54.2(@opentelemetry/api@1.9.0)
+      "@opentelemetry/resources": 1.27.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/sdk-logs": 0.54.2(@opentelemetry/api@1.9.0)
+      "@opentelemetry/sdk-trace-base": 1.27.0(@opentelemetry/api@1.9.0)
+    optional: true
+
   "@opentelemetry/exporter-metrics-otlp-http@0.214.0(@opentelemetry/api@1.9.0)":
     dependencies:
       "@opentelemetry/api": 1.9.0
@@ -12966,20 +13944,54 @@ snapshots:
       "@opentelemetry/resources": 2.6.1(@opentelemetry/api@1.9.0)
       "@opentelemetry/sdk-metrics": 2.6.1(@opentelemetry/api@1.9.0)
 
-  "@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.0)":
+  "@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.0)":
     dependencies:
       "@opentelemetry/api": 1.9.0
-      "@opentelemetry/core": 2.6.0(@opentelemetry/api@1.9.0)
-      "@opentelemetry/otlp-exporter-base": 0.213.0(@opentelemetry/api@1.9.0)
-      "@opentelemetry/otlp-transformer": 0.213.0(@opentelemetry/api@1.9.0)
-      "@opentelemetry/resources": 2.6.0(@opentelemetry/api@1.9.0)
-      "@opentelemetry/sdk-trace-base": 2.6.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/otlp-exporter-base": 0.214.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/otlp-transformer": 0.214.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/resources": 2.6.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/sdk-trace-base": 2.6.1(@opentelemetry/api@1.9.0)
 
-  "@opentelemetry/otlp-exporter-base@0.213.0(@opentelemetry/api@1.9.0)":
+  "@opentelemetry/exporter-trace-otlp-proto@0.54.2(@opentelemetry/api@1.9.0)":
     dependencies:
       "@opentelemetry/api": 1.9.0
-      "@opentelemetry/core": 2.6.0(@opentelemetry/api@1.9.0)
-      "@opentelemetry/otlp-transformer": 0.213.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/core": 1.27.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/otlp-exporter-base": 0.54.2(@opentelemetry/api@1.9.0)
+      "@opentelemetry/otlp-transformer": 0.54.2(@opentelemetry/api@1.9.0)
+      "@opentelemetry/resources": 1.27.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/sdk-trace-base": 1.27.0(@opentelemetry/api@1.9.0)
+    optional: true
+
+  "@opentelemetry/instrumentation-pino@0.43.0(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/api-logs": 0.54.2
+      "@opentelemetry/core": 1.30.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/instrumentation": 0.54.2(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  "@opentelemetry/instrumentation@0.54.2(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/api-logs": 0.54.2
+      "@types/shimmer": 1.2.0
+      import-in-the-middle: 1.15.0
+      require-in-the-middle: 7.5.2
+      semver: 7.7.4
+      shimmer: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  "@opentelemetry/otlp-exporter-base@0.208.0(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/core": 2.2.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/otlp-transformer": 0.208.0(@opentelemetry/api@1.9.0)
+    optional: true
 
   "@opentelemetry/otlp-exporter-base@0.214.0(@opentelemetry/api@1.9.0)":
     dependencies:
@@ -12987,16 +13999,24 @@ snapshots:
       "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.0)
       "@opentelemetry/otlp-transformer": 0.214.0(@opentelemetry/api@1.9.0)
 
-  "@opentelemetry/otlp-transformer@0.213.0(@opentelemetry/api@1.9.0)":
+  "@opentelemetry/otlp-exporter-base@0.54.2(@opentelemetry/api@1.9.0)":
     dependencies:
       "@opentelemetry/api": 1.9.0
-      "@opentelemetry/api-logs": 0.213.0
-      "@opentelemetry/core": 2.6.0(@opentelemetry/api@1.9.0)
-      "@opentelemetry/resources": 2.6.0(@opentelemetry/api@1.9.0)
-      "@opentelemetry/sdk-logs": 0.213.0(@opentelemetry/api@1.9.0)
-      "@opentelemetry/sdk-metrics": 2.6.0(@opentelemetry/api@1.9.0)
-      "@opentelemetry/sdk-trace-base": 2.6.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/core": 1.27.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/otlp-transformer": 0.54.2(@opentelemetry/api@1.9.0)
+    optional: true
+
+  "@opentelemetry/otlp-transformer@0.208.0(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/api-logs": 0.208.0
+      "@opentelemetry/core": 2.2.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/resources": 2.2.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/sdk-logs": 0.208.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/sdk-metrics": 2.2.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/sdk-trace-base": 2.2.0(@opentelemetry/api@1.9.0)
       protobufjs: 7.5.4
+    optional: true
 
   "@opentelemetry/otlp-transformer@0.214.0(@opentelemetry/api@1.9.0)":
     dependencies:
@@ -13009,16 +14029,48 @@ snapshots:
       "@opentelemetry/sdk-trace-base": 2.6.1(@opentelemetry/api@1.9.0)
       protobufjs: 7.5.4
 
+  "@opentelemetry/otlp-transformer@0.54.2(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/api-logs": 0.54.2
+      "@opentelemetry/core": 1.27.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/resources": 1.27.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/sdk-logs": 0.54.2(@opentelemetry/api@1.9.0)
+      "@opentelemetry/sdk-metrics": 1.27.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/sdk-trace-base": 1.27.0(@opentelemetry/api@1.9.0)
+      protobufjs: 7.5.4
+    optional: true
+
+  "@opentelemetry/propagator-b3@1.30.1(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/core": 1.30.1(@opentelemetry/api@1.9.0)
+    optional: true
+
+  "@opentelemetry/propagator-jaeger@1.30.1(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/core": 1.30.1(@opentelemetry/api@1.9.0)
+    optional: true
+
+  "@opentelemetry/resources@1.27.0(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/core": 1.27.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/semantic-conventions": 1.27.0
+    optional: true
+
+  "@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/core": 1.30.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/semantic-conventions": 1.28.0
+    optional: true
+
   "@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0)":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/core": 2.2.0(@opentelemetry/api@1.9.0)
-      "@opentelemetry/semantic-conventions": 1.40.0
-
-  "@opentelemetry/resources@2.6.0(@opentelemetry/api@1.9.0)":
-    dependencies:
-      "@opentelemetry/api": 1.9.0
-      "@opentelemetry/core": 2.6.0(@opentelemetry/api@1.9.0)
       "@opentelemetry/semantic-conventions": 1.40.0
 
   "@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.0)":
@@ -13027,13 +14079,13 @@ snapshots:
       "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.0)
       "@opentelemetry/semantic-conventions": 1.40.0
 
-  "@opentelemetry/sdk-logs@0.213.0(@opentelemetry/api@1.9.0)":
+  "@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.0)":
     dependencies:
       "@opentelemetry/api": 1.9.0
-      "@opentelemetry/api-logs": 0.213.0
-      "@opentelemetry/core": 2.6.0(@opentelemetry/api@1.9.0)
-      "@opentelemetry/resources": 2.6.0(@opentelemetry/api@1.9.0)
-      "@opentelemetry/semantic-conventions": 1.40.0
+      "@opentelemetry/api-logs": 0.208.0
+      "@opentelemetry/core": 2.2.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/resources": 2.2.0(@opentelemetry/api@1.9.0)
+    optional: true
 
   "@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.0)":
     dependencies:
@@ -13043,11 +14095,27 @@ snapshots:
       "@opentelemetry/resources": 2.6.1(@opentelemetry/api@1.9.0)
       "@opentelemetry/semantic-conventions": 1.40.0
 
-  "@opentelemetry/sdk-metrics@2.6.0(@opentelemetry/api@1.9.0)":
+  "@opentelemetry/sdk-logs@0.54.2(@opentelemetry/api@1.9.0)":
     dependencies:
       "@opentelemetry/api": 1.9.0
-      "@opentelemetry/core": 2.6.0(@opentelemetry/api@1.9.0)
-      "@opentelemetry/resources": 2.6.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/api-logs": 0.54.2
+      "@opentelemetry/core": 1.27.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/resources": 1.27.0(@opentelemetry/api@1.9.0)
+    optional: true
+
+  "@opentelemetry/sdk-metrics@1.27.0(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/core": 1.27.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/resources": 1.27.0(@opentelemetry/api@1.9.0)
+    optional: true
+
+  "@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/core": 2.2.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/resources": 2.2.0(@opentelemetry/api@1.9.0)
+    optional: true
 
   "@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.0)":
     dependencies:
@@ -13055,18 +14123,27 @@ snapshots:
       "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.0)
       "@opentelemetry/resources": 2.6.1(@opentelemetry/api@1.9.0)
 
+  "@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/core": 1.27.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/resources": 1.27.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/semantic-conventions": 1.27.0
+    optional: true
+
+  "@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/core": 1.30.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/resources": 1.30.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/semantic-conventions": 1.28.0
+    optional: true
+
   "@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0)":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/core": 2.2.0(@opentelemetry/api@1.9.0)
       "@opentelemetry/resources": 2.2.0(@opentelemetry/api@1.9.0)
-      "@opentelemetry/semantic-conventions": 1.40.0
-
-  "@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0)":
-    dependencies:
-      "@opentelemetry/api": 1.9.0
-      "@opentelemetry/core": 2.6.0(@opentelemetry/api@1.9.0)
-      "@opentelemetry/resources": 2.6.0(@opentelemetry/api@1.9.0)
       "@opentelemetry/semantic-conventions": 1.40.0
 
   "@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0)":
@@ -13076,6 +14153,17 @@ snapshots:
       "@opentelemetry/resources": 2.6.1(@opentelemetry/api@1.9.0)
       "@opentelemetry/semantic-conventions": 1.40.0
 
+  "@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/context-async-hooks": 1.30.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/core": 1.30.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/propagator-b3": 1.30.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/propagator-jaeger": 1.30.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/sdk-trace-base": 1.30.1(@opentelemetry/api@1.9.0)
+      semver: 7.7.4
+    optional: true
+
   "@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0)":
     dependencies:
       "@opentelemetry/api": 1.9.0
@@ -13083,7 +14171,16 @@ snapshots:
       "@opentelemetry/core": 2.2.0(@opentelemetry/api@1.9.0)
       "@opentelemetry/sdk-trace-base": 2.2.0(@opentelemetry/api@1.9.0)
 
+  "@opentelemetry/semantic-conventions@1.27.0":
+    optional: true
+
+  "@opentelemetry/semantic-conventions@1.28.0":
+    optional: true
+
   "@opentelemetry/semantic-conventions@1.40.0": {}
+
+  "@picovoice/cobra-node@3.0.3":
+    optional: true
 
   "@pinojs/redact@0.4.0":
     optional: true
@@ -13628,6 +14725,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  "@stablelib/base64@1.0.1": {}
+
   "@standard-schema/spec@1.1.0": {}
 
   "@tokenizer/inflate@0.4.1":
@@ -13636,8 +14735,10 @@ snapshots:
       token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
-  "@tokenizer/token@0.3.0": {}
+  "@tokenizer/token@0.3.0":
+    optional: true
 
   "@tsconfig/node10@1.0.11": {}
 
@@ -13671,8 +14772,10 @@ snapshots:
   "@types/dom-mediacapture-transform@0.1.11":
     dependencies:
       "@types/dom-webcodecs": 0.1.13
+    optional: true
 
-  "@types/dom-webcodecs@0.1.13": {}
+  "@types/dom-webcodecs@0.1.13":
+    optional: true
 
   "@types/estree@1.0.8": {}
 
@@ -13709,7 +14812,8 @@ snapshots:
 
   "@types/node@12.20.55": {}
 
-  "@types/node@14.18.63": {}
+  "@types/node@14.18.63":
+    optional: true
 
   "@types/node@20.19.9":
     dependencies:
@@ -13718,10 +14822,17 @@ snapshots:
   "@types/node@22.19.15":
     dependencies:
       undici-types: 6.21.0
+    optional: true
 
   "@types/normalize-package-data@2.4.4": {}
 
+  "@types/pidusage@2.0.5":
+    optional: true
+
   "@types/retry@0.12.0": {}
+
+  "@types/shimmer@1.2.0":
+    optional: true
 
   "@types/stack-utils@2.0.3": {}
 
@@ -13834,7 +14945,13 @@ snapshots:
 
   "@vercel/oidc@3.1.0": {}
 
-  "@xmldom/xmldom@0.8.11": {}
+  "@xmldom/xmldom@0.8.11":
+    optional: true
+
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+    optional: true
 
   abstract-logging@2.0.1:
     optional: true
@@ -13849,6 +14966,11 @@ snapshots:
     dependencies:
       mime-types: 3.0.1
       negotiator: 1.0.0
+
+  acorn-import-attributes@1.9.5(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+    optional: true
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -13956,6 +15078,7 @@ snapshots:
       lodash.union: 4.6.0
       normalize-path: 3.0.0
       readable-stream: 2.3.8
+    optional: true
 
   archiver-utils@3.0.4:
     dependencies:
@@ -13969,6 +15092,7 @@ snapshots:
       lodash.union: 4.6.0
       normalize-path: 3.0.0
       readable-stream: 3.6.2
+    optional: true
 
   archiver@5.3.2:
     dependencies:
@@ -13979,6 +15103,7 @@ snapshots:
       readdir-glob: 1.1.3
       tar-stream: 2.2.0
       zip-stream: 4.1.1
+    optional: true
 
   arg@4.1.3: {}
 
@@ -13994,7 +15119,8 @@ snapshots:
 
   array-union@2.1.0: {}
 
-  async@0.2.10: {}
+  async@0.2.10:
+    optional: true
 
   async@3.2.6: {}
 
@@ -14076,6 +15202,9 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4:
+    optional: true
+
   bare-events@2.8.2: {}
 
   bare-fs@4.5.6:
@@ -14116,7 +15245,8 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  big-integer@1.6.52: {}
+  big-integer@1.6.52:
+    optional: true
 
   bignumber.js@9.3.1: {}
 
@@ -14126,6 +15256,7 @@ snapshots:
     dependencies:
       buffers: 0.1.1
       chainsaw: 0.1.0
+    optional: true
 
   bl@4.1.0:
     dependencies:
@@ -14133,7 +15264,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  bluebird@3.4.7: {}
+  bluebird@3.4.7:
+    optional: true
 
   body-parser@2.2.2:
     dependencies:
@@ -14149,6 +15281,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  boolean@3.2.0:
+    optional: true
+
   bottleneck@2.19.5: {}
 
   bowser@2.11.0: {}
@@ -14161,6 +15296,11 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
+    optional: true
 
   braces@3.0.3:
     dependencies:
@@ -14181,20 +15321,29 @@ snapshots:
     dependencies:
       node-int64: 0.4.0
 
-  buffer-crc32@0.2.13: {}
+  buffer-crc32@0.2.13:
+    optional: true
 
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
-  buffer-indexof-polyfill@1.0.2: {}
+  buffer-indexof-polyfill@1.0.2:
+    optional: true
 
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  buffers@0.1.1: {}
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    optional: true
+
+  buffers@0.1.1:
+    optional: true
 
   bullmq@5.71.1:
     dependencies:
@@ -14207,6 +15356,7 @@ snapshots:
       uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   bundle-name@4.1.0:
     dependencies:
@@ -14226,17 +15376,22 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase-keys@9.1.3:
+    dependencies:
+      camelcase: 8.0.0
+      map-obj: 5.0.0
+      quick-lru: 6.1.2
+      type-fest: 4.41.0
+    optional: true
+
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001727: {}
-
-  canvas@3.2.2:
-    dependencies:
-      node-addon-api: 7.1.1
-      prebuild-install: 7.1.3
+  camelcase@8.0.0:
     optional: true
+
+  caniuse-lite@1.0.30001727: {}
 
   caseless@0.12.0:
     optional: true
@@ -14244,6 +15399,7 @@ snapshots:
   chainsaw@0.1.0:
     dependencies:
       traverse: 0.3.9
+    optional: true
 
   chalk@2.4.2:
     dependencies:
@@ -14277,9 +15433,6 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
-
-  chownr@1.1.4:
-    optional: true
 
   ci-info@3.9.0: {}
 
@@ -14384,6 +15537,9 @@ snapshots:
 
   commander@11.1.0: {}
 
+  commander@12.1.0:
+    optional: true
+
   commander@13.1.0: {}
 
   commander@9.5.0: {}
@@ -14393,14 +15549,13 @@ snapshots:
       array-ify: 1.0.0
       dot-prop: 5.3.0
 
-  complex.js@2.4.2: {}
-
   compress-commons@4.1.2:
     dependencies:
       buffer-crc32: 0.2.13
       crc32-stream: 4.0.3
       normalize-path: 3.0.0
       readable-stream: 3.6.2
+    optional: true
 
   concat-map@0.0.1: {}
 
@@ -14474,12 +15629,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  crc-32@1.2.2: {}
+  crc-32@1.2.2:
+    optional: true
 
   crc32-stream@4.0.3:
     dependencies:
       crc-32: 1.2.2
       readable-stream: 3.6.2
+    optional: true
 
   create-jest@29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.3)):
     dependencies:
@@ -14501,6 +15658,7 @@ snapshots:
   cron-parser@4.9.0:
     dependencies:
       luxon: 3.7.2
+    optional: true
 
   croner@9.1.0: {}
 
@@ -14520,7 +15678,11 @@ snapshots:
 
   dataloader@1.4.0: {}
 
-  dayjs@1.11.19: {}
+  dateformat@4.6.3:
+    optional: true
+
+  dayjs@1.11.19:
+    optional: true
 
   debug@4.4.1:
     dependencies:
@@ -14529,13 +15691,6 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-
-  decimal.js@10.6.0: {}
-
-  decompress-response@6.0.0:
-    dependencies:
-      mimic-response: 3.1.0
-    optional: true
 
   dedent@1.6.0: {}
 
@@ -14559,14 +15714,29 @@ snapshots:
     dependencies:
       clone: 1.0.4
 
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+    optional: true
+
   define-lazy-prop@3.0.0: {}
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+    optional: true
 
   delayed-stream@1.0.0: {}
 
   delegates@1.0.0:
     optional: true
 
-  denque@2.1.0: {}
+  denque@2.1.0:
+    optional: true
 
   depd@1.1.2:
     optional: true
@@ -14574,6 +15744,9 @@ snapshots:
   depd@2.0.0: {}
 
   dequal@2.0.3:
+    optional: true
+
+  destr@2.0.5:
     optional: true
 
   destroy@1.2.0:
@@ -14586,11 +15759,15 @@ snapshots:
 
   detect-newline@3.1.0: {}
 
+  detect-node@2.1.0:
+    optional: true
+
   diff-sequences@29.6.3: {}
 
   diff@4.0.2: {}
 
-  dingbat-to-unicode@1.0.1: {}
+  dingbat-to-unicode@1.0.1:
+    optional: true
 
   dir-glob@3.0.1:
     dependencies:
@@ -14609,6 +15786,7 @@ snapshots:
   duck@0.1.12:
     dependencies:
       underscore: 1.13.7
+    optional: true
 
   dunder-proto@1.0.1:
     dependencies:
@@ -14704,6 +15882,9 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
+  es6-error@4.1.1:
+    optional: true
+
   esbuild@0.25.12:
     optionalDependencies:
       "@esbuild/aix-ppc64": 0.25.12
@@ -14736,8 +15917,6 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
-
-  escape-latex@1.2.0: {}
 
   escape-string-regexp@1.0.5: {}
 
@@ -14818,6 +15997,9 @@ snapshots:
 
   etag@1.8.1: {}
 
+  event-target-shim@5.0.1:
+    optional: true
+
   eventemitter3@5.0.1: {}
 
   events-universal@1.0.1:
@@ -14826,9 +16008,14 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
 
+  events@3.3.0:
+    optional: true
+
   eventsource-parser@3.0.3: {}
 
   eventsource-parser@3.0.6: {}
+
+  eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
     dependencies:
@@ -14845,6 +16032,7 @@ snapshots:
       tmp: 0.2.5
       unzipper: 0.10.14
       uuid: 8.3.2
+    optional: true
 
   execa@5.1.1:
     dependencies:
@@ -14886,9 +16074,6 @@ snapshots:
       yoctocolors: 2.1.1
 
   exit@0.1.2: {}
-
-  expand-template@2.0.3:
-    optional: true
 
   expect@29.7.0:
     dependencies:
@@ -14948,10 +16133,17 @@ snapshots:
 
   fast-content-type-parse@3.0.0: {}
 
+  fast-copy@3.0.2:
+    optional: true
+
+  fast-copy@4.0.3:
+    optional: true
+
   fast-csv@4.3.6:
     dependencies:
       "@fast-csv/format": 4.3.5
       "@fast-csv/parse": 4.3.6
+    optional: true
 
   fast-decode-uri-component@1.0.1:
     optional: true
@@ -14987,6 +16179,14 @@ snapshots:
       fast-decode-uri-component: 1.0.1
     optional: true
 
+  fast-redact@3.5.0:
+    optional: true
+
+  fast-safe-stringify@2.1.1:
+    optional: true
+
+  fast-sha256@1.3.0: {}
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -15012,7 +16212,7 @@ snapshots:
   fastify-plugin@5.1.0:
     optional: true
 
-  fastify@5.8.2:
+  fastify@5.8.5:
     dependencies:
       "@fastify/ajv-compiler": 4.0.5
       "@fastify/error": 4.2.0
@@ -15078,6 +16278,7 @@ snapshots:
       uint8array-extras: 1.5.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   filelist@1.0.4:
     dependencies:
@@ -15131,12 +16332,16 @@ snapshots:
       flatted: 3.3.3
       keyv: 4.5.4
 
+  flatbuffers@25.9.23:
+    optional: true
+
   flatted@3.3.3: {}
 
   fluent-ffmpeg@2.1.3:
     dependencies:
       async: 0.2.10
       which: 1.3.1
+    optional: true
 
   follow-redirects@1.15.9(debug@4.4.1):
     optionalDependencies:
@@ -15155,13 +16360,20 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+    optional: true
+
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
-
-  fraction.js@5.2.2: {}
 
   fresh@0.5.2:
     optional: true
@@ -15173,7 +16385,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 2.3.8
 
-  fs-constants@1.0.0: {}
+  fs-constants@1.0.0:
+    optional: true
 
   fs-extra@11.3.0:
     dependencies:
@@ -15204,6 +16417,7 @@ snapshots:
       inherits: 2.0.4
       mkdirp: 0.5.6
       rimraf: 2.7.1
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -15299,9 +16513,6 @@ snapshots:
       through2: 2.0.5
       traverse: 0.6.8
 
-  github-from-package@0.0.0:
-    optional: true
-
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -15319,6 +16530,13 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+    optional: true
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -15328,7 +16546,23 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
+  global-agent@3.0.0:
+    dependencies:
+      boolean: 3.2.0
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.7.4
+      serialize-error: 7.0.1
+    optional: true
+
   globals@14.0.0: {}
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
+    optional: true
 
   globby@11.1.0:
     dependencies:
@@ -15407,6 +16641,9 @@ snapshots:
       - encoding
       - supports-color
 
+  guid-typescript@1.0.9:
+    optional: true
+
   handlebars@4.7.8:
     dependencies:
       minimist: 1.2.8
@@ -15420,6 +16657,11 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+    optional: true
+
   has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
@@ -15430,9 +16672,22 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+    optional: true
+
+  heap-js@2.7.1:
+    optional: true
+
+  help-me@5.0.0:
+    optional: true
+
   highlight.js@10.7.3: {}
 
   hono@4.12.2: {}
+
+  hono@4.12.25: {}
 
   hono@4.12.9: {}
 
@@ -15502,7 +16757,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https@1.0.0: {}
+  https@1.0.0:
+    optional: true
 
   human-id@4.1.1: {}
 
@@ -15536,8 +16792,10 @@ snapshots:
   image-size@1.2.1:
     dependencies:
       queue: 6.0.2
+    optional: true
 
-  immediate@3.0.6: {}
+  immediate@3.0.6:
+    optional: true
 
   import-fresh@3.3.1:
     dependencies:
@@ -15550,6 +16808,14 @@ snapshots:
       import-meta-resolve: 4.1.0
     transitivePeerDependencies:
       - supports-color
+
+  import-in-the-middle@1.15.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-import-attributes: 1.9.5(acorn@8.15.0)
+      cjs-module-lexer: 1.4.3
+      module-details-from-path: 1.0.4
+    optional: true
 
   import-local@3.2.0:
     dependencies:
@@ -15626,6 +16892,7 @@ snapshots:
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   ip-address@10.0.1: {}
 
@@ -15767,8 +17034,6 @@ snapshots:
       minimatch: 3.1.2
 
   java-properties@1.0.2: {}
-
-  javascript-natural-sort@0.7.1: {}
 
   jest-changed-files@29.7.0:
     dependencies:
@@ -16079,7 +17344,13 @@ snapshots:
       - supports-color
       - ts-node
 
+  jose@5.10.0:
+    optional: true
+
   jose@6.1.3: {}
+
+  joycon@3.1.1:
+    optional: true
 
   js-tokens@4.0.0: {}
 
@@ -16109,6 +17380,11 @@ snapshots:
       dequal: 2.0.3
     optional: true
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      "@babel/runtime": 7.28.2
+      ts-algebra: 2.0.0
+
   json-schema-to-zod@2.8.0: {}
 
   json-schema-traverse@0.4.1: {}
@@ -16120,6 +17396,9 @@ snapshots:
   json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-stringify-safe@5.0.1:
+    optional: true
 
   json5@2.2.3: {}
 
@@ -16135,12 +17414,15 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonrepair@3.14.0: {}
+
   jszip@3.10.1:
     dependencies:
       lie: 3.3.0
       pako: 1.0.11
       readable-stream: 2.3.8
       setimmediate: 1.0.5
+    optional: true
 
   jwa@2.0.1:
     dependencies:
@@ -16207,6 +17489,7 @@ snapshots:
   lazystream@1.0.1:
     dependencies:
       readable-stream: 2.3.8
+    optional: true
 
   leven@3.1.0: {}
 
@@ -16218,6 +17501,7 @@ snapshots:
   lie@3.3.0:
     dependencies:
       immediate: 3.0.6
+    optional: true
 
   light-my-request@6.6.0:
     dependencies:
@@ -16245,7 +17529,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  listenercount@1.0.1: {}
+  listenercount@1.0.1:
+    optional: true
 
   listr2@8.3.3:
     dependencies:
@@ -16255,6 +17540,14 @@ snapshots:
       log-update: 6.1.0
       rfdc: 1.4.1
       wrap-ansi: 9.0.0
+
+  livekit-server-sdk@2.15.4:
+    dependencies:
+      "@bufbuild/protobuf": 1.10.1
+      "@livekit/protocol": 1.46.6
+      camelcase-keys: 9.1.3
+      jose: 5.10.0
+    optional: true
 
   load-json-file@4.0.0:
     dependencies:
@@ -16282,31 +17575,41 @@ snapshots:
 
   lodash.capitalize@4.2.1: {}
 
-  lodash.defaults@4.2.0: {}
+  lodash.defaults@4.2.0:
+    optional: true
 
-  lodash.difference@4.5.0: {}
+  lodash.difference@4.5.0:
+    optional: true
 
   lodash.escaperegexp@4.1.2: {}
 
-  lodash.flatten@4.4.0: {}
+  lodash.flatten@4.4.0:
+    optional: true
 
-  lodash.groupby@4.6.0: {}
+  lodash.groupby@4.6.0:
+    optional: true
 
-  lodash.isarguments@3.1.0: {}
+  lodash.isarguments@3.1.0:
+    optional: true
 
-  lodash.isboolean@3.0.3: {}
+  lodash.isboolean@3.0.3:
+    optional: true
 
-  lodash.isequal@4.5.0: {}
+  lodash.isequal@4.5.0:
+    optional: true
 
-  lodash.isfunction@3.0.9: {}
+  lodash.isfunction@3.0.9:
+    optional: true
 
-  lodash.isnil@4.0.0: {}
+  lodash.isnil@4.0.0:
+    optional: true
 
   lodash.isplainobject@4.0.6: {}
 
   lodash.isstring@4.0.1: {}
 
-  lodash.isundefined@3.0.1: {}
+  lodash.isundefined@3.0.1:
+    optional: true
 
   lodash.memoize@4.1.2: {}
 
@@ -16314,9 +17617,11 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
-  lodash.union@4.6.0: {}
+  lodash.union@4.6.0:
+    optional: true
 
-  lodash.uniq@4.5.0: {}
+  lodash.uniq@4.5.0:
+    optional: true
 
   lodash.uniqby@4.7.0: {}
 
@@ -16347,6 +17652,7 @@ snapshots:
       duck: 0.1.12
       option: 0.2.4
       underscore: 1.13.7
+    optional: true
 
   lru-cache@10.4.3: {}
 
@@ -16358,7 +17664,8 @@ snapshots:
 
   lunr@2.3.9: {}
 
-  luxon@3.7.2: {}
+  luxon@3.7.2:
+    optional: true
 
   make-dir@4.0.0:
     dependencies:
@@ -16382,6 +17689,10 @@ snapshots:
       path-is-absolute: 1.0.1
       underscore: 1.13.7
       xmlbuilder: 10.1.1
+    optional: true
+
+  map-obj@5.0.0:
+    optional: true
 
   marked-terminal@7.3.0(marked@15.0.12):
     dependencies:
@@ -16398,19 +17709,12 @@ snapshots:
 
   marked@4.3.0: {}
 
-  math-intrinsics@1.1.0: {}
-
-  mathjs@15.1.1:
+  matcher@3.0.0:
     dependencies:
-      "@babel/runtime": 7.28.2
-      complex.js: 2.4.2
-      decimal.js: 10.6.0
-      escape-latex: 1.2.0
-      fraction.js: 5.2.2
-      javascript-natural-sort: 0.7.1
-      seedrandom: 3.0.5
-      tiny-emitter: 2.1.0
-      typed-function: 4.2.1
+      escape-string-regexp: 4.0.0
+    optional: true
+
+  math-intrinsics@1.1.0: {}
 
   media-typer@0.3.0:
     optional: true
@@ -16421,6 +17725,7 @@ snapshots:
     dependencies:
       "@types/dom-mediacapture-transform": 0.1.11
       "@types/dom-webcodecs": 0.1.13
+    optional: true
 
   meow@13.2.0: {}
 
@@ -16455,7 +17760,9 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  mimic-response@3.1.0:
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
     optional: true
 
   minimatch@3.1.2:
@@ -16474,16 +17781,18 @@ snapshots:
 
   minipass@7.1.2: {}
 
-  minisearch@7.2.0: {}
-
-  mkdirp-classic@0.5.3:
+  minipass@7.1.3:
     optional: true
 
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
+    optional: true
 
   mkdirp@1.0.4: {}
+
+  module-details-from-path@1.0.4:
+    optional: true
 
   mri@1.2.0: {}
 
@@ -16504,6 +17813,7 @@ snapshots:
   msgpackr@1.11.5:
     optionalDependencies:
       msgpackr-extract: 3.0.3
+    optional: true
 
   music-metadata@11.12.1:
     dependencies:
@@ -16519,6 +17829,7 @@ snapshots:
       win-guid: 0.2.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   mustache@4.2.0: {}
 
@@ -16534,12 +17845,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11: {}
-
   nanoid@5.1.5: {}
-
-  napi-build-utils@2.0.0:
-    optional: true
 
   natural-compare@1.4.0: {}
 
@@ -16552,14 +17858,7 @@ snapshots:
 
   nerf-dart@1.0.0: {}
 
-  node-abi@3.85.0:
-    dependencies:
-      semver: 7.7.4
-    optional: true
-
-  node-abort-controller@3.1.1: {}
-
-  node-addon-api@7.1.1:
+  node-abort-controller@3.1.1:
     optional: true
 
   node-cache@5.1.2:
@@ -16574,6 +17873,9 @@ snapshots:
       char-regex: 1.0.2
       emojilib: 2.4.0
       skin-tone: 2.0.0
+
+  node-fetch-native@1.6.7:
+    optional: true
 
   node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
@@ -16633,13 +17935,15 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  ollama-ai-provider@1.2.0(zod@4.3.6):
+  object-keys@1.1.1:
+    optional: true
+
+  ofetch@1.5.1:
     dependencies:
-      "@ai-sdk/provider": 1.1.3
-      "@ai-sdk/provider-utils": 2.2.8(zod@4.3.6)
-      partial-json: 0.1.7
-    optionalDependencies:
-      zod: 4.3.6
+      destr: 2.0.5
+      node-fetch-native: 1.6.7
+      ufo: 1.6.4
+    optional: true
 
   on-exit-leak-free@2.1.2:
     optional: true
@@ -16664,6 +17968,29 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
+    optional: true
+
+  onnxruntime-common@1.24.3:
+    optional: true
+
+  onnxruntime-node@1.24.3:
+    dependencies:
+      adm-zip: 0.5.16
+      global-agent: 3.0.0
+      onnxruntime-common: 1.24.3
+    optional: true
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    dependencies:
+      flatbuffers: 25.9.23
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.24.0-dev.20251116-b39e144322
+      platform: 1.3.6
+      protobufjs: 7.5.4
+    optional: true
+
   open@11.0.0:
     dependencies:
       default-browser: 5.5.0
@@ -16673,7 +18000,14 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
-  option@0.2.4: {}
+  openai@6.42.0(ws@8.21.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.21.0
+      zod: 4.3.6
+    optional: true
+
+  option@0.2.4:
+    optional: true
 
   optionator@0.9.4:
     dependencies:
@@ -16776,7 +18110,8 @@ snapshots:
 
   package-manager-detector@1.3.0: {}
 
-  pako@1.0.11: {}
+  pako@1.0.11:
+    optional: true
 
   parent-module@1.0.1:
     dependencies:
@@ -16815,8 +18150,6 @@ snapshots:
 
   parseurl@1.3.3: {}
 
-  partial-json@0.1.7: {}
-
   path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
@@ -16836,6 +18169,12 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.2.4
+      minipass: 7.1.3
+    optional: true
+
   path-to-regexp@8.3.0: {}
 
   path-type@4.0.0: {}
@@ -16846,18 +18185,22 @@ snapshots:
     dependencies:
       "@napi-rs/canvas": 0.1.80
       pdfjs-dist: 5.4.296
+    optional: true
 
   pdf-to-img@5.0.0:
     dependencies:
       pdfjs-dist: 5.4.449
+    optional: true
 
   pdfjs-dist@5.4.296:
     optionalDependencies:
       "@napi-rs/canvas": 0.1.86
+    optional: true
 
   pdfjs-dist@5.4.449:
     optionalDependencies:
       "@napi-rs/canvas": 0.1.86
+    optional: true
 
   picocolors@1.1.1: {}
 
@@ -16865,13 +18208,67 @@ snapshots:
 
   pidtree@0.6.0: {}
 
+  pidusage@4.0.1:
+    dependencies:
+      safe-buffer: 5.2.1
+    optional: true
+
   pify@3.0.0: {}
 
   pify@4.0.1: {}
 
+  pino-abstract-transport@1.2.0:
+    dependencies:
+      readable-stream: 4.7.0
+      split2: 4.2.0
+    optional: true
+
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+    optional: true
+
   pino-abstract-transport@3.0.0:
     dependencies:
       split2: 4.2.0
+    optional: true
+
+  pino-pretty@11.3.0:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 3.0.2
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pump: 3.0.3
+      readable-stream: 4.7.0
+      secure-json-parse: 2.7.0
+      sonic-boom: 4.2.1
+      strip-json-comments: 3.1.1
+    optional: true
+
+  pino-pretty@13.1.3:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 4.0.3
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pump: 3.0.3
+      secure-json-parse: 4.1.0
+      sonic-boom: 4.2.1
+      strip-json-comments: 5.0.3
+    optional: true
+
+  pino-std-serializers@6.2.2:
     optional: true
 
   pino-std-serializers@7.1.0:
@@ -16892,6 +18289,36 @@ snapshots:
       thread-stream: 4.0.0
     optional: true
 
+  pino@8.21.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+      fast-redact: 3.5.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 1.2.0
+      pino-std-serializers: 6.2.2
+      process-warning: 3.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 3.8.1
+      thread-stream: 2.7.0
+    optional: true
+
+  pino@9.14.0:
+    dependencies:
+      "@pinojs/redact": 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.2.0
+    optional: true
+
   pirates@4.0.7: {}
 
   pkce-challenge@5.0.0: {}
@@ -16905,6 +18332,9 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
+  platform@1.3.6:
+    optional: true
+
   plimit-lit@1.6.1:
     dependencies:
       queue-lit: 1.5.2
@@ -16917,21 +18347,6 @@ snapshots:
       https: 1.0.0
       image-size: 1.2.1
       jszip: 3.10.1
-
-  prebuild-install@7.1.3:
-    dependencies:
-      detect-libc: 2.1.2
-      expand-template: 2.0.3
-      github-from-package: 0.0.0
-      minimist: 1.2.8
-      mkdirp-classic: 0.5.3
-      napi-build-utils: 2.0.0
-      node-abi: 3.85.0
-      pump: 3.0.3
-      rc: 1.2.8
-      simple-get: 4.0.1
-      tar-fs: 2.1.4
-      tunnel-agent: 0.6.0
     optional: true
 
   prelude-ls@1.2.1: {}
@@ -16952,10 +18367,16 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
+  process-warning@3.0.0:
+    optional: true
+
   process-warning@4.0.1:
     optional: true
 
   process-warning@5.0.0:
+    optional: true
+
+  process@0.11.10:
     optional: true
 
   progress@2.0.3:
@@ -17024,8 +18445,12 @@ snapshots:
   queue@6.0.2:
     dependencies:
       inherits: 2.0.4
+    optional: true
 
   quick-format-unescaped@4.0.4:
+    optional: true
+
+  quick-lru@6.1.2:
     optional: true
 
   range-parser@1.2.1: {}
@@ -17102,9 +18527,19 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+    optional: true
+
   readdir-glob@1.1.3:
     dependencies:
       minimatch: 5.1.6
+    optional: true
 
   readdirp@3.6.0:
     dependencies:
@@ -17113,11 +18548,13 @@ snapshots:
   real-require@0.2.0:
     optional: true
 
-  redis-errors@1.2.0: {}
+  redis-errors@1.2.0:
+    optional: true
 
   redis-parser@3.0.0:
     dependencies:
       redis-errors: 1.2.0
+    optional: true
 
   redis@4.7.1:
     dependencies:
@@ -17145,6 +18582,15 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  require-in-the-middle@7.5.2:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+      resolve: 1.22.10
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   resolve-cwd@3.0.0:
     dependencies:
@@ -17198,6 +18644,16 @@ snapshots:
     dependencies:
       glob: 10.4.5
 
+  roarr@2.15.4:
+    dependencies:
+      boolean: 3.2.0
+      detect-node: 2.1.0
+      globalthis: 1.0.4
+      json-stringify-safe: 5.0.1
+      semver-compare: 1.0.0
+      sprintf-js: 1.1.3
+    optional: true
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -17240,18 +18696,16 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sax@1.4.3: {}
-
   saxes@5.0.1:
     dependencies:
       xmlchars: 2.2.0
+    optional: true
 
-  secure-json-parse@2.7.0: {}
+  secure-json-parse@2.7.0:
+    optional: true
 
   secure-json-parse@4.1.0:
     optional: true
-
-  seedrandom@3.0.5: {}
 
   semantic-release@24.2.7(typescript@5.8.3):
     dependencies:
@@ -17288,6 +18742,9 @@ snapshots:
       - supports-color
       - typescript
 
+  semver-compare@1.0.0:
+    optional: true
+
   semver-diff@4.0.0:
     dependencies:
       semver: 7.7.2
@@ -17298,7 +18755,8 @@ snapshots:
 
   semver@7.7.2: {}
 
-  semver@7.7.4: {}
+  semver@7.7.4:
+    optional: true
 
   send@1.2.0:
     dependencies:
@@ -17316,6 +18774,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  serialize-error@7.0.1:
+    dependencies:
+      type-fest: 0.13.1
+    optional: true
+
   serve-static@2.2.0:
     dependencies:
       encodeurl: 2.0.0
@@ -17328,7 +18791,8 @@ snapshots:
   set-cookie-parser@2.7.2:
     optional: true
 
-  setimmediate@1.0.5: {}
+  setimmediate@1.0.5:
+    optional: true
 
   setprototypeof@1.2.0: {}
 
@@ -17377,6 +18841,9 @@ snapshots:
       vscode-oniguruma: 1.7.0
       vscode-textmate: 8.0.0
 
+  shimmer@1.2.1:
+    optional: true
+
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -17415,16 +18882,6 @@ snapshots:
       figures: 2.0.0
       pkg-conf: 2.1.0
 
-  simple-concat@1.0.1:
-    optional: true
-
-  simple-get@4.0.1:
-    dependencies:
-      decompress-response: 6.0.0
-      once: 1.4.0
-      simple-concat: 1.0.1
-    optional: true
-
   sisteransi@1.0.5: {}
 
   skin-tone@2.0.0:
@@ -17444,6 +18901,11 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 5.1.0
+
+  sonic-boom@3.8.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+    optional: true
 
   sonic-boom@4.2.1:
     dependencies:
@@ -17492,11 +18954,20 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  sprintf-js@1.1.3:
+    optional: true
+
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
 
-  standard-as-callback@2.1.0: {}
+  standard-as-callback@2.1.0:
+    optional: true
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      "@stablelib/base64": 1.0.1
+      fast-sha256: 1.3.0
 
   statuses@1.5.0:
     optional: true
@@ -17589,11 +19060,15 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-json-comments@5.0.3:
+    optional: true
+
   strnum@2.2.0: {}
 
   strtok3@10.3.4:
     dependencies:
       "@tokenizer/token": 0.3.0
+    optional: true
 
   stubs@3.0.0: {}
 
@@ -17623,14 +19098,6 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tar-fs@2.1.4:
-    dependencies:
-      chownr: 1.1.4
-      mkdirp-classic: 0.5.3
-      pump: 3.0.3
-      tar-stream: 2.2.0
-    optional: true
-
   tar-stream@2.2.0:
     dependencies:
       bl: 4.1.0
@@ -17638,6 +19105,7 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   tar-stream@3.1.8:
     dependencies:
@@ -17697,6 +19165,16 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  thread-stream@2.7.0:
+    dependencies:
+      real-require: 0.2.0
+    optional: true
+
+  thread-stream@3.2.0:
+    dependencies:
+      real-require: 0.2.0
+    optional: true
+
   thread-stream@4.0.0:
     dependencies:
       real-require: 0.2.0
@@ -17713,13 +19191,12 @@ snapshots:
     dependencies:
       convert-hrtime: 5.0.0
 
-  tiny-emitter@2.1.0: {}
-
   tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
 
-  tmp@0.2.5: {}
+  tmp@0.2.5:
+    optional: true
 
   tmpl@1.0.5: {}
 
@@ -17737,14 +19214,18 @@ snapshots:
       "@borewit/text-codec": 0.2.1
       "@tokenizer/token": 0.3.0
       ieee754: 1.2.1
+    optional: true
 
   tr46@0.0.3: {}
 
-  traverse@0.3.9: {}
+  traverse@0.3.9:
+    optional: true
 
   traverse@0.6.8: {}
 
   tree-kill@1.2.2: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
@@ -17835,11 +19316,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  tunnel-agent@0.6.0:
-    dependencies:
-      safe-buffer: 5.2.1
-    optional: true
-
   tunnel@0.0.6: {}
 
   type-check@0.4.0:
@@ -17847,6 +19323,9 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-detect@4.0.8: {}
+
+  type-fest@0.13.1:
+    optional: true
 
   type-fest@0.21.3: {}
 
@@ -17872,8 +19351,6 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.1
 
-  typed-function@4.2.1: {}
-
   typedarray@0.0.6:
     optional: true
 
@@ -17887,12 +19364,17 @@ snapshots:
 
   typescript@5.8.3: {}
 
+  ufo@1.6.4:
+    optional: true
+
   uglify-js@3.19.3:
     optional: true
 
-  uint8array-extras@1.5.0: {}
+  uint8array-extras@1.5.0:
+    optional: true
 
-  underscore@1.13.7: {}
+  underscore@1.13.7:
+    optional: true
 
   undici-types@6.21.0: {}
 
@@ -17928,6 +19410,7 @@ snapshots:
       listenercount: 1.0.1
       readable-stream: 2.3.8
       setimmediate: 1.0.5
+    optional: true
 
   update-browserslist-db@1.1.3(browserslist@4.25.1):
     dependencies:
@@ -17943,11 +19426,11 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@11.1.0: {}
+  uuid@11.1.0:
+    optional: true
 
-  uuid@13.0.0: {}
-
-  uuid@8.3.2: {}
+  uuid@8.3.2:
+    optional: true
 
   uuid@9.0.1: {}
 
@@ -17990,12 +19473,14 @@ snapshots:
   which@1.3.1:
     dependencies:
       isexe: 2.0.0
+    optional: true
 
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
-  win-guid@0.2.1: {}
+  win-guid@0.2.1:
+    optional: true
 
   word-wrap@1.2.5: {}
 
@@ -18032,23 +19517,18 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
 
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   wsl-utils@0.3.1:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
-  xml2js@0.6.2:
-    dependencies:
-      sax: 1.4.3
-      xmlbuilder: 11.0.1
+  xmlbuilder@10.1.1:
+    optional: true
 
-  xmlbuilder@10.1.1: {}
-
-  xmlbuilder@11.0.1: {}
-
-  xmlchars@2.2.0: {}
+  xmlchars@2.2.0:
+    optional: true
 
   xtend@4.0.2: {}
 
@@ -18108,6 +19588,7 @@ snapshots:
       archiver-utils: 3.0.4
       compress-commons: 4.1.2
       readable-stream: 3.6.2
+    optional: true
 
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@
  * Main export file
  */
 
+import { createRequire } from "node:module";
+
 // ============================================================================
 // Core Exports
 // ============================================================================
@@ -68,7 +70,26 @@ export type {
 // Version Information
 // ============================================================================
 
-export const VERSION = "2.2.1";
+/**
+ * Single source of truth for the Yama version: read from package.json at runtime
+ * (this module sits one level below package.json in both src/ and dist/, so the
+ * relative require resolves in dev and in the published build). Falls back to a
+ * sentinel if the file can't be read, instead of drifting from a hardcoded
+ * literal.
+ */
+function resolveVersion(): string {
+  try {
+    const require = createRequire(import.meta.url);
+    const pkg = require("../package.json") as { version?: string };
+    return typeof pkg.version === "string" && pkg.version.length > 0
+      ? pkg.version
+      : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+export const VERSION = resolveVersion();
 
 // ============================================================================
 // Default Export

--- a/src/v2/config/ConfigLoader.ts
+++ b/src/v2/config/ConfigLoader.ts
@@ -24,14 +24,18 @@ export class ConfigLoader {
   ): Promise<YamaConfig> {
     console.log("📋 Loading Yama configuration...");
 
+    // Final precedence (lowest → highest):
+    //   defaults < file < env < instance overrides
+    // Environment variables intentionally override the committed config file
+    // (the standard expectation). Env overrides are re-applied AFTER the file
+    // merge; they are idempotent and only mutate values when the env var is
+    // actually set (see applyEnvironmentOverrides / applyMemoryOverrides), so
+    // they never clobber file values with undefined.
+
     // Layer 1: Start with default config
     let config = DefaultConfig.get();
 
-    // Layer 2: Apply environment variable overrides
-    // Lowest user-provided layer in SDK mode precedence.
-    config = this.applyEnvironmentOverrides(config);
-
-    // Layer 3: Load from file if provided or search for default locations
+    // Layer 2: Load from file if provided or search for default locations
     const filePath = await this.resolveConfigPath(configPath);
     if (filePath) {
       console.log(`   Reading config from: ${filePath}`);
@@ -42,6 +46,9 @@ export class ConfigLoader {
       console.log("   Using default configuration (no config file found)");
     }
 
+    // Layer 3: Apply environment variable overrides AFTER the file so env wins
+    // over the committed config (consistently for both ai.* and memory.*).
+    config = this.applyEnvironmentOverrides(config);
     config.memory = this.applyMemoryOverrides(config.memory);
 
     // Layer 4: Apply SDK instance overrides (highest priority)

--- a/src/v2/config/DefaultConfig.ts
+++ b/src/v2/config/DefaultConfig.ts
@@ -22,7 +22,8 @@ export class DefaultConfig {
         provider: "auto",
         model: "gemini-2.5-pro",
         temperature: 0.2,
-        maxTokens: 128000,
+        // Sane output ceiling (NeuroLink clamps further per-model server-side).
+        maxTokens: 32000,
         enableAnalytics: true,
         enableEvaluation: false,
         timeout: "15m",
@@ -41,7 +42,8 @@ export class DefaultConfig {
           provider: "auto",
           model: "gemini-2.5-flash",
           temperature: 0.1,
-          maxTokens: 32000,
+          // Lighter sub-task: sane output ceiling (NeuroLink clamps further per-model server-side).
+          maxTokens: 16000,
           timeout: "5m",
           cacheResults: true,
         },

--- a/src/v2/core/LearningOrchestrator.ts
+++ b/src/v2/core/LearningOrchestrator.ts
@@ -25,6 +25,7 @@ import {
   buildObservabilityConfigFromEnv,
   validateObservabilityConfig,
 } from "../utils/ObservabilityConfig.js";
+import { clampMaxTokens } from "../utils/tokenLimits.js";
 
 // Type for structured learning extraction output
 interface LearningExtractionOutput {
@@ -127,7 +128,7 @@ export class LearningOrchestrator {
         provider: this.config.ai.provider,
         model: this.config.ai.model,
         temperature: 0.1,
-        maxTokens: 50000,
+        maxTokens: clampMaxTokens(50000),
         timeout: this.config.ai.timeout,
         context: {
           operation: "learning-fetch-comments",
@@ -154,7 +155,7 @@ export class LearningOrchestrator {
         provider: this.config.ai.provider,
         model: this.config.ai.model,
         temperature: 0.2,
-        maxTokens: 10000,
+        maxTokens: clampMaxTokens(10000),
         timeout: "2m",
         disableTools: true, // No tools needed for extraction phase
         context: {
@@ -254,7 +255,7 @@ export class LearningOrchestrator {
             provider: this.config.ai.provider,
             model: this.config.ai.model,
             temperature: 0.1,
-            maxTokens: 100,
+            maxTokens: clampMaxTokens(100),
             disableTools: true,
             context: {
               userId: ownerId,
@@ -490,20 +491,16 @@ Analyze the PR data above and extract learnings.
     prId: number,
   ): ExtractedLearning[] {
     try {
-      const content = (response.content || "") as string;
+      // Prefer the provider's structured output (NeuroLink populates
+      // `structuredData` when the model returns a parsed object) before falling
+      // back to hand-parsing the raw text. This avoids brittle regex extraction
+      // when a clean object is already available.
+      const structured = this.coerceLearningOutput(response.structuredData);
 
-      // Find JSON in response (may be in code block)
-      const jsonMatch =
-        content.match(/```json\s*([\s\S]*?)\s*```/) ||
-        content.match(/\{[\s\S]*\}/);
-
-      if (!jsonMatch) {
-        console.log("   ⚠️ No JSON found in extraction response");
+      const parsed = structured ?? this.parseLearningOutputFromText(response);
+      if (!parsed) {
         return [];
       }
-
-      const jsonStr = jsonMatch[1] || jsonMatch[0];
-      const parsed = JSON.parse(jsonStr) as LearningExtractionOutput;
 
       // Log summary if available
       if (parsed.summary) {
@@ -540,6 +537,64 @@ Analyze the PR data above and extract learnings.
       );
       return [];
     }
+  }
+
+  /**
+   * Validate that a candidate value (typically `response.structuredData`) is a
+   * usable learning-extraction object. Returns it typed when it carries a
+   * `learnings` array, otherwise null so callers fall back to text parsing.
+   */
+  private coerceLearningOutput(
+    candidate: unknown,
+  ): LearningExtractionOutput | null {
+    if (
+      candidate &&
+      typeof candidate === "object" &&
+      Array.isArray((candidate as { learnings?: unknown }).learnings)
+    ) {
+      return candidate as LearningExtractionOutput;
+    }
+    return null;
+  }
+
+  /**
+   * Fallback parser: extract the learning-extraction JSON from the raw response
+   * text (may be wrapped in a ```json code block).
+   */
+  private parseLearningOutputFromText(
+    response: Record<string, unknown>,
+  ): LearningExtractionOutput | null {
+    const content = (response.content || "") as string;
+
+    // Extract JSON without backtracking-prone regexes (ReDoS-safe): locate the
+    // fenced ```json block (or the first '{' .. last '}' span) via linear string
+    // scans instead of polynomial regex matching on uncontrolled model output.
+    let jsonStr: string | null = null;
+
+    const fenceToken = "```json";
+    const fenceStart = content.indexOf(fenceToken);
+    if (fenceStart !== -1) {
+      const afterFence = fenceStart + fenceToken.length;
+      const fenceEnd = content.indexOf("```", afterFence);
+      if (fenceEnd !== -1) {
+        jsonStr = content.slice(afterFence, fenceEnd).trim();
+      }
+    }
+
+    if (!jsonStr) {
+      const objStart = content.indexOf("{");
+      const objEnd = content.lastIndexOf("}");
+      if (objStart !== -1 && objEnd > objStart) {
+        jsonStr = content.slice(objStart, objEnd + 1);
+      }
+    }
+
+    if (!jsonStr) {
+      console.log("   ⚠️ No JSON found in extraction response");
+      return null;
+    }
+
+    return JSON.parse(jsonStr) as LearningExtractionOutput;
   }
 
   // ============================================================================
@@ -669,7 +724,7 @@ Consolidate the learnings as instructed. Return the complete updated knowledge b
       provider: this.config.ai.provider,
       model: this.config.ai.model,
       temperature: 0.2,
-      maxTokens: 30000,
+      maxTokens: clampMaxTokens(30000),
     });
 
     // Parse and update the knowledge base

--- a/src/v2/core/MCPServerManager.ts
+++ b/src/v2/core/MCPServerManager.ts
@@ -6,6 +6,7 @@
 import { join } from "path";
 import { MCPServersConfig, GitHubConfig } from "../types/config.types.js";
 import { MCPServerError } from "../types/v2.types.js";
+import { isMutatingGitTool as isMutatingGitToolShared } from "../utils/toolPolicy.js";
 
 /**
  * Default remote HTTP endpoint for GitHub's hosted MCP server.
@@ -229,11 +230,12 @@ export class MCPServerManager {
   }
 
   private isMutatingGitTool(toolName: string): boolean {
-    // Handles plain names (git_commit) and prefixed names (local-git.git_commit).
-    const normalized = toolName.split(/[.:/]/).pop() || toolName;
-    return /^git_(commit|push|add|checkout|create_branch|merge|rebase|cherry_pick|reset|revert|tag|rm|clean|stash|apply)\b/i.test(
-      normalized,
-    );
+    // Delegate to the shared fail-closed allow-list policy: any git_* tool not
+    // on the read-only allow-list is treated as mutating. This closes the gaps
+    // the old regex blocklist missed (git_branch, git_mv, git_pull, git_fetch,
+    // git_restore, git_switch, git_remote). Prefix handling (local-git.git_*)
+    // is performed inside the shared helper.
+    return isMutatingGitToolShared(toolName);
   }
 
   /**

--- a/src/v2/core/YamaV2Orchestrator.ts
+++ b/src/v2/core/YamaV2Orchestrator.ts
@@ -24,7 +24,6 @@ import {
   ReviewRequest,
   ReviewResult,
   ReviewMode,
-  ReviewUpdate,
   ReviewStatistics,
   TokenUsage,
   UnifiedReviewRequest,
@@ -35,6 +34,9 @@ import {
   buildObservabilityConfigFromEnv,
   validateObservabilityConfig,
 } from "../utils/ObservabilityConfig.js";
+import { clampMaxTokens } from "../utils/tokenLimits.js";
+import { isMutatingGitTool } from "../utils/toolPolicy.js";
+import { VERSION } from "../../index.js";
 
 export class YamaOrchestrator {
   private neurolink!: NeuroLink;
@@ -247,26 +249,31 @@ export class YamaOrchestrator {
         "   AI will now make decisions and execute actions autonomously\n",
       );
 
-      // Review call: RETRIEVE memory (for context), but DON'T STORE
-      const aiResponse = await this.neurolink.generate({
-        input: { text: instructions },
-        provider: this.config.ai.provider,
-        model: this.config.ai.model,
-        temperature: this.config.ai.temperature,
-        maxTokens: this.config.ai.maxTokens,
-        timeout: this.config.ai.timeout,
-        skipToolPromptInjection: true,
-        ...this.getPRToolFilteringOptions(instructions),
-        context: {
-          sessionId,
-          userId: this.getUserId(request),
-          operation: "code-review",
-          metadata: toolContext.metadata,
-        },
-        memory: { read: true, write: false },
-        enableAnalytics: this.config.ai.enableAnalytics,
-        enableEvaluation: this.config.ai.enableEvaluation,
-      } as unknown as Parameters<NeuroLink["generate"]>[0]);
+      // Review call: RETRIEVE memory (for context), but DON'T STORE.
+      // Wrapped in a bounded retry (ai.retryAttempts) for transient failures.
+      const aiResponse = await this.generateWithRetry(
+        () =>
+          this.neurolink.generate({
+            input: { text: instructions },
+            provider: this.config.ai.provider,
+            model: this.config.ai.model,
+            temperature: this.config.ai.temperature,
+            maxTokens: clampMaxTokens(this.config.ai.maxTokens),
+            timeout: this.config.ai.timeout,
+            skipToolPromptInjection: true,
+            ...this.getPRToolFilteringOptions(instructions),
+            context: {
+              sessionId,
+              userId: this.getUserId(request),
+              operation: "code-review",
+              metadata: toolContext.metadata,
+            },
+            memory: { read: true, write: false },
+            enableAnalytics: this.config.ai.enableAnalytics,
+            enableEvaluation: this.config.ai.enableEvaluation,
+          } as unknown as Parameters<NeuroLink["generate"]>[0]),
+        "code-review",
+      );
       this.recordToolCallsFromResponse(sessionId, aiResponse);
 
       // Extract and parse results
@@ -333,32 +340,36 @@ export class YamaOrchestrator {
       );
       this.setToolContext(toolContext);
 
-      const aiResponse = await this.neurolink.generate({
-        input: { text: instructions },
-        provider: this.config.ai.provider,
-        model: this.config.ai.model,
-        temperature: this.config.ai.temperature,
-        maxTokens: Math.min(this.config.ai.maxTokens, 16_000),
-        timeout: this.config.ai.timeout,
-        enableAnalytics: this.config.ai.enableAnalytics,
-        enableEvaluation: this.config.ai.enableEvaluation,
-        // Request JSON output at the provider level (prompt-level mode; safe alongside tools).
-        output: { format: "json" },
-        // Tools are passed natively; avoids huge duplicated tool-schema prompt injection.
-        skipToolPromptInjection: true,
-        ...this.getLocalToolFilteringOptions(),
-        context: {
-          sessionId,
-          userId: this.getUserId(pseudoRequest),
-          operation: "local-review",
-          metadata: {
-            repoPath: diffContext.repoPath,
-            diffSource: diffContext.diffSource,
-            baseRef: diffContext.baseRef,
-            headRef: diffContext.headRef,
-          },
-        },
-      } as unknown as Parameters<NeuroLink["generate"]>[0]);
+      const aiResponse = await this.generateWithRetry(
+        () =>
+          this.neurolink.generate({
+            input: { text: instructions },
+            provider: this.config.ai.provider,
+            model: this.config.ai.model,
+            temperature: this.config.ai.temperature,
+            maxTokens: clampMaxTokens(this.config.ai.maxTokens),
+            timeout: this.config.ai.timeout,
+            enableAnalytics: this.config.ai.enableAnalytics,
+            enableEvaluation: this.config.ai.enableEvaluation,
+            // Request JSON output at the provider level (prompt-level mode; safe alongside tools).
+            output: { format: "json" },
+            // Tools are passed natively; avoids huge duplicated tool-schema prompt injection.
+            skipToolPromptInjection: true,
+            ...this.getLocalToolFilteringOptions(),
+            context: {
+              sessionId,
+              userId: this.getUserId(pseudoRequest),
+              operation: "local-review",
+              metadata: {
+                repoPath: diffContext.repoPath,
+                diffSource: diffContext.diffSource,
+                baseRef: diffContext.baseRef,
+                headRef: diffContext.headRef,
+              },
+            },
+          } as unknown as Parameters<NeuroLink["generate"]>[0]),
+        "local-review",
+      );
       this.recordToolCallsFromResponse(sessionId, aiResponse);
 
       const result = this.parseLocalReviewResult(
@@ -375,78 +386,6 @@ export class YamaOrchestrator {
         result as unknown as ReviewResult,
       );
       return result;
-    } catch (error) {
-      this.sessionManager.failSession(sessionId, error as Error);
-      throw error;
-    }
-  }
-
-  /**
-   * Stream review with real-time updates (for verbose mode)
-   */
-  async *streamReview(
-    request: ReviewRequest,
-  ): AsyncIterableIterator<ReviewUpdate> {
-    await this.ensureInitialized("pr", request.configPath, request);
-
-    const sessionId = this.sessionManager.createSession(request);
-
-    try {
-      const bootstrapStandards = await this.getBootstrappedStandards(
-        request,
-        sessionId,
-      );
-
-      // Build instructions
-      const instructions = await this.promptBuilder.buildReviewInstructions(
-        request,
-        this.config,
-        bootstrapStandards,
-        this.detectedProvider,
-      );
-
-      // Create tool context
-      const toolContext = this.createToolContext(sessionId, request);
-      this.setToolContext(toolContext);
-
-      // Stream AI execution
-      yield {
-        type: "progress",
-        timestamp: new Date().toISOString(),
-        sessionId,
-        data: {
-          phase: "context_gathering",
-          progress: 0,
-          message: "Starting review...",
-        },
-      };
-
-      // Note: NeuroLink streaming implementation depends on version
-      // This is a placeholder for streaming functionality
-      const aiResponse = await this.neurolink.generate({
-        input: { text: instructions },
-        provider: this.config.ai.provider,
-        model: this.config.ai.model,
-        skipToolPromptInjection: true,
-        ...this.getPRToolFilteringOptions(instructions),
-        context: {
-          sessionId,
-          userId: this.getUserId(request),
-        },
-        memory: { enabled: false },
-        enableAnalytics: true,
-      } as unknown as Parameters<NeuroLink["generate"]>[0]);
-
-      yield {
-        type: "progress",
-        timestamp: new Date().toISOString(),
-        sessionId,
-        data: {
-          phase: "decision_making",
-          progress: 100,
-          message: "Review complete",
-        },
-      };
     } catch (error) {
       this.sessionManager.failSession(sessionId, error as Error);
       throw error;
@@ -510,7 +449,7 @@ export class YamaOrchestrator {
         provider: this.config.ai.provider,
         model: this.config.ai.model,
         temperature: this.config.ai.temperature,
-        maxTokens: this.config.ai.maxTokens,
+        maxTokens: clampMaxTokens(this.config.ai.maxTokens),
         timeout: this.config.ai.timeout,
         skipToolPromptInjection: true,
         ...this.getPRToolFilteringOptions(reviewInstructions),
@@ -558,7 +497,7 @@ export class YamaOrchestrator {
           provider: this.config.ai.provider,
           model: this.config.ai.model,
           temperature: this.config.ai.temperature,
-          maxTokens: this.config.ai.maxTokens,
+          maxTokens: clampMaxTokens(this.config.ai.maxTokens),
           timeout: this.config.ai.timeout,
           skipToolPromptInjection: true,
           ...this.getPRToolFilteringOptions(enhanceInstructions),
@@ -696,7 +635,7 @@ export class YamaOrchestrator {
       branch: request.branch,
       dryRun: request.dryRun || false,
       metadata: {
-        yamaVersion: "2.2.1",
+        yamaVersion: VERSION,
         startTime: new Date().toISOString(),
       },
     };
@@ -718,7 +657,7 @@ export class YamaOrchestrator {
       repository: request.repository || request.repo,
       dryRun: request.dryRun || false,
       metadata: {
-        yamaVersion: "2.2.1",
+        yamaVersion: VERSION,
         startTime: new Date().toISOString(),
         repoPath: diffContext.repoPath,
         diffSource: diffContext.diffSource,
@@ -731,6 +670,83 @@ export class YamaOrchestrator {
   private setToolContext(context: Record<string, unknown>): void {
     this.currentToolContext = context;
     (this.neurolink as any).setToolContext(context);
+  }
+
+  /**
+   * Run a NeuroLink generate() call with a small bounded retry on transient
+   * errors (wires up the previously-unused `ai.retryAttempts` config). Retries
+   * up to `retryAttempts` times (>=1 total attempt) with a short exponential
+   * backoff. Non-transient errors (e.g. auth/validation) fail fast on the first
+   * attempt so we don't paper over real misconfiguration.
+   */
+  private async generateWithRetry<T>(
+    run: () => Promise<T>,
+    label: string,
+  ): Promise<T> {
+    const configured = this.config.ai.retryAttempts;
+    const maxAttempts =
+      typeof configured === "number" && Number.isFinite(configured)
+        ? Math.max(1, Math.floor(configured))
+        : 1;
+
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return await run();
+      } catch (error) {
+        lastError = error;
+        if (attempt >= maxAttempts || !this.isTransientError(error)) {
+          throw error;
+        }
+        const backoffMs = Math.min(1000 * 2 ** (attempt - 1), 8000);
+        console.warn(
+          `   ⚠️  ${label} generate attempt ${attempt}/${maxAttempts} failed ` +
+            `(${(error as Error).message}); retrying in ${backoffMs}ms...`,
+        );
+        await this.delay(backoffMs);
+      }
+    }
+    // Unreachable in practice (loop either returns or throws), but keeps types happy.
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  }
+
+  /**
+   * Heuristic transient-error classifier for retry decisions. Conservative:
+   * matches common network / rate-limit / timeout / 5xx signals and leaves
+   * everything else (auth, validation, 4xx) as non-retryable.
+   */
+  private isTransientError(error: unknown): boolean {
+    const message = (
+      error instanceof Error ? error.message : String(error ?? "")
+    ).toLowerCase();
+    if (!message) {
+      return false;
+    }
+    return (
+      message.includes("timeout") ||
+      message.includes("timed out") ||
+      message.includes("etimedout") ||
+      message.includes("econnreset") ||
+      message.includes("econnrefused") ||
+      message.includes("enotfound") ||
+      message.includes("eai_again") ||
+      message.includes("socket hang up") ||
+      message.includes("network") ||
+      message.includes("rate limit") ||
+      message.includes("rate_limit") ||
+      message.includes("too many requests") ||
+      message.includes("429") ||
+      message.includes("500") ||
+      message.includes("502") ||
+      message.includes("503") ||
+      message.includes("504") ||
+      message.includes("overloaded") ||
+      message.includes("temporarily unavailable")
+    );
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   /**
@@ -760,11 +776,13 @@ export class YamaOrchestrator {
       summary: this.extractSummary(aiResponse),
       duration,
       tokenUsage: {
-        input: this.toSafeNumber(aiResponse?.usage?.inputTokens),
-        output: this.toSafeNumber(aiResponse?.usage?.outputTokens),
-        total: this.toSafeNumber(aiResponse?.usage?.totalTokens),
+        // NeuroLink 9.70.x usage shape is { input, output, total } — NOT
+        // inputTokens/outputTokens/totalTokens (those always resolved to 0).
+        input: this.toSafeNumber(aiResponse?.usage?.input),
+        output: this.toSafeNumber(aiResponse?.usage?.output),
+        total: this.toSafeNumber(aiResponse?.usage?.total),
       },
-      costEstimate: this.calculateCost(aiResponse.usage),
+      costEstimate: this.calculateCost(aiResponse),
       sessionId,
     };
   }
@@ -812,25 +830,50 @@ export class YamaOrchestrator {
     diffContext: LocalDiffContext,
   ): LocalReviewResult {
     const rawContent = aiResponse?.content || aiResponse?.outputs?.text || "";
-    const parsed = this.extractJsonPayload(rawContent);
+    // Prefer NeuroLink's already-parsed structuredData (output.format "json")
+    // before re-parsing the raw content string by hand; fall back to the
+    // hand-parse so older shapes / non-JSON outputs still work.
+    const structured =
+      aiResponse?.structuredData &&
+      typeof aiResponse.structuredData === "object" &&
+      !Array.isArray(aiResponse.structuredData)
+        ? (aiResponse.structuredData as Record<string, any>)
+        : null;
+    const parsed = structured ?? this.extractJsonPayload(rawContent);
+    const jsonTruncated = aiResponse?.jsonTruncated === true;
     const usage = aiResponse?.usage || {};
     const tokenUsage: TokenUsage = {
-      input: this.toSafeNumber(usage.inputTokens),
-      output: this.toSafeNumber(usage.outputTokens),
-      total: this.toSafeNumber(usage.totalTokens),
+      // NeuroLink 9.70.x usage shape is { input, output, total }.
+      input: this.toSafeNumber(usage.input),
+      output: this.toSafeNumber(usage.output),
+      total: this.toSafeNumber(usage.total),
     };
 
     if (!parsed) {
-      const fallbackIssue: LocalReviewFinding = {
-        id: "OUTPUT_FORMAT_VIOLATION",
-        severity: "MAJOR",
-        category: "review-engine",
-        title: "Model did not return structured JSON",
-        description:
-          "Local review response was unstructured (likely tool-call trace or partial output), so findings cannot be trusted.",
-        suggestion:
-          "Retry with a tool-calling capable model or reduce review scope (smaller diff / includePaths) to keep responses structured.",
-      };
+      // Distinguish a truncated response (model ran out of output budget mid-JSON)
+      // from a genuinely malformed one, and advise raising maxTokens in that case
+      // rather than emitting the generic format-violation guidance.
+      const fallbackIssue: LocalReviewFinding = jsonTruncated
+        ? {
+            id: "OUTPUT_TRUNCATED",
+            severity: "MAJOR",
+            category: "review-engine",
+            title: "Model output was truncated before valid JSON completed",
+            description:
+              "The local review response was cut off (jsonTruncated), so the JSON could not be parsed and findings cannot be trusted.",
+            suggestion:
+              "Raise ai.maxTokens (output budget) and/or reduce review scope (smaller diff / includePaths) so the structured JSON can finish.",
+          }
+        : {
+            id: "OUTPUT_FORMAT_VIOLATION",
+            severity: "MAJOR",
+            category: "review-engine",
+            title: "Model did not return structured JSON",
+            description:
+              "Local review response was unstructured (likely tool-call trace or partial output), so findings cannot be trusted.",
+            suggestion:
+              "Retry with a tool-calling capable model or reduce review scope (smaller diff / includePaths) to keep responses structured.",
+          };
       const issuesBySeverity = this.countFindingsBySeverity([fallbackIssue]);
 
       return {
@@ -838,7 +881,9 @@ export class YamaOrchestrator {
         decision: "CHANGES_REQUESTED",
         summary:
           this.sanitizeLocalSummary(rawContent) ||
-          "Local review could not produce structured JSON output.",
+          (jsonTruncated
+            ? "Local review output was truncated before valid JSON completed."
+            : "Local review could not produce structured JSON output."),
         issues: [fallbackIssue],
         enhancements: [],
         statistics: {
@@ -851,7 +896,7 @@ export class YamaOrchestrator {
         },
         duration: Math.round((Date.now() - startTime) / 1000),
         tokenUsage,
-        costEstimate: this.calculateCost(aiResponse?.usage),
+        costEstimate: this.calculateCost(aiResponse),
         sessionId,
         schemaVersion: request.outputSchemaVersion || "1.0",
         metadata: {
@@ -895,7 +940,7 @@ export class YamaOrchestrator {
       },
       duration: Math.round((Date.now() - startTime) / 1000),
       tokenUsage,
-      costEstimate: this.calculateCost(aiResponse?.usage),
+      costEstimate: this.calculateCost(aiResponse),
       sessionId,
       schemaVersion: request.outputSchemaVersion || "1.0",
       metadata: {
@@ -1004,7 +1049,12 @@ export class YamaOrchestrator {
     return findings
       .map((raw, index) => {
         const value = (raw || {}) as Record<string, unknown>;
-        const severity = this.normalizeSeverity(value.severity);
+        const ruleKey =
+          (typeof value.rule === "string" && value.rule) ||
+          (typeof value.category === "string" && value.category) ||
+          (typeof value.id === "string" && value.id) ||
+          undefined;
+        const severity = this.normalizeSeverity(value.severity, ruleKey);
         if (!severity) {
           return null;
         }
@@ -1045,9 +1095,33 @@ export class YamaOrchestrator {
 
   private normalizeSeverity(
     severity: unknown,
+    ruleKey?: string,
+  ): LocalReviewFinding["severity"] | null {
+    // Calibration: allow projectStandards.severityOverrides to remap a finding's
+    // severity by its rule/category key (defensive — config is optional and the
+    // override value is itself validated against the known severity set). This
+    // takes precedence over the model-reported severity.
+    const overrides = this.config.projectStandards?.severityOverrides;
+    if (overrides && ruleKey) {
+      const overridden = this.coerceSeverity(overrides[ruleKey]);
+      if (overridden) {
+        return overridden;
+      }
+    }
+
+    return this.coerceSeverity(severity) ?? "MINOR";
+  }
+
+  /**
+   * Map an arbitrary value to a known severity, or null if it is not one of the
+   * recognised levels. Unlike normalizeSeverity this does NOT default to MINOR,
+   * so callers can distinguish "unknown" from a real level.
+   */
+  private coerceSeverity(
+    severity: unknown,
   ): LocalReviewFinding["severity"] | null {
     if (typeof severity !== "string") {
-      return "MINOR";
+      return null;
     }
     const value = severity.toUpperCase();
     if (
@@ -1058,7 +1132,7 @@ export class YamaOrchestrator {
     ) {
       return value;
     }
-    return "MINOR";
+    return null;
   }
 
   private countFindingsBySeverity(
@@ -1124,8 +1198,11 @@ export class YamaOrchestrator {
     const toolCalls = session.toolCalls || [];
     const ts = getProviderToolset(this.detectedProvider);
 
-    let requestedChanges: boolean | undefined;
-    let approved: boolean | undefined;
+    // ORDER-AWARE: the LAST decisive review-status / approval tool call wins, so
+    // a later approval correctly overrides an earlier request-changes (and vice
+    // versa). The previous logic let any "BLOCKED" stick regardless of order,
+    // reporting BLOCKED even when the AI changed its mind and approved afterward.
+    let lastDecision: "APPROVED" | "BLOCKED" | undefined;
 
     for (const tc of toolCalls) {
       const decision = ts.interpretDecision({
@@ -1133,17 +1210,15 @@ export class YamaOrchestrator {
         args: tc?.args || {},
       });
 
-      if (decision === "BLOCKED") {
-        requestedChanges = true;
-      } else if (decision === "APPROVED") {
-        approved = true;
+      if (decision === "BLOCKED" || decision === "APPROVED") {
+        lastDecision = decision;
       }
     }
 
-    if (requestedChanges === true) {
+    if (lastDecision === "BLOCKED") {
       return "BLOCKED";
     }
-    if (approved === true) {
+    if (lastDecision === "APPROVED") {
       return "APPROVED";
     }
 
@@ -1248,7 +1323,10 @@ export class YamaOrchestrator {
     };
 
     commentCalls.forEach((call) => {
-      const text = call.args?.comment_text || "";
+      // Comment body field differs per provider: Bitbucket comment tools use
+      // `comment_text`, GitHub comment tools use `body`. Read either so severity
+      // counts work for both (GitHub previously always counted 0).
+      const text = call.args?.comment_text ?? call.args?.body ?? "";
 
       if (text.includes("🔒 CRITICAL") || text.includes("CRITICAL:")) {
         counts.critical++;
@@ -1275,19 +1353,34 @@ export class YamaOrchestrator {
   }
 
   /**
-   * Calculate cost estimate from token usage
+   * Calculate cost estimate from an AI response.
+   *
+   * Prefers NeuroLink's own analytics cost (`response.analytics.cost`, a USD
+   * number computed per-provider/model when enableAnalytics is true — Yama sets
+   * it). The previous implementation hardcoded Gemini-2.0-Flash pricing
+   * ($0.25/$1.00 per 1M) for EVERY provider, which is ~12-15x too low for Claude.
+   * Only when the analytics cost is unavailable do we fall back to a clearly
+   * labeled rough estimate based on the { input, output } token usage.
    */
-  private calculateCost(usage: any): number {
+  private calculateCost(aiResponse: any): number {
+    const analyticsCost = aiResponse?.analytics?.cost;
+    if (typeof analyticsCost === "number" && Number.isFinite(analyticsCost)) {
+      return Number(analyticsCost.toFixed(6));
+    }
+
+    const usage = aiResponse?.usage;
     if (!usage) {
       return 0;
     }
 
-    // Rough estimates (update with actual pricing)
-    const inputCostPer1M = 0.25; // $0.25 per 1M input tokens (Gemini 2.0 Flash)
-    const outputCostPer1M = 1.0; // $1.00 per 1M output tokens
+    // ROUGH FALLBACK ONLY — provider/model agnostic placeholder pricing used
+    // when NeuroLink analytics cost is unavailable. Not accurate for any
+    // specific model; treat as an order-of-magnitude estimate.
+    const inputCostPer1M = 0.25;
+    const outputCostPer1M = 1.0;
 
-    const inputTokens = this.toSafeNumber(usage.inputTokens);
-    const outputTokens = this.toSafeNumber(usage.outputTokens);
+    const inputTokens = this.toSafeNumber(usage.input);
+    const outputTokens = this.toSafeNumber(usage.output);
 
     const inputCost = (inputTokens / 1_000_000) * inputCostPer1M;
     const outputCost = (outputTokens / 1_000_000) * outputCostPer1M;
@@ -1326,8 +1419,30 @@ export class YamaOrchestrator {
       return {};
     }
 
-    const hasJiraSignal =
-      /\b[A-Z]{2,}-\d+\b/.test(inputText) || /\bjira\b/i.test(inputText);
+    // Jira issue-key signal. The naive /\b[A-Z]{2,}-\d+\b/ over-matched common
+    // non-Jira tokens (UTF-8, SHA-256, SHA256-..., CVE-2024, ISO-8601, RFC-3339),
+    // wrongly keeping Jira tools enabled. Exclude a small denylist of those
+    // prefixes so the match stays conservative (still keeps tools when a real
+    // ABC-123 style key — or the literal word "jira" — is present).
+    const jiraKeyPattern = /\b([A-Z]{2,})-\d+\b/g;
+    const nonJiraKeyPrefixes = new Set([
+      "UTF",
+      "SHA",
+      "SHA256",
+      "SHA512",
+      "MD5",
+      "CVE",
+      "ISO",
+      "RFC",
+      "UTC",
+      "GMT",
+      "BASE64",
+    ]);
+    const hasJiraKey = Array.from(
+      inputText.matchAll(jiraKeyPattern),
+      (m) => m[1],
+    ).some((prefix) => !nonJiraKeyPrefixes.has(prefix));
+    const hasJiraSignal = hasJiraKey || /\bjira\b/i.test(inputText);
 
     if (hasJiraSignal) {
       return {};
@@ -1362,7 +1477,11 @@ export class YamaOrchestrator {
 
   /**
    * Query-level read-only filtering for local-git MCP tools.
-   * Uses regex-based mutation detection instead of hardcoded tool-name lists.
+   *
+   * Uses the shared, fail-closed `isMutatingGitTool` helper (any git_* tool not
+   * on the read-only allow-list is treated as mutating) so the orchestrator,
+   * explorer, and MCP manager all agree on what is read-only. The previous local
+   * regex silently missed mutating tools like git_branch / git_mv / git_pull.
    */
   private getLocalToolFilteringOptions(): { excludeTools?: string[] } {
     try {
@@ -1371,8 +1490,6 @@ export class YamaOrchestrator {
         return {};
       }
 
-      const mutatingGitToolPattern =
-        /^git_(commit|push|add|checkout|create_branch|merge|rebase|cherry_pick|reset|revert|tag|rm|clean|stash|apply)\b/i;
       // High-volume read operations can flood context with huge payloads.
       const highVolumeGitToolPattern =
         /^git_(diff|diff_staged|diff_unstaged|log|show)\b/i;
@@ -1381,11 +1498,13 @@ export class YamaOrchestrator {
         .filter((tool: any) => tool?.serverId === "local-git")
         .map((tool: any) => tool?.name)
         .filter((name: unknown): name is string => typeof name === "string")
-        .filter(
-          (name: string) =>
-            mutatingGitToolPattern.test(this.normalizeToolName(name)) ||
-            highVolumeGitToolPattern.test(this.normalizeToolName(name)),
-        );
+        .filter((name: string) => {
+          const normalized = this.normalizeToolName(name);
+          return (
+            isMutatingGitTool(normalized) ||
+            highVolumeGitToolPattern.test(normalized)
+          );
+        });
 
       if (excludeTools.length === 0) {
         return {};
@@ -1659,7 +1778,7 @@ export class YamaOrchestrator {
     console.log(`
     ⚔️  YAMA - AI-Native Code Review Guardian
 
-    Version: 2.2.1
+    Version: ${VERSION}
     Mode: Autonomous AI-Powered Review
     Powered by: NeuroLink + MCP Tools
     `);

--- a/src/v2/exploration/ContextExplorerService.ts
+++ b/src/v2/exploration/ContextExplorerService.ts
@@ -20,6 +20,8 @@ import {
   getProviderToolset,
   type VCSProviderName,
 } from "../providers/ProviderToolset.js";
+import { clampMaxTokens, MAX_EXTRACTION_TOKENS } from "../utils/tokenLimits.js";
+import { isMutatingGitTool } from "../utils/toolPolicy.js";
 import { ExplorerPromptBuilder } from "./ExplorerPromptBuilder.js";
 import { RulesContextLoader } from "./RulesContextLoader.js";
 import {
@@ -130,7 +132,9 @@ export class ContextExplorerService {
       model: this.config.ai.explore.model || this.config.ai.model,
       temperature:
         this.config.ai.explore.temperature ?? this.config.ai.temperature,
-      maxTokens: this.config.ai.explore.maxTokens || this.config.ai.maxTokens,
+      maxTokens: clampMaxTokens(
+        this.config.ai.explore.maxTokens ?? this.config.ai.maxTokens,
+      ),
       timeout: this.config.ai.explore.timeout || this.config.ai.timeout,
       skipToolPromptInjection: true,
       ...this.getToolFilteringOptions(runtimeContext.mode),
@@ -154,9 +158,9 @@ export class ContextExplorerService {
       provider: this.config.ai.explore.provider || this.config.ai.provider,
       model: this.config.ai.explore.model || this.config.ai.model,
       temperature: 0.1,
-      maxTokens: Math.min(
-        this.config.ai.explore.maxTokens || this.config.ai.maxTokens,
-        12_000,
+      maxTokens: clampMaxTokens(
+        this.config.ai.explore.maxTokens ?? this.config.ai.maxTokens,
+        MAX_EXTRACTION_TOKENS,
       ),
       timeout: "2m",
       disableTools: true,
@@ -304,16 +308,20 @@ export class ContextExplorerService {
   private shouldExcludeTool(mode: "pr" | "local", toolName: string): boolean {
     const normalized = this.normalizeToolName(toolName);
 
+    // Provider (non-git) mutation tools — Bitbucket/GitHub write tools derived
+    // from each provider toolset — are always excluded for the read-only
+    // explore subagent.
     if (
       ContextExplorerService.MUTATION_TOOL_NAMES.has(normalized.toLowerCase())
     ) {
       return true;
     }
 
+    // Git tools are filtered with the shared fail-closed allow-list in local
+    // mode (any git_* tool not on the read-only list is treated as mutating),
+    // closing the gaps the old regex missed (git_branch, git_mv, git_pull, …).
     if (mode === "local") {
-      return /^git_(commit|push|add|checkout|create_branch|merge|rebase|cherry_pick|reset|revert|tag|rm|clean|stash|apply)\b/i.test(
-        normalized,
-      );
+      return isMutatingGitTool(toolName);
     }
 
     return false;

--- a/src/v2/prompts/ReviewSystemPrompt.ts
+++ b/src/v2/prompts/ReviewSystemPrompt.ts
@@ -61,6 +61,7 @@ ${toolUsageSection}
     <level name="MAJOR"    emoji="⚠️">Blocks if multiple. MUST include a real-code suggestion. Logic bugs, perf issues, broken APIs.</level>
     <level name="MINOR"    emoji="💡">Request changes. Suggestion optional. Quality, naming, duplication.</level>
     <level name="SUGGESTION" emoji="💬">Informational. Optimizations and improvements.</level>
+    <marker-rule>EVERY posted inline comment body MUST BEGIN with its severity marker as the very first token, exactly one of: "🔒 CRITICAL:", "⚠️ MAJOR:", "💡 MINOR:", "💬 SUGGESTION:". Write the marker verbatim (emoji + level + colon) before any other text — it is how issues are counted, so an omitted or altered marker is not counted.</marker-rule>
   </severity-levels>
 
   <anti-patterns>

--- a/src/v2/providers/ProviderToolset.ts
+++ b/src/v2/providers/ProviderToolset.ts
@@ -192,7 +192,9 @@ class BitbucketToolset implements ProviderToolset {
          history-dependent behavior — <!-- EXPLORE_BEGIN -->call explore_context with a precise
          task and wait for its evidence before commenting<!-- EXPLORE_END --><!-- EXPLORE_DISABLED_BEGIN -->use search_code or get_file_content to verify before commenting<!-- EXPLORE_DISABLED_END -->.
       d. For every confirmed issue, call add_comment immediately with line_number and
-         line_type from the diff JSON. Include a real-code suggestion for CRITICAL/MAJOR.
+         line_type from the diff JSON. Begin comment_text with the exact severity marker as
+         its first token — "🔒 CRITICAL:", "⚠️ MAJOR:", "💡 MINOR:", or "💬 SUGGESTION:" —
+         then the message. Include a real-code suggestion for CRITICAL/MAJOR.
       e. Move to the next file. Never request another file's diff before finishing the
          current one. Never request a multi-file diff.
 
@@ -397,8 +399,10 @@ class GitHubToolset implements ProviderToolset {
          history-dependent behavior — <!-- EXPLORE_BEGIN -->call explore_context with a precise
          task and wait for its evidence before commenting<!-- EXPLORE_END --><!-- EXPLORE_DISABLED_BEGIN -->use search_code or get_file_contents to verify before commenting<!-- EXPLORE_DISABLED_END -->.
       d. For every confirmed issue, call add_comment_to_pending_review immediately with
-         path, line, subjectType="LINE", and body taken from the diff. Include a real-code
-         suggestion in body for CRITICAL/MAJOR.
+         path, line, subjectType="LINE", and body taken from the diff. Begin body with the
+         exact severity marker as its first token — "🔒 CRITICAL:", "⚠️ MAJOR:", "💡 MINOR:",
+         or "💬 SUGGESTION:" — then the message. Include a real-code suggestion in body for
+         CRITICAL/MAJOR.
       e. Move to the next file. Never jump between files mid-review.
 
     STEP 5 — Decision (submit the review)

--- a/src/v2/utils/tokenLimits.ts
+++ b/src/v2/utils/tokenLimits.ts
@@ -1,0 +1,39 @@
+/**
+ * Centralized output-token limits for NeuroLink generate() calls.
+ *
+ * Yama previously passed `ai.maxTokens` (defaulting to 128000) straight to
+ * generate(). 128000 is a context-window size, not an output cap — no model
+ * emits that many output tokens, and on the non-streaming Vertex+Claude path it
+ * historically tripped the Anthropic SDK's "Streaming is required" guard
+ * (expected time > 10 min for maxTokens > ~21333). NeuroLink >= 9.70 clamps
+ * per-model server-side, but Yama still clamps to a sane ceiling so configs can
+ * never pass absurd values and behavior is consistent across every call site
+ * (previous clamps were inconsistent: 16_000 in one place, 12_000 in another,
+ * and unclamped in the main review path).
+ */
+
+/** Sane default output-token ceiling for review/generation calls. */
+export const MAX_OUTPUT_TOKENS = 32_000;
+
+/** Smaller ceiling for lightweight structured-extraction passes. */
+export const MAX_EXTRACTION_TOKENS = 12_000;
+
+/**
+ * Clamp a requested maxTokens value to a safe ceiling.
+ *
+ * Returns `cap` when the requested value is missing, non-finite, or non-positive
+ * so callers always end up with a usable, bounded number.
+ */
+export function clampMaxTokens(
+  requested: number | undefined | null,
+  cap: number = MAX_OUTPUT_TOKENS,
+): number {
+  if (
+    typeof requested !== "number" ||
+    !Number.isFinite(requested) ||
+    requested <= 0
+  ) {
+    return cap;
+  }
+  return Math.min(requested, cap);
+}

--- a/src/v2/utils/toolPolicy.ts
+++ b/src/v2/utils/toolPolicy.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared tool-safety policy helpers.
+ *
+ * Centralizes git mutation detection so the orchestrator, the explorer, and the
+ * MCP server manager all agree on what is read-only. Uses a fail-closed
+ * allow-list: any `git_*` tool NOT on the read-only list is treated as mutating.
+ * The previous per-file blocklists silently missed mutating tools such as
+ * `git_branch`, `git_mv`, `git_pull`, `git_fetch`, `git_restore`, `git_switch`,
+ * and `git_remote`, leaving them exposed in "read-only" review modes.
+ */
+
+/** Strip server/namespace prefixes, e.g. "local-git:git_status" -> "git_status". */
+export function normalizeToolName(name: string): string {
+  return name.split(/[.:/]/).pop() || name;
+}
+
+/** Git MCP tools that only READ repository state and are always safe to expose. */
+export const READ_ONLY_GIT_TOOLS: ReadonlySet<string> = new Set([
+  "git_status",
+  "git_log",
+  "git_show",
+  "git_diff",
+  "git_diff_staged",
+  "git_diff_unstaged",
+  "git_blame",
+]);
+
+/**
+ * Returns true if the given tool is a git tool that can MUTATE repository state.
+ *
+ * Fail-closed: any `git_*` tool not on the read-only allow-list is treated as
+ * mutating. Non-git tools return false — callers handle provider-specific
+ * mutation tool lists (e.g. Bitbucket/GitHub write tools) separately.
+ */
+export function isMutatingGitTool(toolName: string): boolean {
+  const name = normalizeToolName(toolName).toLowerCase();
+  if (!name.startsWith("git_")) {
+    return false;
+  }
+  return !READ_ONLY_GIT_TOOLS.has(name);
+}


### PR DESCRIPTION
## Summary

Upgrades `@juspay/neurolink` `^9.42.0` → `^9.70.7` and fixes a set of review/config correctness bugs surfaced while validating the bump.

The bump alone resolves the production Vertex+Claude failure:

> `[GoogleVertex] Native Anthropic SDK generate error … Streaming is required for operations that may take longer than 10 minutes`

NeuroLink `>= 9.67.2` plumbs a client-level timeout into the Anthropic Vertex SDK, which disables the SDK's non-streaming 10‑minute guard. The affected window was `9.64.0 – 9.67.1` (native Anthropic path present, timeout not yet plumbed); pinning the floor to `^9.70.7` keeps every consumer above it.

`@juspay/hippocampus` is added as a direct dependency because NeuroLink `9.70.x` made it an **optional peer** — without it, conversation memory silently disables.

## Correctness fixes

**Critical (metrics were silently broken regardless of version):**
- Token usage read non-existent result fields (`inputTokens/outputTokens/totalTokens`) — NeuroLink returns `usage.{input,output,total}`. Usage and cost were always `0`.
- GitHub severity counts were always `0`: the counter read `comment_text`, but GitHub comment tools use `body`.
- `calculateCost` hardcoded Gemini‑Flash pricing for **all** providers (~12–15× under‑report for Claude). Now prefers NeuroLink `analytics.cost` with a clearly‑labelled rough fallback.

**Review correctness:**
- Decision was "BLOCKED‑sticky" (any block beat a later approval regardless of order). Now order‑aware: the last decisive signal wins.
- Severity counting relied on comment markers the prompt never mandated. The review prompt now requires every comment body to begin with its severity marker (matched exactly to what the counter greps).
- `projectStandards.severityOverrides` (declared but never read) is now wired into severity normalization.
- Read‑only tool filtering missed mutating git tools (`git_branch`, `git_mv`, `git_pull`, `git_fetch`, …). Replaced the per‑file blocklists with a single **fail‑closed** read‑only allow‑list (`src/v2/utils/toolPolicy.ts`).
- Jira tool‑filter signal regex no longer matches false positives like `UTF-8` / `SHA-256`.

**Resilience / hygiene:**
- `ai.retryAttempts` (previously dead config) now drives a bounded retry on transient errors around the review calls.
- Local JSON review path prefers `structuredData` and handles `jsonTruncated` (advising a higher `maxTokens` instead of a generic format error).
- `maxTokens` is clamped through one shared helper (`src/v2/utils/tokenLimits.ts`); inconsistent inline clamps (16k/12k) unified.
- Removed the dead `streamReview` stub (no callers, not exported); `VERSION` is now sourced from `package.json` instead of a stale `2.2.1` literal.

## ⚠️ Intentional behavior changes (please review)

1. **Config precedence**: environment variables now override the YAML config file (previously the committed `yama.config.yaml` silently overrode `AI_MAX_TOKENS` / `AI_MODEL` / `AI_PROVIDER` / `AI_TEMPERATURE`). Final precedence: `defaults < file < env < instance overrides`, now consistent for both `ai.*` and `memory.*`.
2. **`ai.maxTokens` default lowered `128000` → `32000`**. 128000 is a context‑window size, not an output cap; no model emits that many output tokens and NeuroLink clamps per‑model anyway. User‑set values up to the ceiling are respected.

## Verification

Local run of the full CI checklist, all green:
- `type-check`, `build`, `prepack` ✅
- `test` — 202/202 ✅
- `lint` — 0 errors ✅
- `validate:env`, `validate:security` (0 high‑severity) ✅
- single commit, conventional message, no merge commits ✅

## Notes
- The large `pnpm-lock.yaml` diff is expected: NeuroLink `9.70.x` moved many heavy dependencies to `optionalDependencies`, so the resolved tree is slimmer.
