### PR TITLE
fix: verify PR identifiers against the PR branch, not the default-branch index

### DIFF
--- a/src/v2/exploration/ExplorerPromptBuilder.ts
+++ b/src/v2/exploration/ExplorerPromptBuilder.ts
@@ -47,6 +47,7 @@ Rules:
 3. Prefer the smallest sufficient evidence. Do not dump raw tool output.
 4. If you are uncertain, say so explicitly in findings or openQuestions.
 5. Return valid JSON only. No markdown fences or commentary outside JSON.
+6. search_code indexes the repository's DEFAULT branch only — a zero-result is NOT proof code is absent. To verify a symbol, class, or token exists on the branch under review, fetch the file with the branch/ref set to the Branch listed above. Never conclude something is missing from a search_code miss alone.
 
 Research task:
 - Task: ${input.task}

--- a/src/v2/prompts/ReviewSystemPrompt.ts
+++ b/src/v2/prompts/ReviewSystemPrompt.ts
@@ -48,6 +48,7 @@ export function buildReviewSystemPrompt(
   <core-rules>
     <rule id="standards-first">Read the &lt;project-standards&gt; block in your task before touching any file. Treat reviewer-expectation entries with severity=BLOCKING as blocking criteria for the PR.</rule>
     <rule id="verify-before-comment">Never comment on code you don't understand. Use search_code or get_file_content for cheap, single-shot lookups.<!-- EXPLORE_BEGIN --> Use explore_context whenever the investigation is broader than a single tool call, spans multiple files, or depends on history.<!-- EXPLORE_END --></rule>
+    <rule id="branch-scoped-verification">search_code indexes the repository's DEFAULT branch ONLY. It cannot see definitions added on the branch under review that are not yet on the default branch (e.g. a shared class, token, or helper merged to an integration branch like beta/develop but not yet released to the default branch). A zero-result from search_code is therefore NOT proof an identifier is missing. Before flagging any referenced symbol, class, CSS class, token, import, or helper as missing / undefined / undeclared, confirm it on the branch under review — fetch the expected file with get_file_content passing this PR's branch (the &lt;branch&gt; value in your context), or delegate to explore_context. Only report it missing if it is genuinely absent on the PR's own branch.</rule>
     <rule id="file-by-file">Process exactly one file at a time. Get its diff, analyze it fully, post all comments for it, then move on. Never request another file's diff before finishing the current file. Never request a full multi-file PR diff.</rule>
     <rule id="accurate-commenting">Inline comments use line_number and line_type taken directly from the diff JSON: ADDED → destination_line, REMOVED → source_line, CONTEXT → destination_line.</rule>
     <rule id="comment-immediately">Post comments as you find issues. Do not batch them until the end.</rule>
@@ -68,6 +69,7 @@ ${toolUsageSection}
     <dont>Request all files upfront — use lazy loading, one file at a time.</dont>
     <dont>Batch comments until the end — comment immediately as you find issues.</dont>
     <dont>Assume what code does — verify with tools first.</dont>
+    <dont>Flag a symbol, class, or token as missing / undefined from a search_code miss — search_code only indexes the default branch; confirm on this PR's branch with get_file_content (branch=this PR's branch) before claiming absence.</dont>
     <dont>Use a code_snippet field — always use line_number and line_type from the diff JSON.</dont>
     <dont>Jump between files — finish one file before starting another.</dont>
     <dont>Duplicate an existing comment — check first; reply if a developer's response is wrong.</dont>

--- a/src/v2/providers/ProviderToolset.ts
+++ b/src/v2/providers/ProviderToolset.ts
@@ -135,10 +135,12 @@ class BitbucketToolset implements ProviderToolset {
     <tool name="search_code">
       <use-when>A single direct lookup answers your question (function definition, single file).</use-when>
       <do-not-use-when>The investigation needs more than one call or spans multiple files — delegate to explore_context instead.</do-not-use-when>
+      <caveat>Indexes the repository's DEFAULT branch only. It cannot see code added on this PR's branch that is not yet on the default branch, so a zero-result is NOT proof an identifier is missing — never conclude "missing/undefined" from a search_code miss. To confirm presence on the branch under review, call get_file_content with this PR's branch.</caveat>
     </tool>
 
     <tool name="get_file_content">
       <use-when>You already know the path and need the file's contents.</use-when>
+      <important>To read code as it exists on the branch under review — including definitions added on this PR that are not yet on the default branch — pass this PR's branch (the &lt;branch&gt; value in your context). Omitting the branch reads the default branch, which can make PR-branch code look absent.</important>
     </tool>
 
     <!-- EXPLORE_BEGIN -->
@@ -330,10 +332,11 @@ class GitHubToolset implements ProviderToolset {
     <tool name="search_code">
       <use-when>A single direct lookup answers your question (function definition, single file). Pass a query.</use-when>
       <do-not-use-when>The investigation needs more than one call or spans multiple files — delegate to explore_context instead.</do-not-use-when>
+      <caveat>Searches the repository's DEFAULT branch only. It cannot see code added on this PR's branch that is not yet on the default branch, so a zero-result is NOT proof an identifier is missing — never conclude "missing/undefined" from a search_code miss. To confirm presence on the branch under review, call get_file_contents with ref set to this PR's branch.</caveat>
     </tool>
 
     <tool name="get_file_contents">
-      <use-when>You already know the path and need the file's contents. Pass owner, repo, path, and optionally ref.</use-when>
+      <use-when>You already know the path and need the file's contents. Pass owner, repo, path, and — to read the branch under review rather than the default branch — ref set to this PR's branch (the &lt;branch&gt; value in your context). Omitting ref reads the default branch, which can make PR-branch code look absent.</use-when>
     </tool>
 
     <!-- EXPLORE_BEGIN -->

--- a/tests/unit/ProviderToolset.test.ts
+++ b/tests/unit/ProviderToolset.test.ts
@@ -467,6 +467,12 @@ describe("ProviderToolset", () => {
       expect(section).not.toContain("get_pull_request_diff");
       expect(section).not.toContain("set_pr_approval");
     });
+
+    test("warns that search_code is default-branch-only and points to ref-scoped fetch", () => {
+      expect(section).toContain("DEFAULT branch only");
+      expect(section).toMatch(/NOT proof an identifier is missing/i);
+      expect(section).toContain("ref set to this PR's branch");
+    });
   });
 
   describe("Bitbucket systemPromptToolsSection", () => {
@@ -485,6 +491,12 @@ describe("ProviderToolset", () => {
     test("does NOT mention GitHub-only tools", () => {
       expect(section).not.toContain("pull_request_review_write");
       expect(section).not.toContain("add_comment_to_pending_review");
+    });
+
+    test("warns that search_code is default-branch-only and points to branch-scoped fetch", () => {
+      expect(section).toContain("DEFAULT branch only");
+      expect(section).toMatch(/NOT proof an identifier is missing/i);
+      expect(section).toContain("get_file_content with this PR's branch");
     });
   });
 

--- a/tests/v2/unit/prompts.test.ts
+++ b/tests/v2/unit/prompts.test.ts
@@ -43,6 +43,15 @@ describe("Review System Prompt", () => {
     expect(REVIEW_SYSTEM_PROMPT).toContain('id="accurate-commenting"');
   });
 
+  it("warns that search_code is default-branch-only so PR-branch code is not falsely flagged missing", () => {
+    // Regression guard: a shared class/token added on an integration branch (e.g. beta)
+    // but not yet on the default branch was falsely reported as "does not exist" because
+    // the reviewer trusted a default-branch-only search_code miss.
+    expect(REVIEW_SYSTEM_PROMPT).toContain('id="branch-scoped-verification"');
+    expect(REVIEW_SYSTEM_PROMPT).toContain("DEFAULT branch");
+    expect(REVIEW_SYSTEM_PROMPT).toMatch(/not proof an identifier is missing/i);
+  });
+
   it("should contain tool usage instructions for the tools the agent actually uses", () => {
     expect(REVIEW_SYSTEM_PROMPT).toContain("<tool-usage>");
     expect(REVIEW_SYSTEM_PROMPT).toContain('<tool name="get_pull_request">');


### PR DESCRIPTION
## Problem

Yama V2's review agent falsely reported a shared CSS class (`global-table-scroll-x`) as *\"does not exist anywhere in the codebase\"* and blocked a PR — even though the class **is** defined in the repo. It exists on the PR's **target branch** (`beta`) but not yet on the repository's **default branch** (`release`).

Root cause: the review/explorer prompts tell the agent to verify with `search_code`, but `search_code` is backed by Bitbucket's index which covers the **default branch only**. Any shared class / token / helper added on an integration branch (e.g. `beta`) but not yet promoted to the default branch returns **zero hits**, and the agent concludes it is missing. This falsely blocks *every* PR that references such a symbol (it hit both the current PR and an already-merged one). The PR's branch was already available to the prompt (`<branch>`), but nothing instructed the agent to scope existence checks to it, or warned that a `search_code` miss is inconclusive.

## Fix (prompt-level; both providers)

- **`ReviewSystemPrompt.ts`** — new `branch-scoped-verification` core rule + matching anti-pattern: `search_code` is default-branch-only, so a zero-result is not proof of absence; before flagging any symbol/class/token/import/helper as missing, confirm it on the branch under review via `get_file_content` with this PR's branch (or `explore_context`).
- **`ProviderToolset.ts`** — a `<caveat>` on `search_code` and a branch/ref instruction on `get_file_content` / `get_file_contents`, for **both** the Bitbucket and GitHub toolsets.
- **`ExplorerPromptBuilder.ts`** — the same branch-scoping rule for the explorer subagent.

No tool wiring or behavior changes — guidance only.

## Tests

Adds regression assertions that the branch-scoping guidance is present in the review prompt and both provider tool sections.

- `pnpm test` → 205 passing
- `pnpm run lint` → 0 errors
- `pnpm run type-check` → clean
- `pnpm run build` → clean

## Impact

Once released, this stops the false \"identifier does not exist\" blocks for every PR that uses a shared class/token/helper present on an integration branch but not yet on the default branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved code review accuracy when verifying changes on pull request branches.
  - Review guidance now distinguishes default-branch search results from pull request branch contents.
  - Reviewers will verify potentially missing symbols directly on the pull request branch before reporting them as absent.

- **Tests**
  - Added coverage to ensure branch-specific verification guidance remains available for supported code-hosting providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->