### PR TITLE
ci(review): switch self-review to the coder model on the new proxy

### DIFF
--- a/.github/workflows/yama-self-review.yml
+++ b/.github/workflows/yama-self-review.yml
@@ -93,17 +93,12 @@ jobs:
         with:
           github-token: ${{ secrets.YAMA_GITHUB_TOKEN }}
           ai-provider: litellm
-          # Empirically validated (run 29823266055): the CI LiteLLM key caps
-          # "external paid models" at $5/month, so claude/gemini models are
-          # rejected; its FREE internal set is the glm/kimi family. Also,
-          # gemini-2.5-flash function calls break in LiteLLM's Vertex adapter
-          # (thoughtSignature parsing). To run sonnet+gemini-flash in CI, add
-          # Vertex credentials (google-application-credentials input) — that
-          # combination is validated end-to-end locally on Vertex direct.
-          # private-large for both roles — tool calling verified locally via
-          # the proxy (free internal model on this key class).
-          ai-model: private-large
-          explore-model: private-large
+          # dev-test key on the grid.breezehq.dev proxy: all models, no budget
+          # cap. `coder` validated against the proxy on 2026-07-24 — chat and
+          # OpenAI-shape tool calling (finish_reason=tool_calls) both confirmed,
+          # which the MCP-driven review requires.
+          ai-model: coder
+          explore-model: coder
           litellm-base-url: ${{ secrets.LITELLM_BASE_URL }}
           litellm-api-key: ${{ secrets.LITELLM_API_KEY }}
           focus-areas: security,performance,codeQuality


### PR DESCRIPTION
# Pull Request

## Description

Points the Yama self-review workflow at the new dev-test LiteLLM proxy key and switches both reviewer roles to the `coder` model.

- `ai-model` / `explore-model`: `private-large` → `coder`
- Replaced the stale comment about the old key's $5/month external-model cap (the new key has no budget cap and an unrestricted model list)
- Secret values (`LITELLM_BASE_URL` → the new proxy, `LITELLM_API_KEY` → the dev-test key) were rotated out-of-band via `gh secret set` — no secret names changed, so the preflight gate and this workflow file keep working as-is

Pre-validated against the proxy before wiring CI: `coder` answers chat completions and handles OpenAI-shape function calling (`finish_reason: tool_calls` with well-formed arguments), which the MCP-driven review depends on. This PR's own self-review run doubles as the end-to-end test.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [x] 🔧 Build/CI configuration change
- [ ] 🔒 Security enhancement

## Related Issues

- Related to #66 (its self-review ran on the old key/model)

## Changes Made

- `.github/workflows/yama-self-review.yml`: `ai-model`/`explore-model` → `coder`; comment block updated for the new key class

## Platform Impact

- [ ] Bitbucket
- [x] GitHub
- [ ] GitLab
- [ ] All platforms
- [ ] No platform-specific changes

## AI Provider Impact

- [ ] OpenAI
- [ ] Anthropic
- [ ] Google AI
- [ ] All providers
- [x] No AI provider changes (still `litellm`; only the model/key behind the proxy changed)

## Component Impact

- [ ] CLI
- [ ] Core Engine
- [ ] API Integration
- [ ] AI Features
- [ ] Security
- [x] Configuration
- [ ] Documentation
- [ ] Tests

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

Manual verification against the proxy: chat completion round-trip and a function-calling probe on `coder` (returns `tool_calls` with correct JSON arguments). The Yama Self Review check on this PR exercises the full pipeline with the new key.

### Test Environment

- OS: Linux 6.8
- Node.js version: 20.19.5
- Package manager: pnpm 10.x

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security impact

Key lives only in repo secrets; workflow references are unchanged (`secrets.LITELLM_API_KEY` / `secrets.LITELLM_BASE_URL`).

## Breaking Changes

None.

## Configuration Changes

- [x] No configuration changes

(Workflow inputs only; no Yama config schema or env var changes.)

## Screenshots/Demo

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md if needed
- [x] I have verified that sensitive data is not exposed

## Additional Notes

Single commit per branch policy followed. Watch this PR's own "Yama Self Review" check — it is the live end-to-end validation of the new key + model.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review configuration to use the validated `coder` model.
  * Refined configuration guidance for model selection and tool-calling support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->