### PR TITLE
fix(release): run release.yml on Node 24 so npm@latest OIDC install succeeds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "pnpm"
           registry-url: https://registry.npmjs.org/
 
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
@@ -85,7 +85,7 @@ jobs:
       - name: Setup Node for GitHub Packages
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://npm.pkg.github.com"
           scope: "@juspay"
 


### PR DESCRIPTION
## What

Bump `release.yml`'s Node from **20 → 24** (all three `actions/setup-node` steps).

## Why

The **Release and Publish** run on the `#62` merge to `main` **failed**, so no release tag was cut. The failure is in the `Upgrade npm for OIDC support` step:

```
npm error code EBADENGINE
npm error notsup Not compatible with your version of node/npm: npm@12.0.1
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

`npm install -g npm@latest` now resolves to npm 12, which requires **Node ≥22** — but `release.yml` pinned **Node 20**, so the global npm upgrade aborts and the release job dies before `semantic-release` ever runs.

Node 24 is also what the action itself runs on (`action.yml` uses `node-version: "24"` because NeuroLink's memory layer needs the `node:sqlite` built-in), so this aligns the release pipeline with the action's own runtime.

## Impact

Unblocks releases from `main` again. In particular it lets a tag **> v2.7.1** be cut that bundles `@juspay/neurolink@10.1.2` (merged in #62) — whose `DEFAULT_TIMEOUTS` carries `litellm: "5m"` (juspay/neurolink#1216), closing the 30s `doGenerate` timeout that currently breaks large-PR Yama reviews on downstream repos.

## Test

CI-config-only change; no source touched. The next push to `main` after merge will exercise the fixed release job.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release pipeline to use Node.js 24 for testing, releasing, and package publishing.
  * Existing release and deployment behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->