### PR TITLE
fix(config): make ai temperature optional, omit when unset

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -57,6 +57,13 @@ If you still want Jira context, add it as a **user-configured MCP server** in
 - **Config precedence:** `.yama/config.yaml` is now preferred. The legacy
   `yama.config.yaml` / `config/yama.config.yaml` still load but emit a deprecation
   warning — move your config to `.yama/config.yaml`.
+- **`ai.temperature` no longer defaults to `0.2`** (and `ai.explore.temperature`
+  no longer defaults to `0.1`). When unset, the field is omitted from NeuroLink
+  `generate()` calls entirely and the provider's own default applies. Set
+  `ai.temperature: 0.2` (and `ai.explore.temperature: 0.1`) explicitly to keep
+  the previous behavior. Internal deterministic passes (critic, verdict
+  follow-up, extraction, learning, memory condensation) keep their fixed low
+  temperatures.
 
 ## Project MCP is opt-in (security)
 

--- a/src/v2/config/DefaultConfig.ts
+++ b/src/v2/config/DefaultConfig.ts
@@ -21,7 +21,8 @@ export class DefaultConfig {
       ai: {
         provider: "auto",
         model: "gemini-2.5-pro",
-        temperature: 0.2,
+        // temperature deliberately has no default: unset means "omit from the
+        // NeuroLink call" so the provider's own default applies.
         // Sane output ceiling (NeuroLink clamps further per-model server-side).
         maxTokens: 32000,
         enableAnalytics: true,
@@ -52,7 +53,6 @@ export class DefaultConfig {
           enabled: true,
           provider: "auto",
           model: "gemini-2.5-flash",
-          temperature: 0.1,
           // Lighter sub-task: sane output ceiling (NeuroLink clamps further per-model server-side).
           maxTokens: 16000,
           timeout: "5m",

--- a/src/v2/core/YamaOrchestrator.ts
+++ b/src/v2/core/YamaOrchestrator.ts
@@ -38,6 +38,7 @@ import {
   prReviewVerdictSchema,
 } from "./reviewSchema.js";
 import { clampMaxTokens } from "../utils/tokenLimits.js";
+import { temperatureOption } from "../utils/generateOptions.js";
 import { parseDurationMs } from "../utils/duration.js";
 import {
   buildFindingId,
@@ -291,7 +292,7 @@ export class YamaOrchestrator {
             input: { text: instructions },
             provider: this.config.ai.provider,
             model: this.config.ai.model,
-            temperature: this.config.ai.temperature,
+            ...temperatureOption(this.config.ai.temperature),
             maxTokens: clampMaxTokens(this.config.ai.maxTokens),
             timeout: this.config.ai.timeout,
             // Prefer streaming transport for the long agentic loop (chunked
@@ -403,7 +404,7 @@ export class YamaOrchestrator {
             input: { text: instructions },
             provider: this.config.ai.provider,
             model: this.config.ai.model,
-            temperature: this.config.ai.temperature,
+            ...temperatureOption(this.config.ai.temperature),
             maxTokens: clampMaxTokens(this.config.ai.maxTokens),
             timeout: this.config.ai.timeout,
             enableAnalytics: this.config.ai.enableAnalytics,
@@ -520,7 +521,7 @@ export class YamaOrchestrator {
         input: { text: reviewInstructions },
         provider: this.config.ai.provider,
         model: this.config.ai.model,
-        temperature: this.config.ai.temperature,
+        ...temperatureOption(this.config.ai.temperature),
         maxTokens: clampMaxTokens(this.config.ai.maxTokens),
         timeout: this.config.ai.timeout,
         // Prefer streaming transport for the long agentic loop (chunked SSE
@@ -584,7 +585,7 @@ export class YamaOrchestrator {
           input: { text: enhanceInstructions },
           provider: this.config.ai.provider,
           model: this.config.ai.model,
-          temperature: this.config.ai.temperature,
+          ...temperatureOption(this.config.ai.temperature),
           maxTokens: clampMaxTokens(this.config.ai.maxTokens),
           timeout: this.config.ai.timeout,
           skipToolPromptInjection: true,

--- a/src/v2/exploration/ContextExplorerService.ts
+++ b/src/v2/exploration/ContextExplorerService.ts
@@ -14,6 +14,7 @@ import { MemoryManager } from "../memory/MemoryManager.js";
 import { KnowledgeBaseManager } from "../learning/KnowledgeBaseManager.js";
 import { NeuroLinkFactory } from "../core/NeuroLinkFactory.js";
 import { clampMaxTokens, MAX_EXTRACTION_TOKENS } from "../utils/tokenLimits.js";
+import { temperatureOption } from "../utils/generateOptions.js";
 import { isMutatingGitTool } from "../utils/toolPolicy.js";
 import { ExplorerPromptBuilder } from "./ExplorerPromptBuilder.js";
 import { RulesContextLoader } from "./RulesContextLoader.js";
@@ -115,8 +116,9 @@ export class ContextExplorerService {
       input: { text: prompt },
       provider: this.config.ai.explore.provider || this.config.ai.provider,
       model: this.config.ai.explore.model || this.config.ai.model,
-      temperature:
+      ...temperatureOption(
         this.config.ai.explore.temperature ?? this.config.ai.temperature,
+      ),
       maxTokens: clampMaxTokens(
         this.config.ai.explore.maxTokens ?? this.config.ai.maxTokens,
       ),

--- a/src/v2/types/config.ts
+++ b/src/v2/types/config.ts
@@ -59,7 +59,11 @@ export type AIProvider = string;
 export type AIConfig = {
   provider: AIProvider;
   model: string;
-  temperature: number;
+  /**
+   * Sampling temperature. Optional — when unset, the field is omitted from
+   * NeuroLink `generate()` calls entirely and the provider default applies.
+   */
+  temperature?: number;
   maxTokens: number;
   enableAnalytics: boolean;
   enableEvaluation: boolean;
@@ -75,6 +79,7 @@ export type ExploreAIConfig = {
   enabled: boolean;
   provider?: AIProvider;
   model?: string;
+  /** Falls back to `ai.temperature`; when both are unset, omitted from the call. */
   temperature?: number;
   maxTokens?: number;
   timeout?: string;

--- a/src/v2/utils/generateOptions.ts
+++ b/src/v2/utils/generateOptions.ts
@@ -1,0 +1,15 @@
+/**
+ * Optional fragments for NeuroLink generate() option objects.
+ */
+
+/**
+ * Spreadable temperature fragment. Yama never defaults temperature: when the
+ * user has not configured one, the field is omitted from the generate() call
+ * entirely so the provider's own default applies. Non-finite values (e.g. a
+ * bare `temperature:` YAML key parsing to null) are treated as unset.
+ */
+export function temperatureOption(value: unknown): { temperature?: number } {
+  return typeof value === "number" && Number.isFinite(value)
+    ? { temperature: value }
+    : {};
+}

--- a/tests/v2/unit/generateOptions.test.ts
+++ b/tests/v2/unit/generateOptions.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Optional generate() option fragments: temperature is never defaulted — when
+ * the user has not configured one, the field must be omitted from the
+ * NeuroLink call so the provider default applies.
+ */
+import { describe, it, expect } from "@jest/globals";
+import { temperatureOption } from "../../../src/v2/utils/generateOptions.js";
+import { DefaultConfig } from "../../../src/v2/config/DefaultConfig.js";
+
+describe("temperatureOption", () => {
+  it("includes finite numbers, including 0", () => {
+    expect(temperatureOption(0.2)).toEqual({ temperature: 0.2 });
+    expect(temperatureOption(0)).toEqual({ temperature: 0 });
+    expect(temperatureOption(1)).toEqual({ temperature: 1 });
+  });
+
+  it("omits the field when unset", () => {
+    expect(temperatureOption(undefined)).toEqual({});
+    expect("temperature" in temperatureOption(undefined)).toBe(false);
+  });
+
+  it("treats non-finite and non-number values as unset", () => {
+    // A bare `temperature:` YAML key parses to null; strings and NaN can leak
+    // in through untyped config sources — none of them may reach the provider.
+    expect(temperatureOption(null)).toEqual({});
+    expect(temperatureOption(Number.NaN)).toEqual({});
+    expect(temperatureOption(Number.POSITIVE_INFINITY)).toEqual({});
+    expect(temperatureOption("0.2")).toEqual({});
+  });
+
+  it("spreads into an options object without a temperature key when unset", () => {
+    const options = { model: "m", ...temperatureOption(undefined) };
+    expect(Object.keys(options)).toEqual(["model"]);
+  });
+});
+
+describe("DefaultConfig temperature", () => {
+  it("ships no temperature default for the main or explore AI config", () => {
+    const config = DefaultConfig.get();
+    expect("temperature" in config.ai).toBe(false);
+    expect("temperature" in config.ai.explore).toBe(false);
+  });
+});

--- a/yama.config.example.yaml
+++ b/yama.config.example.yaml
@@ -19,7 +19,7 @@ display:
 ai:
   provider: "auto" # auto | google-ai | anthropic | openai | bedrock
   model: "gemini-2.5-pro" # or claude-3-7-sonnet-20250219-v1:0, gpt-4, etc.
-  temperature: 0.2 # Lower = more deterministic (0.0-1.0)
+  temperature: 0.2 # Optional. Lower = more deterministic (0.0-1.0); omit to use the provider default
   maxTokens: 128000 # Maximum tokens per AI call
   enableAnalytics: true # Track token usage and costs
   enableEvaluation: false # Enable quality evaluation (slower)
@@ -39,7 +39,7 @@ ai:
     enabled: true
     provider: "auto"
     model: "gemini-2.5-flash"
-    temperature: 0.1
+    temperature: 0.1 # Optional; falls back to ai.temperature, else provider default
     maxTokens: 32000
     timeout: "5m"
     cacheResults: true


### PR DESCRIPTION
## Description

`ai.temperature` was silently defaulted to `0.2` (and `ai.explore.temperature` to `0.1`) by `DefaultConfig`, so every NeuroLink `generate()` call always carried a Yama-chosen temperature even when the user never configured one. Temperature is now fully optional: when unset, the field is **omitted from the `generate()` call entirely** and the provider's own default applies.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/v2/types/config.ts` — `AIConfig.temperature` is now optional (`temperature?: number`); documented the omit-when-unset semantics on both `AIConfig` and `ExploreAIConfig`.
- `src/v2/config/DefaultConfig.ts` — removed the hardcoded `0.2` / `0.1` temperature defaults.
- `src/v2/utils/generateOptions.ts` (new) — `temperatureOption()` helper returning a spreadable `{ temperature }` fragment only for finite numbers; non-finite/non-number values (e.g. a bare `temperature:` YAML key parsing to `null`) are treated as unset, so they can never reach the provider.
- `src/v2/core/YamaOrchestrator.ts` — all four config-driven call sites (PR review, local review, review+enhance phase 1, enhancement phase 2) now spread `temperatureOption(...)` instead of always passing `temperature`.
- `src/v2/exploration/ContextExplorerService.ts` — research call keeps the `explore.temperature ?? ai.temperature` fallback but omits the field when both are unset.
- `MIGRATION.md` — documented the default removal with a copy-paste hint to restore the old behavior.
- `yama.config.example.yaml` — marked `temperature` optional in both example blocks.
- `tests/v2/unit/generateOptions.test.ts` (new) — covers finite values (incl. `0`), unset/null/NaN/string handling, spread behavior, and that `DefaultConfig` ships no temperature keys.

Deliberately unchanged: the fixed low temperatures of internal deterministic passes (critic `0`, verdict follow-up `0`, explore extraction `0.1`, learning ops, memory-condensation fallback) — these are algorithmic determinism choices, not config defaults.

`AI_TEMPERATURE` / `AI_EXPLORE_TEMPERATURE` env overrides are unaffected and still apply when set.

## Platform Impact

- [x] No platform-specific changes

## AI Provider Impact

- [x] All providers

## Component Impact

- [x] Core Engine
- [x] Configuration
- [x] Tests
- [x] Documentation

## Testing

- [x] Unit tests added/updated
- [x] All existing tests pass

`pnpm run type-check`, `pnpm run lint` (0 errors), `pnpm test` (229 passed incl. 5 new), `pnpm run build` — all green.

### Test Environment

- OS: Linux
- Node.js version: 20.19.5
- Package manager: pnpm

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security impact

## Breaking Changes

None API-wise. Behavior note: configs that never set `temperature` previously ran at `0.2` and will now use the provider default — set `ai.temperature: 0.2` explicitly to keep the old behavior (documented in MIGRATION.md).

## Configuration Changes

- [x] Configuration schema updated (`ai.temperature` and `ai.explore.temperature` are now optional with no default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * AI generation now uses the provider’s default temperature when no temperature is configured.
  * Exploration temperature falls back to the general AI setting, then the provider default.
  * Existing temperature behavior can be restored by explicitly setting the previous values.

* **Documentation**
  * Updated migration guidance and configuration examples to explain optional temperature settings and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->