### PR TITLE
fix(review): gate-anchored verdicts, posting finalization, no default wall clock

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -104,7 +104,8 @@ library, ensure your runtime meets that floor.
 ## v3 foundations (same release)
 
 **No additional breaking changes.** All new capabilities are opt-out/opt-in
-config keys with behavior-preserving defaults:
+config keys with behavior-preserving defaults — with one intentional default
+change (`performance.maxReviewDuration`, called out after the table):
 
 | New key                                   | Default                                  | Effect                                                                                                                                                                              |
 | ----------------------------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -114,6 +115,16 @@ config keys with behavior-preserving defaults:
 | `ai.conversationMemory.contextCompaction` | enabled, threshold 0.8                   | NeuroLink auto-compaction for long reviews.                                                                                                                                         |
 | `ai.mcpOutputLimits`                      | `externalize` at 100 KB                  | Oversized MCP tool outputs are paged on demand instead of flooding context.                                                                                                         |
 | `.yama/rules/**`                          | none                                     | Structured team rules (id/scope/severity/blocking + examples). Violated blocking rules force BLOCKED deterministically.                                                             |
+
+**One intentional default change:** `performance.maxReviewDuration` is now
+**unset** by default (was `15m`), so review behavior changes after upgrading —
+reviews are bounded by work (`loop.maxSteps`, per-step `ai.timeout`,
+`toolTimeoutMs`/`stallTimeoutMs` hang guards), not by wall clock, and long
+reviews may take longer than before. The old default cut long reviews mid-loop,
+losing comment posting and forcing a fabrication-prone verdict recovery. Set
+`performance.maxReviewDuration` (or `performance.loop.turnTimeoutMs`) explicitly
+to restore a hard ceiling; note it caps each agentic review turn, not the whole
+CLI run.
 
 Behavioral notes:
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -5,8 +5,17 @@
  */
 
 import { Command } from "commander";
+import { setMaxListeners } from "node:events";
 import dotenv from "dotenv";
 import { VERSION, createYama, McpRegistry } from "../index.js";
+
+// NeuroLink's agentic loop attaches one abort listener per step to each
+// generate() call's AbortSignal without removing them, so any loop past 10
+// steps spams MaxListenersExceededWarning (observed at every explore_context
+// launch). Raise the default for EventTargets created in this process until
+// that is fixed upstream — the listeners are released when the call settles;
+// this is warning noise, not a leak.
+setMaxListeners(100);
 import { createLearningOrchestrator } from "../v2/core/LearningOrchestrator.js";
 import { formatFindingsMarkdown } from "../v2/utils/findingsSummary.js";
 import type {

--- a/src/v2/config/DefaultConfig.ts
+++ b/src/v2/config/DefaultConfig.ts
@@ -207,10 +207,19 @@ export class DefaultConfig {
         logTokenUsage: true,
         exportFormat: "json",
         exportPath: ".yama/analytics/",
+        report: {
+          enabled: true,
+          path: ".yama/reports",
+        },
       },
 
       performance: {
-        maxReviewDuration: "15m",
+        // No maxReviewDuration default: the review is bounded by WORK
+        // (loop.maxSteps, the submit_review gate, per-step ai.timeout and
+        // toolTimeoutMs hang guards) — not by wall-clock. A default time cap
+        // used to cut long reviews mid-loop, losing posted-comment follow-ups
+        // and forcing a fabrication-prone verdict recovery. Set it explicitly
+        // only if an external scheduler requires a hard ceiling.
         loop: {
           maxSteps: 100,
           toolTimeoutMs: 300_000,

--- a/src/v2/core/ReviewResultParser.ts
+++ b/src/v2/core/ReviewResultParser.ts
@@ -10,13 +10,18 @@
  */
 
 import { SessionManager } from "./SessionManager.js";
-import { deriveDecision } from "./reviewDecision.js";
+import {
+  deriveDecision,
+  DEFAULT_MAJOR_BLOCK_THRESHOLD,
+} from "./reviewDecision.js";
 import { isVerdictShaped } from "./reviewSchema.js";
+import { reconcileVerdictWithGate } from "../harness/verdictReconciler.js";
 
 import {
   LocalDiffContext,
   ReviewCompletion,
   ReviewDecisionResult,
+  ReviewGateSnapshot,
   ReviewResult,
   IssuesBySeverity,
   TokenUsage,
@@ -40,6 +45,7 @@ export class ReviewResultParser {
     startTime: number,
     sessionId: string,
     severityOverrides?: Record<string, string>,
+    gate?: ReviewGateSnapshot,
   ): ReviewResult {
     const session = this.sessionManager.getSession(sessionId);
     const duration = Math.round((Date.now() - startTime) / 1000);
@@ -58,11 +64,43 @@ export class ReviewResultParser {
           `(structuredData keys: ${parsed ? Object.keys(parsed).join(", ") || "<empty>" : "<absent>"})`,
       );
     }
-    const issues = this.normalizeFindings(
+    const verdictIssues = this.normalizeFindings(
       parsed?.issues,
       "issue",
       severityOverrides,
     );
+
+    // Anchor the verdict to the gate: once the agent has used submit_review,
+    // only gate-accepted (deduped + critic-verified) findings may drive the
+    // decision. Verdict issues that never passed the gate are quarantined as
+    // advisory — on partial runs the verdict recovery has been observed to
+    // fabricate whole issue lists out of the rules prompt, and counting those
+    // would block PRs on findings nobody verified.
+    const gateAnchored = gate?.invoked === true;
+    let issues = verdictIssues;
+    let ungatedIssues: LocalReviewFinding[] = [];
+    if (gateAnchored) {
+      const gatedFindings = this.normalizeFindings(
+        gate.accepted,
+        "issue",
+        severityOverrides,
+      );
+      const reconciled = reconcileVerdictWithGate({
+        gatedFindings,
+        verdictIssues,
+      });
+      issues = reconciled.issues;
+      ungatedIssues = reconciled.ungatedIssues;
+      if (ungatedIssues.length > 0) {
+        console.warn(
+          `   🛡️  ${ungatedIssues.length} verdict issue(s) never passed the ` +
+            `submit_review gate — quarantined as advisory (not posted, not ` +
+            `decision-driving): ` +
+            ungatedIssues.map((issue) => `"${issue.title}"`).join(", "),
+        );
+      }
+    }
+
     const issuesBySeverity = this.countFindingsBySeverity(issues);
     const aiDecision: ReviewDecisionResult = conforming
       ? this.normalizeDecision(parsed?.decision, issuesBySeverity)
@@ -74,15 +112,40 @@ export class ReviewResultParser {
           `${completion.jsonTruncated ? ", jsonTruncated" : ""}) — result is PARTIAL.`,
       );
     }
-    const decision = deriveDecision(aiDecision, issuesBySeverity, {
+    let decision = deriveDecision(aiDecision, issuesBySeverity, {
       partial: completion.partial,
     });
+    // Unverified (ungated) blocking claims are fail-safe in BOTH directions:
+    // they may not block on their own, but they may not be approved-over
+    // either — a human should look before this PR is greenlit.
+    const ungatedCounts = this.countFindingsBySeverity(ungatedIssues);
+    if (
+      decision === "APPROVED" &&
+      (ungatedCounts.critical > 0 ||
+        ungatedCounts.major >= DEFAULT_MAJOR_BLOCK_THRESHOLD)
+    ) {
+      decision = "CHANGES_REQUESTED";
+      console.log(
+        `   🛡️  ${ungatedCounts.critical} critical / ${ungatedCounts.major} major ` +
+          `unverified claim(s) exist — APPROVED capped at CHANGES_REQUESTED.`,
+      );
+    }
     if (decision !== aiDecision) {
       console.log(
         `   🛡️  Decision reconciled: AI reported ${aiDecision}, Yama enforces ${decision} ` +
           `(critical=${issuesBySeverity.critical}, major=${issuesBySeverity.major}).`,
       );
     }
+
+    // A partial (or verdict-less) run's model summary is untrustworthy — it is
+    // reconstructed from a compacted session and has described entirely
+    // different PRs. With gate data available, build the summary from what was
+    // actually verified instead.
+    const summary =
+      gateAnchored && (completion.partial || !conforming)
+        ? this.buildGateAnchoredSummary(issues, ungatedIssues, completion)
+        : this.sanitizeLocalSummary(parsed?.summary) ||
+          this.extractSummary(aiResponse);
 
     const toolCalls = session.toolCalls || [];
     const filesReviewed = new Set(
@@ -100,11 +163,11 @@ export class ReviewResultParser {
         codeQualityScore: 0,
         toolCallsMade: toolCalls.length,
         cacheHits: 0,
+        // With the gate active this is the number of verified findings
+        // cleared for posting — not the length of whatever the model claimed.
         totalComments: issues.length,
       },
-      summary:
-        this.sanitizeLocalSummary(parsed?.summary) ||
-        this.extractSummary(aiResponse),
+      summary,
       duration,
       tokenUsage: {
         input: this.toSafeNumber(aiResponse?.usage?.input),
@@ -115,12 +178,53 @@ export class ReviewResultParser {
       sessionId,
       completion,
       issues,
+      ungatedIssues: ungatedIssues.length > 0 ? ungatedIssues : undefined,
       resolvedIssueIds: Array.isArray(parsed?.resolvedIssueIds)
         ? parsed.resolvedIssueIds.filter(
             (id: unknown): id is string => typeof id === "string",
           )
         : undefined,
     };
+  }
+
+  /**
+   * Deterministic summary for runs whose model-written summary can't be
+   * trusted (partial loop or missing verdict): lists exactly the gate-verified
+   * findings, flags the early stop, and mentions quarantined claims.
+   */
+  private buildGateAnchoredSummary(
+    issues: LocalReviewFinding[],
+    ungatedIssues: LocalReviewFinding[],
+    completion: ReviewCompletion,
+  ): string {
+    const lines: string[] = ["## 🤖 Yama Review Summary", ""];
+    if (completion.partial) {
+      lines.push(
+        `⚠️ The review loop ended early (\`${completion.stopReason}\`` +
+          `${completion.stepsUsed ? `, ${completion.stepsUsed} steps` : ""}) — ` +
+          `this verdict is built strictly from gate-verified findings.`,
+        "",
+      );
+    }
+    if (issues.length === 0) {
+      lines.push("No verified findings were accepted by the review gate.");
+    } else {
+      lines.push(`**Verified findings (${issues.length}):**`, "");
+      for (const issue of issues) {
+        const location = issue.filePath
+          ? ` — \`${issue.filePath}${issue.line ? `:${issue.line}` : ""}\``
+          : "";
+        lines.push(`- **${issue.severity}**: ${issue.title}${location}`);
+      }
+    }
+    if (ungatedIssues.length > 0) {
+      lines.push(
+        "",
+        `_${ungatedIssues.length} additional claim(s) in the model verdict ` +
+          `never passed verification and were quarantined (see ungatedIssues)._`,
+      );
+    }
+    return lines.join("\n");
   }
 
   /**

--- a/src/v2/core/RunReporter.ts
+++ b/src/v2/core/RunReporter.ts
@@ -1,0 +1,239 @@
+/**
+ * RunReporter — writes the per-run review report artifact.
+ *
+ * Everything valuable a run produces (bootstrap standards, explore
+ * investigations, gate batches with critic outcomes, finalization, the
+ * reconciled verdict) used to live only in stdout and evaporate with the CI
+ * log. This collects those events and renders one markdown report (plus the
+ * raw JSON) per session, so CI can archive the review's reasoning next to its
+ * state file. Local files only — a log, not a PR side effect — and strictly
+ * best-effort: reporting failures warn and never affect the review.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  ReviewResult,
+  RunReportConfig,
+  RunReportEvent,
+  RunReportFindingRef,
+  RunReportMeta,
+  RunReportOutcome,
+  RunReportTimelineEntry,
+} from "../types/index.js";
+
+const DEFAULT_REPORT_PATH = ".yama/reports";
+
+/**
+ * Flatten free text (model-authored titles, exception messages, explore
+ * prose) for safe interpolation into one markdown table cell or bullet:
+ * newlines collapse to spaces, and backslashes are escaped BEFORE pipes so a
+ * pre-existing "\|" in the input cannot re-arm the pipe and break the row
+ * structure — the error path is exactly where the report matters most.
+ */
+const inline = (value: string | undefined): string =>
+  (value || "")
+    .replace(/\s+/g, " ")
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    .trim();
+
+export class RunReporter {
+  private readonly timeline: RunReportTimelineEntry[] = [];
+
+  constructor(private readonly meta: RunReportMeta) {}
+
+  record(event: RunReportEvent): void {
+    this.timeline.push({ ...event, at: new Date().toISOString() });
+  }
+
+  /** Render + write the report. Returns the markdown path, or null. */
+  async write(
+    config: RunReportConfig | undefined,
+    result?: ReviewResult,
+    error?: string,
+  ): Promise<string | null> {
+    if (config?.enabled === false) {
+      return null;
+    }
+    try {
+      const dir = config?.path || DEFAULT_REPORT_PATH;
+      await mkdir(dir, { recursive: true });
+      const outcome = this.buildOutcome(result, error);
+      const base = join(dir, this.meta.sessionId);
+      await writeFile(`${base}.md`, this.renderMarkdown(outcome), "utf8");
+      await writeFile(
+        `${base}.json`,
+        JSON.stringify(
+          { meta: this.meta, timeline: this.timeline, outcome },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+      console.log(`   📄 Run report written: ${base}.md`);
+      return `${base}.md`;
+    } catch (writeError) {
+      console.warn(
+        `   ⚠️  Could not write run report: ${(writeError as Error).message}`,
+      );
+      return null;
+    }
+  }
+
+  private buildOutcome(
+    result?: ReviewResult,
+    error?: string,
+  ): RunReportOutcome {
+    if (!result) {
+      return { error };
+    }
+    const toRef = (issue: {
+      severity: string;
+      title: string;
+      filePath?: string;
+      line?: number;
+    }): RunReportFindingRef => ({
+      severity: issue.severity,
+      title: issue.title,
+      filePath: issue.filePath,
+      line: issue.line,
+    });
+    return {
+      decision: result.decision,
+      completion: result.completion,
+      durationSeconds: result.duration,
+      issues: (result.issues || []).map(toRef),
+      ungatedIssues: (result.ungatedIssues || []).map(toRef),
+      summary: result.summary,
+      tokenUsage: result.tokenUsage,
+      costEstimate: result.costEstimate,
+      error,
+    };
+  }
+
+  private renderMarkdown(outcome: RunReportOutcome): string {
+    const meta = this.meta;
+    const lines: string[] = [];
+    const repo = [meta.workspace, meta.repository].filter(Boolean).join("/");
+    const title = meta.pullRequestId
+      ? `${repo} PR #${meta.pullRequestId}`
+      : repo || meta.sessionId;
+    lines.push(`# Yama Review Report — ${title}`, "");
+    lines.push(`| | |`, `| --- | --- |`);
+    lines.push(`| Session | \`${meta.sessionId}\` |`);
+    lines.push(`| Started | ${meta.startedAt} |`);
+    if (meta.aiProvider || meta.aiModel) {
+      lines.push(
+        `| Model | ${meta.aiProvider || ""} / ${meta.aiModel || ""} |`,
+      );
+    }
+    lines.push(`| Mode | ${meta.dryRun ? "🟡 DRY-RUN" : "🔴 LIVE"} |`);
+    if (outcome.decision) {
+      lines.push(`| Decision | **${outcome.decision}** |`);
+    }
+    if (outcome.completion) {
+      lines.push(
+        `| Completion | ${outcome.completion.stopReason}` +
+          `${outcome.completion.stepsUsed ? ` (${outcome.completion.stepsUsed} steps)` : ""}` +
+          `${outcome.completion.partial ? " — **PARTIAL**" : ""} |`,
+      );
+    }
+    if (outcome.durationSeconds !== undefined) {
+      lines.push(`| Duration | ${outcome.durationSeconds}s |`);
+    }
+    if (outcome.tokenUsage) {
+      lines.push(
+        `| Tokens | ${outcome.tokenUsage.total} (in ${outcome.tokenUsage.input} / out ${outcome.tokenUsage.output}) |`,
+      );
+    }
+    if (outcome.error) {
+      lines.push(`| Error | ${inline(outcome.error)} |`);
+    }
+    lines.push("");
+
+    const findingLine = (issue: RunReportFindingRef): string => {
+      const location = issue.filePath
+        ? ` — \`${inline(issue.filePath)}${issue.line ? `:${issue.line}` : ""}\``
+        : "";
+      return `- **${issue.severity}**: ${inline(issue.title)}${location}`;
+    };
+
+    lines.push(`## Verified findings (${outcome.issues?.length ?? 0})`, "");
+    if (outcome.issues?.length) {
+      for (const issue of outcome.issues) {
+        lines.push(findingLine(issue));
+      }
+    } else {
+      lines.push("_None accepted by the review gate._");
+    }
+    lines.push("");
+
+    if (outcome.ungatedIssues?.length) {
+      lines.push(
+        `## Quarantined claims (${outcome.ungatedIssues.length})`,
+        "",
+        "_Listed in the model verdict but never verified by the_ " +
+          "`submit_review` _gate — excluded from the decision, comments, and state._",
+        "",
+      );
+      for (const issue of outcome.ungatedIssues) {
+        lines.push(findingLine(issue));
+      }
+      lines.push("");
+    }
+
+    lines.push(`## Timeline`, "");
+    if (this.timeline.length === 0) {
+      lines.push("_No events recorded._");
+    }
+    for (const entry of this.timeline) {
+      const at = entry.at.slice(11, 19);
+      switch (entry.kind) {
+        case "bootstrap":
+          lines.push(
+            `- \`${at}\` 🧭 Bootstrapped repo standards (${entry.chars} chars)`,
+          );
+          break;
+        case "explore":
+          lines.push(
+            `- \`${at}\` 🔎 Explore${entry.cached ? " (cached)" : ""}: ${inline(entry.task)}`,
+          );
+          if (entry.summary) {
+            lines.push(`  - ${inline(entry.summary)}`);
+          }
+          break;
+        case "submit":
+          lines.push(
+            `- \`${at}\` 🛡️ submit_review (${entry.mode}): ` +
+              `${entry.accepted.length} accepted, ${entry.rejected.length} rejected`,
+          );
+          for (const finding of entry.accepted) {
+            lines.push(`  - ✅ ${finding.severity}: ${inline(finding.title)}`);
+          }
+          for (const finding of entry.rejected) {
+            lines.push(
+              `  - ❌ ${finding.severity}: ${inline(finding.title)} — ${inline(finding.reason)}`,
+            );
+          }
+          break;
+        case "finalization":
+          lines.push(
+            `- \`${at}\` 📮 Finalization: ${entry.outcome}` +
+              `${entry.detail ? ` (${inline(entry.detail)})` : ""}`,
+          );
+          break;
+        case "note":
+          lines.push(`- \`${at}\` 📝 ${inline(entry.text)}`);
+          break;
+      }
+    }
+    lines.push("");
+
+    if (outcome.summary) {
+      lines.push(`## Review summary`, "", outcome.summary, "");
+    }
+
+    return lines.join("\n");
+  }
+}

--- a/src/v2/core/YamaOrchestrator.ts
+++ b/src/v2/core/YamaOrchestrator.ts
@@ -32,6 +32,7 @@ import {
 } from "../types/index.js";
 import { NeuroLinkFactory } from "./NeuroLinkFactory.js";
 import { ReviewResultParser } from "./ReviewResultParser.js";
+import { RunReporter } from "./RunReporter.js";
 import {
   isVerdictShaped,
   localReviewVerdictSchema,
@@ -58,7 +59,11 @@ import {
 import { RulesContextLoader } from "../exploration/RulesContextLoader.js";
 import type { YamaRule } from "../types/index.js";
 import { gateFindings } from "../harness/submitReviewGate.js";
-import type { SubmitReviewAccepted, SubmittedFinding } from "../types/index.js";
+import type {
+  ReviewGateSnapshot,
+  SubmitReviewAccepted,
+  SubmittedFinding,
+} from "../types/index.js";
 import { isMutatingGitTool, normalizeToolName } from "../utils/toolPolicy.js";
 import { VERSION } from "../utils/version.js";
 
@@ -86,9 +91,15 @@ export class YamaOrchestrator {
   private previousOpenIds = new Set<string>();
   /** Finding ids accepted by submit_review during the current run. */
   private acceptedFindingIds = new Set<string>();
+  /** Full accepted findings this run — the final verdict is anchored to these. */
+  private acceptedFindings: SubmitReviewAccepted[] = [];
+  /** How many times the agent invoked submit_review this run. */
+  private submitReviewCalls = 0;
   /** Learned false positives (dismissed / ignored 3+ runs) — never re-posted. */
   private suppressedFindingIds = new Set<string>();
   private currentToolContext: Record<string, unknown> | null = null;
+  /** Per-run report collector (PR flows); null outside a review run. */
+  private runReporter: RunReporter | null = null;
   private initOptions: YamaInitOptions;
   private bootstrapStandardsCache: Map<string, string> = new Map();
   private loadedRules: YamaRule[] = [];
@@ -241,12 +252,19 @@ export class YamaOrchestrator {
     const sessionId = this.sessionManager.createSession(request);
 
     this.logReviewStart(request, sessionId);
+    this.runReporter = this.createRunReporter(sessionId, request);
 
     try {
       const bootstrapStandards = await this.getBootstrappedStandards(
         request,
         sessionId,
       );
+      if (bootstrapStandards) {
+        this.runReporter.record({
+          kind: "bootstrap",
+          chars: bootstrapStandards.length,
+        });
+      }
       const previousReview = await this.loadPreviousReview(request);
 
       // Build comprehensive AI instructions
@@ -317,7 +335,7 @@ export class YamaOrchestrator {
         "code-review",
       );
       this.resultParser.recordToolCallsFromResponse(sessionId, aiResponse);
-      const verdictResponse = await this.ensureStructuredVerdict(
+      const verdictResponse = await this.ensureVerdictAndPosting(
         aiResponse,
         prReviewVerdictSchema,
         sessionId,
@@ -325,13 +343,14 @@ export class YamaOrchestrator {
         "code-review-verdict",
       );
 
-      // Extract and parse results
+      // Extract and parse results — anchored to the submit_review gate.
       const result = this.applyRuleCompliance(
         this.resultParser.parseReviewResult(
           verdictResponse,
           startTime,
           sessionId,
           this.config.projectStandards?.severityOverrides,
+          this.buildGateSnapshot(),
         ),
       );
 
@@ -341,11 +360,13 @@ export class YamaOrchestrator {
       this.sessionManager.completeSession(sessionId, result);
 
       this.logReviewComplete(result);
+      await this.writeRunReport(result);
 
       return result;
     } catch (error) {
       this.sessionManager.failSession(sessionId, error as Error);
       console.error("\n❌ Review failed:", (error as Error).message);
+      await this.writeRunReport(undefined, (error as Error).message);
       throw error;
     }
   }
@@ -472,6 +493,7 @@ export class YamaOrchestrator {
     const sessionId = this.sessionManager.createSession(request);
 
     this.logReviewStart(request, sessionId);
+    this.runReporter = this.createRunReporter(sessionId, request);
 
     try {
       // ========================================================================
@@ -482,6 +504,12 @@ export class YamaOrchestrator {
         request,
         sessionId,
       );
+      if (bootstrapStandards) {
+        this.runReporter.record({
+          kind: "bootstrap",
+          chars: bootstrapStandards.length,
+        });
+      }
 
       const previousReview = await this.loadPreviousReview(request);
 
@@ -544,7 +572,7 @@ export class YamaOrchestrator {
         enableEvaluation: this.config.ai.enableEvaluation,
       } as unknown as Parameters<NeuroLink["generate"]>[0]);
       this.resultParser.recordToolCallsFromResponse(sessionId, reviewResponse);
-      const verdictResponse = await this.ensureStructuredVerdict(
+      const verdictResponse = await this.ensureVerdictAndPosting(
         reviewResponse,
         prReviewVerdictSchema,
         sessionId,
@@ -552,13 +580,14 @@ export class YamaOrchestrator {
         "code-review-verdict",
       );
 
-      // Parse review results
+      // Parse review results — anchored to the submit_review gate.
       const reviewResult = this.applyRuleCompliance(
         this.resultParser.parseReviewResult(
           verdictResponse,
           startTime,
           sessionId,
           this.config.projectStandards?.severityOverrides,
+          this.buildGateSnapshot(),
         ),
       );
 
@@ -621,11 +650,13 @@ export class YamaOrchestrator {
       this.sessionManager.completeSession(sessionId, reviewResult);
 
       this.logReviewComplete(reviewResult);
+      await this.writeRunReport(reviewResult);
 
       return reviewResult;
     } catch (error) {
       this.sessionManager.failSession(sessionId, error as Error);
       console.error("\n❌ Review failed:", (error as Error).message);
+      await this.writeRunReport(undefined, (error as Error).message);
       throw error;
     }
   }
@@ -761,6 +792,153 @@ export class YamaOrchestrator {
   private setToolContext(context: Record<string, unknown>): void {
     this.currentToolContext = context;
     (this.neurolink as any).setToolContext(context);
+  }
+
+  /** Fresh report collector for a PR review run. */
+  private createRunReporter(
+    sessionId: string,
+    request: ReviewRequest,
+  ): RunReporter {
+    return new RunReporter({
+      sessionId,
+      workspace: request.workspace || request.owner,
+      repository: request.repository || request.repo,
+      pullRequestId: request.pullRequestId ?? request.prNumber,
+      provider: this.detectedProvider,
+      aiProvider: this.config.ai.provider,
+      aiModel: this.config.ai.model,
+      dryRun: request.dryRun === true,
+      startedAt: new Date().toISOString(),
+    });
+  }
+
+  /**
+   * Write the run report (best-effort) and release the collector, keeping the
+   * "null outside a review run" invariant true for reused instances.
+   */
+  private async writeRunReport(
+    result?: ReviewResult,
+    error?: string,
+  ): Promise<void> {
+    const reporter = this.runReporter;
+    this.runReporter = null;
+    await reporter?.write(this.config.monitoring?.report, result, error);
+  }
+
+  /** The gate's view of this run — what the final verdict is anchored to. */
+  private buildGateSnapshot(): ReviewGateSnapshot {
+    return {
+      invoked: this.submitReviewCalls > 0,
+      accepted: [...this.acceptedFindings],
+    };
+  }
+
+  /**
+   * Close out the PR review phase with the reliability the agentic loop cannot
+   * guarantee on its own:
+   *
+   * 1. POSTING PASS (tools ON, same session): if the gate accepted findings in
+   *    a live run, the loop may still have ended (step cap, stall, tool step)
+   *    between acceptance and posting — historically the #1 way findings ended
+   *    up only in logs. One bounded follow-up turn instructs the agent to
+   *    verify every accepted finding has its inline comment and post the
+   *    missing ones, then return the structured verdict in the same turn.
+   *    Step-bounded, no wall clock.
+   * 2. VERDICT FALLBACK (tools OFF): if structure is still missing, fall back
+   *    to the plain same-session verdict request. The parser anchors whatever
+   *    comes back to the gate, so a fabricated issues list cannot drive the
+   *    decision either way.
+   */
+  private async ensureVerdictAndPosting(
+    response: any,
+    schema: unknown,
+    sessionId: string,
+    userId: string,
+    operation: string,
+  ): Promise<any> {
+    const dryRun = this.currentToolContext?.dryRun === true;
+    const acceptedCount = this.acceptedFindings.length;
+    const needsPostingPass = !dryRun && acceptedCount > 0;
+
+    if (needsPostingPass) {
+      console.log(
+        `   📮 Finalization: ensuring all ${acceptedCount} accepted finding(s) ` +
+          `are posted (same session, tools on)...`,
+      );
+      try {
+        const loop = this.config.performance?.loop || {};
+        const finalization = await this.neurolink.generate({
+          input: {
+            text:
+              `Review finalization. The submit_review gate accepted ${acceptedCount} ` +
+              `finding(s) this run. Step 1: verify each accepted finding has exactly ` +
+              `ONE inline comment posted on the pull request (severity marker first). ` +
+              `Post any accepted finding that is still missing its comment now. Never ` +
+              `post rejected or unsubmitted findings, and never post a duplicate for a ` +
+              `finding you already posted. Step 2: return the final review verdict as ` +
+              `the strict JSON object defined in the output contract, where "issues" ` +
+              `lists exactly the gate-accepted findings.`,
+          },
+          provider: this.config.ai.provider,
+          model: this.config.ai.model,
+          temperature: 0,
+          maxTokens: clampMaxTokens(this.config.ai.maxTokens),
+          timeout: this.config.ai.timeout,
+          stream: true,
+          schema,
+          skipToolPromptInjection: true,
+          // Bounded by WORK, never by wall clock: enough steps to post every
+          // accepted finding plus margin, without exceeding the operator's
+          // configured step budget; stall/tool guards catch hangs.
+          maxSteps: Math.min(
+            Math.max(20, acceptedCount * 2 + 5),
+            loop.maxSteps ?? 100,
+          ),
+          ...(loop.stallTimeoutMs
+            ? { stallTimeoutMs: loop.stallTimeoutMs }
+            : {}),
+          ...(loop.toolTimeoutMs ? { toolTimeoutMs: loop.toolTimeoutMs } : {}),
+          context: { sessionId, userId, operation: `${operation}-finalize` },
+          memory: { enabled: false },
+        } as unknown as Parameters<NeuroLink["generate"]>[0]);
+        this.resultParser.recordToolCallsFromResponse(sessionId, finalization);
+
+        if (isVerdictShaped(finalization?.structuredData)) {
+          this.runReporter?.record({
+            kind: "finalization",
+            outcome: "verdict",
+          });
+          // Keep the MAIN loop's completion signals (stopReason/stepsUsed):
+          // a partial main review stays partial no matter how cleanly the
+          // finalization turn ended.
+          return { ...response, structuredData: finalization.structuredData };
+        }
+        console.warn(
+          "   ⚠️  Finalization turn returned no structured verdict — falling back.",
+        );
+        this.runReporter?.record({
+          kind: "finalization",
+          outcome: "no-verdict",
+        });
+      } catch (error) {
+        console.warn(
+          `   ⚠️  Finalization turn failed: ${(error as Error).message} — falling back.`,
+        );
+        this.runReporter?.record({
+          kind: "finalization",
+          outcome: "error",
+          detail: (error as Error).message,
+        });
+      }
+    }
+
+    return this.ensureStructuredVerdict(
+      response,
+      schema,
+      sessionId,
+      userId,
+      operation,
+    );
   }
 
   /**
@@ -1019,6 +1197,8 @@ export class YamaOrchestrator {
     const key = this.buildStateKey(request);
     this.previousOpenIds = new Set();
     this.acceptedFindingIds = new Set();
+    this.acceptedFindings = [];
+    this.submitReviewCalls = 0;
     this.suppressedFindingIds = new Set();
     if (!this.stateStore || !key) {
       return { key, block: "" };
@@ -1106,9 +1286,11 @@ export class YamaOrchestrator {
 
   /**
    * Loop guards for agentic generate() calls, wired from `performance.*`
-   * config (previously decorative). `turnTimeoutMs` falls back to
-   * `performance.maxReviewDuration`; steps default bounded well below
-   * NeuroLink's own 200-step ceiling.
+   * config. Steps default bounded well below NeuroLink's own 200-step
+   * ceiling. There is NO default wall clock: `turnTimeoutMs` (or its
+   * `performance.maxReviewDuration` fallback) applies only when explicitly
+   * configured — reviews are bounded by work, not time, so quality never
+   * loses to a clock. Stall/tool timeouts remain as hang protection.
    */
   private getLoopGuardOptions(): Record<string, unknown> {
     const loop = this.config.performance?.loop || {};
@@ -1241,6 +1423,15 @@ export class YamaOrchestrator {
           runtimeContext,
         );
 
+        this.runReporter?.record({
+          kind: "explore",
+          task: String(rawParams.task || "")
+            .trim()
+            .slice(0, 300),
+          cached,
+          summary: (result.summary || "").slice(0, 500),
+        });
+
         return {
           success: true,
           data: {
@@ -1302,6 +1493,7 @@ export class YamaOrchestrator {
         required: ["findings"],
       },
       execute: async (params: unknown) => {
+        this.submitReviewCalls += 1;
         const raw = (params || {}) as { findings?: unknown };
         const submitted: SubmittedFinding[] = Array.isArray(raw.findings)
           ? (raw.findings as SubmittedFinding[]).filter(
@@ -1348,10 +1540,28 @@ export class YamaOrchestrator {
         });
         for (const finding of result.accepted) {
           this.acceptedFindingIds.add(finding.id);
+          this.acceptedFindings.push(finding);
         }
         console.log(
           `   🛡️  submit_review: ${result.accepted.length} accepted, ${result.rejected.length} rejected (mode: ${mode}).`,
         );
+        this.runReporter?.record({
+          kind: "submit",
+          mode,
+          accepted: result.accepted.map((finding) => ({
+            severity: finding.severity,
+            title: finding.title,
+            filePath: finding.filePath,
+            line: finding.line,
+          })),
+          rejected: result.rejected.map((entry) => ({
+            severity: entry.finding.severity,
+            title: entry.finding.title,
+            filePath: entry.finding.filePath,
+            line: entry.finding.line,
+            reason: entry.reason,
+          })),
+        });
         return { success: true, data: result };
       },
     });

--- a/src/v2/harness/verdictReconciler.ts
+++ b/src/v2/harness/verdictReconciler.ts
@@ -1,0 +1,101 @@
+/**
+ * Verdict reconciliation — anchors the final review verdict to what the
+ * submit_review gate actually verified.
+ *
+ * The model's structured verdict lists issues, but only findings the gate
+ * accepted (deduped + critic-verified) are trustworthy. This became load-
+ * bearing the day a partial review's tools-off verdict recovery fabricated a
+ * plausible issues list out of the rules prompt and BLOCKED a PR on findings
+ * that matched nothing the agent had investigated. Pure and deterministic.
+ */
+
+import { LocalReviewFinding } from "../types/index.js";
+
+export type ReconcileVerdictInput = {
+  /** Gate-accepted findings, already normalized to LocalReviewFinding. */
+  gatedFindings: LocalReviewFinding[];
+  /** Issues from the model's structured verdict, already normalized. */
+  verdictIssues: LocalReviewFinding[];
+};
+
+export type ReconcileVerdictOutput = {
+  /**
+   * The decision-driving findings: every gate-accepted finding, enriched with
+   * the matching verdict issue's richer prose where one exists.
+   */
+  issues: LocalReviewFinding[];
+  /** Verdict issues that matched no gate-accepted finding (advisory only). */
+  ungatedIssues: LocalReviewFinding[];
+};
+
+const normalize = (value: string | undefined): string =>
+  (value || "").trim().toLowerCase().replace(/\s+/g, " ");
+
+/**
+ * Match a gated finding to the verdict issue describing the same problem.
+ * Deterministic, tolerant of rephrasing: same file + same title, or same
+ * file + same line + same severity. A finding without a filePath never
+ * matches — two location-less findings must not glue together on prose
+ * alone. (Ids can't be compared directly — the verdict issue ids are
+ * model-invented, the gate ids are content hashes.)
+ */
+function matches(
+  gated: LocalReviewFinding,
+  issue: LocalReviewFinding,
+): boolean {
+  const gatedFile = normalize(gated.filePath);
+  const sameFile =
+    gatedFile.length > 0 && gatedFile === normalize(issue.filePath);
+  if (!sameFile) {
+    return false;
+  }
+  if (normalize(gated.title) === normalize(issue.title)) {
+    return true;
+  }
+  return (
+    gated.line !== undefined &&
+    gated.line === issue.line &&
+    gated.severity === issue.severity
+  );
+}
+
+/**
+ * Split the model's verdict issues against the gate's accepted findings.
+ *
+ * Every gate-accepted finding survives (enriched with the matching verdict
+ * issue's richer description/suggestion where one exists); verdict issues
+ * matching no accepted finding come back as `ungatedIssues` — unverified
+ * claims the caller must treat as advisory only. Each verdict issue is
+ * claimed by at most one gated finding. Pure and deterministic.
+ */
+export function reconcileVerdictWithGate(
+  input: ReconcileVerdictInput,
+): ReconcileVerdictOutput {
+  const claimed = new Set<number>();
+  const issues: LocalReviewFinding[] = input.gatedFindings.map((gated) => {
+    const matchIndex = input.verdictIssues.findIndex(
+      (issue, index) => !claimed.has(index) && matches(gated, issue),
+    );
+    if (matchIndex === -1) {
+      return gated;
+    }
+    claimed.add(matchIndex);
+    const matched = input.verdictIssues[matchIndex];
+    // The gate finding is authoritative (severity was critic-verified); the
+    // verdict issue may carry richer prose written after further analysis.
+    return {
+      ...gated,
+      description:
+        (matched.description?.length || 0) > (gated.description?.length || 0)
+          ? matched.description
+          : gated.description,
+      suggestion: gated.suggestion || matched.suggestion,
+    };
+  });
+
+  const ungatedIssues = input.verdictIssues.filter(
+    (_, index) => !claimed.has(index),
+  );
+
+  return { issues, ungatedIssues };
+}

--- a/src/v2/prompts/ReviewSystemPrompt.ts
+++ b/src/v2/prompts/ReviewSystemPrompt.ts
@@ -22,6 +22,7 @@ export function buildReviewSystemPrompt(): string {
     <rule>BE ACTIONABLE. Every finding names a file and line and gives a concrete fix. Include a real, executable code suggestion for CRITICAL and MAJOR findings.</rule>
     <rule>USE THE TOOLS YOU HAVE. Discover the tools available to you and use them to read the PR and its diff, to post inline comments, and (in live mode) to record your review decision. Do NOT assume or invent tool names — call only tools that actually exist for you.</rule>
     <rule>GATE BEFORE POSTING. Before posting ANY inline comment, submit your candidate findings for the current file (or batch) to the submit_review tool, each with concrete evidence (file:line citations or quoted code). Post comments ONLY for findings it accepts. For a rejected finding: either gather stronger evidence and resubmit it ONCE, or drop it. Findings listed in &lt;previous-review&gt; already have comments — never re-post them; verify instead whether they are fixed and report their ids in resolvedIssueIds.</rule>
+    <rule>POST IMMEDIATELY AFTER ACCEPTANCE. The moment submit_review accepts findings, post their inline comments BEFORE moving to the next file. Never save posting for the end of the review — a finding that is accepted but unposted helps nobody.</rule>
   </method>
 
   <severity>
@@ -41,7 +42,7 @@ export function buildReviewSystemPrompt(): string {
         { "severity": "CRITICAL|MAJOR|MINOR|SUGGESTION", "category": "string", "title": "string", "description": "string", "filePath": "string", "line": 1, "suggestion": "string" }
       ]
     }
-    Yama derives the AUTHORITATIVE decision from these findings (any CRITICAL blocks; enough MAJORs block), so list every issue you found here — even the ones you already posted as comments.
+    Yama derives the AUTHORITATIVE decision from the gate-verified findings (any CRITICAL blocks; enough MAJORs block). "issues" must list exactly the findings submit_review ACCEPTED — never invent, pad, or restate project rules as findings; an issue that was not gated is discarded as unverified.
   </output>
 
   <anti-patterns>

--- a/src/v2/types/config.ts
+++ b/src/v2/types/config.ts
@@ -395,6 +395,21 @@ export type MonitoringConfig = {
   logTokenUsage: boolean;
   exportFormat: "json" | "csv";
   exportPath: string;
+  /** Per-run review report artifact (markdown + JSON). */
+  report?: RunReportConfig;
+};
+
+/**
+ * Per-run report: the human-readable record of what the review actually did —
+ * bootstrap standards, explore investigations, gate batches with critic
+ * verdicts, finalization, and the reconciled verdict. Written locally (a log,
+ * not a PR side effect), so CI can archive it next to the state file.
+ */
+export type RunReportConfig = {
+  /** Default true. */
+  enabled?: boolean;
+  /** Directory for report files. Default ".yama/reports". */
+  path?: string;
 };
 
 // ============================================================================
@@ -402,7 +417,16 @@ export type MonitoringConfig = {
 // ============================================================================
 
 export type PerformanceConfig = {
-  maxReviewDuration: string;
+  /**
+   * OPTIONAL wall-clock cap per agentic review turn (the fallback for
+   * loop.turnTimeoutMs — each generate() call gets its own clock; retries,
+   * finalization, and enhancement turns are capped individually, not the
+   * whole CLI run). Unset by default: reviews are bounded by WORK
+   * (loop.maxSteps + the submit_review gate), not by time — a wall clock
+   * cuts the loop mid-review and loses quality, so only set this when an
+   * external scheduler truly requires it.
+   */
+  maxReviewDuration?: string;
   tokenBudget: TokenBudgetConfig;
   costControls: CostControlsConfig;
   /** Agentic-loop guards, passed to NeuroLink generate() calls. */
@@ -410,13 +434,15 @@ export type PerformanceConfig = {
 };
 
 /**
- * Bounds for the agentic tool-calling loop. All optional — defaults are
- * conservative and derived from `maxReviewDuration` where sensible.
+ * Bounds for the agentic tool-calling loop. All optional. Step/stall/tool
+ * guards protect against hangs and runaways; there is deliberately no default
+ * whole-turn wall clock (see PerformanceConfig.maxReviewDuration).
  */
 export type LoopGuardConfig = {
   /** Max tool-loop steps per generate() call (NeuroLink default is 200). */
   maxSteps?: number;
-  /** Whole-turn wall-clock cap in ms (falls back to maxReviewDuration). */
+  /** Whole-turn wall-clock cap in ms (falls back to maxReviewDuration).
+   *  Off by default — prefer step bounds over time bounds. */
   turnTimeoutMs?: number;
   /** No-progress watchdog in ms. */
   stallTimeoutMs?: number;

--- a/src/v2/types/harness.ts
+++ b/src/v2/types/harness.ts
@@ -39,3 +39,17 @@ export type SubmitReviewResult = {
   /** What the agent should do next, stated explicitly. */
   instruction: string;
 };
+
+/**
+ * What the submit_review gate saw during one run — the ground truth the final
+ * verdict is anchored to. When `invoked` is true, only gate-accepted findings
+ * may drive the decision; verdict issues that never passed the gate are
+ * quarantined as advisory (they are unverified claims, and on partial runs
+ * often outright fabrications reconstructed from the rules prompt).
+ */
+export type ReviewGateSnapshot = {
+  /** True when the agent called submit_review at least once this run. */
+  invoked: boolean;
+  /** Findings the gate accepted (deduped + critic-verified). */
+  accepted: SubmitReviewAccepted[];
+};

--- a/src/v2/types/index.ts
+++ b/src/v2/types/index.ts
@@ -13,6 +13,7 @@ export * from "./exploration.js";
 export * from "./harness.js";
 export * from "./learning.js";
 export * from "./mcp.js";
+export * from "./report.js";
 export * from "./review.js";
 export * from "./rules.js";
 export * from "./state.js";

--- a/src/v2/types/report.ts
+++ b/src/v2/types/report.ts
@@ -1,0 +1,55 @@
+/**
+ * Run-report types — the structured record of one review run, from which the
+ * markdown/JSON report artifact is rendered.
+ */
+
+import { ReviewCompletion } from "./review.js";
+
+export type RunReportMeta = {
+  sessionId: string;
+  workspace?: string;
+  repository?: string;
+  pullRequestId?: number;
+  provider?: string;
+  aiProvider?: string;
+  aiModel?: string;
+  dryRun: boolean;
+  startedAt: string;
+};
+
+export type RunReportFindingRef = {
+  severity: string;
+  title: string;
+  filePath?: string;
+  line?: number | null;
+};
+
+export type RunReportEvent =
+  | { kind: "bootstrap"; chars: number }
+  | { kind: "explore"; task: string; cached: boolean; summary: string }
+  | {
+      kind: "submit";
+      mode: string;
+      accepted: RunReportFindingRef[];
+      rejected: Array<RunReportFindingRef & { reason: string }>;
+    }
+  | {
+      kind: "finalization";
+      outcome: "verdict" | "no-verdict" | "error";
+      detail?: string;
+    }
+  | { kind: "note"; text: string };
+
+export type RunReportTimelineEntry = RunReportEvent & { at: string };
+
+export type RunReportOutcome = {
+  decision?: string;
+  completion?: ReviewCompletion;
+  durationSeconds?: number;
+  issues?: RunReportFindingRef[];
+  ungatedIssues?: RunReportFindingRef[];
+  summary?: string;
+  tokenUsage?: { input: number; output: number; total: number };
+  costEstimate?: number;
+  error?: string;
+};

--- a/src/v2/types/review.ts
+++ b/src/v2/types/review.ts
@@ -76,6 +76,12 @@ export type ReviewResult = {
   completion?: ReviewCompletion;
   /** Normalized findings from the structured verdict (source for state). */
   issues?: LocalReviewFinding[];
+  /**
+   * Verdict issues that never passed the submit_review gate — unverified
+   * claims, quarantined out of `issues`: they do not drive the decision, are
+   * not posted, and are not persisted to state. Surfaced for transparency.
+   */
+  ungatedIssues?: LocalReviewFinding[];
   /** Prior-finding ids the agent verified as fixed this run. */
   resolvedIssueIds?: string[];
   /** Per-rule compliance derived from findings (.yama/rules). */

--- a/tests/v2/unit/defaultConfig.test.ts
+++ b/tests/v2/unit/defaultConfig.test.ts
@@ -1,0 +1,23 @@
+/**
+ * DefaultConfig — locks the bounded-by-work (not time) review defaults.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { DefaultConfig } from "../../../src/v2/config/DefaultConfig.js";
+
+describe("DefaultConfig", () => {
+  it("sets no default review wall clock — the loop is bounded by steps, not time", () => {
+    const config = DefaultConfig.get();
+    expect(config.performance.maxReviewDuration).toBeUndefined();
+    expect(config.performance.loop?.turnTimeoutMs).toBeUndefined();
+    // Hang protection stays: per-tool timeout and a step ceiling.
+    expect(config.performance.loop?.maxSteps).toBe(100);
+    expect(config.performance.loop?.toolTimeoutMs).toBe(300_000);
+  });
+
+  it("enables the per-run report artifact by default", () => {
+    const config = DefaultConfig.get();
+    expect(config.monitoring.report?.enabled).toBe(true);
+    expect(config.monitoring.report?.path).toBe(".yama/reports");
+  });
+});

--- a/tests/v2/unit/reviewResultParser.test.ts
+++ b/tests/v2/unit/reviewResultParser.test.ts
@@ -277,3 +277,165 @@ describe("ReviewResultParser regression guards", () => {
     expect(calls[1].result?.value).toBe("second");
   });
 });
+
+describe("ReviewResultParser.parseReviewResult (gate anchoring)", () => {
+  const session = () => {
+    const sm = new SessionManager();
+    const parser = new ReviewResultParser(sm);
+    const sessionId = sm.createSession({
+      mode: "pr",
+      workspace: "w",
+      repository: "r",
+      pullRequestId: 496,
+    });
+    return { parser, sessionId };
+  };
+
+  it("quarantines fabricated verdict issues on a partial run — they must not drive BLOCKED", () => {
+    const { parser, sessionId } = session();
+
+    // Reproduces the observed failure: the loop died on a limit, the verdict
+    // recovery restated four project rules as MAJOR "findings" about files
+    // that were never gated. Only ONE finding actually passed submit_review.
+    const fabricated = (title: string) => ({
+      severity: "MAJOR",
+      category: "conventions",
+      title,
+      description: "restated project rule",
+      filePath: "src/features/tara/tools/commands/index.ts",
+    });
+    const result = parser.parseReviewResult(
+      {
+        structuredData: {
+          decision: "CHANGES_REQUESTED",
+          summary: "This PR adds a new Slack slash command...",
+          issues: [
+            fabricated("interface keyword used instead of type"),
+            fabricated("types outside src/types/"),
+            fabricated("env var instead of feature flag"),
+            fabricated("missing matching AI tool"),
+          ],
+        },
+        stopReason: "step-cap",
+        usage: {},
+      },
+      Date.now(),
+      sessionId,
+      undefined,
+      {
+        invoked: true,
+        accepted: [
+          {
+            id: "gated-1",
+            severity: "MAJOR",
+            title: "Envelope may still exceed maxBytes",
+            filePath: "src/features/tara/services/mcp.ts",
+            line: 122,
+          },
+        ],
+      },
+    );
+
+    // 1 verified MAJOR < threshold → not BLOCKED; the 4 fabrications are
+    // quarantined, not counted, not persisted.
+    expect(result.decision).toBe("CHANGES_REQUESTED");
+    expect(result.statistics.issuesFound.major).toBe(1);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues?.[0].title).toBe("Envelope may still exceed maxBytes");
+    expect(result.ungatedIssues).toHaveLength(4);
+    expect(result.statistics.totalComments).toBe(1);
+    // Partial-run summary is rebuilt from verified findings, not model prose.
+    expect(result.summary).toContain("gate-verified");
+    expect(result.summary).not.toContain("Slack slash command");
+  });
+
+  it("caps APPROVED at CHANGES_REQUESTED when unverified CRITICAL claims exist", () => {
+    const { parser, sessionId } = session();
+    const result = parser.parseReviewResult(
+      {
+        structuredData: {
+          decision: "APPROVED",
+          summary: "ok",
+          issues: [
+            {
+              severity: "CRITICAL",
+              category: "security",
+              title: "Possible secret in config",
+              description: "never gated",
+              filePath: "src/x.ts",
+            },
+          ],
+        },
+        stopReason: "completed",
+        usage: {},
+      },
+      Date.now(),
+      sessionId,
+      undefined,
+      { invoked: true, accepted: [] },
+    );
+
+    expect(result.decision).toBe("CHANGES_REQUESTED");
+    expect(result.statistics.issuesFound.critical).toBe(0);
+    expect(result.ungatedIssues).toHaveLength(1);
+  });
+
+  it("still blocks on gate-accepted CRITICALs even if the verdict omits them", () => {
+    const { parser, sessionId } = session();
+    const result = parser.parseReviewResult(
+      {
+        structuredData: { decision: "APPROVED", summary: "ok", issues: [] },
+        stopReason: "completed",
+        usage: {},
+      },
+      Date.now(),
+      sessionId,
+      undefined,
+      {
+        invoked: true,
+        accepted: [
+          {
+            id: "gated-crit",
+            severity: "CRITICAL",
+            title: "SQL injection",
+            filePath: "src/db.ts",
+            line: 10,
+          },
+        ],
+      },
+    );
+
+    expect(result.decision).toBe("BLOCKED");
+    expect(result.statistics.issuesFound.critical).toBe(1);
+  });
+
+  it("keeps legacy behaviour when the gate was never invoked", () => {
+    const { parser, sessionId } = session();
+    const result = parser.parseReviewResult(
+      {
+        structuredData: {
+          decision: "APPROVED",
+          summary: "ok",
+          issues: [
+            {
+              severity: "CRITICAL",
+              category: "security",
+              title: "SQL injection",
+              description: "d",
+              filePath: "src/a.ts",
+            },
+          ],
+        },
+        usage: {},
+      },
+      Date.now(),
+      sessionId,
+      undefined,
+      { invoked: false, accepted: [] },
+    );
+
+    expect(result.decision).toBe("BLOCKED");
+    expect(result.statistics.issuesFound.critical).toBe(1);
+    expect(result.ungatedIssues).toBeUndefined();
+  });
+});

--- a/tests/v2/unit/runReporter.test.ts
+++ b/tests/v2/unit/runReporter.test.ts
@@ -1,0 +1,160 @@
+/**
+ * RunReporter — the per-run report artifact (markdown + JSON).
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { RunReporter } from "../../../src/v2/core/RunReporter.js";
+import { ReviewResult } from "../../../src/v2/types/index.js";
+
+const meta = () => ({
+  sessionId: "yama-test-1234",
+  workspace: "PICAF",
+  repository: "curator",
+  pullRequestId: 496,
+  provider: "bitbucket",
+  aiProvider: "vertex",
+  aiModel: "claude",
+  dryRun: false,
+  startedAt: "2026-07-28T08:00:00.000Z",
+});
+
+const result = (): ReviewResult => ({
+  mode: "pr",
+  prId: 496,
+  decision: "CHANGES_REQUESTED",
+  statistics: {
+    filesReviewed: 2,
+    issuesFound: { critical: 0, major: 1, minor: 0, suggestions: 0 },
+    requirementCoverage: 0,
+    codeQualityScore: 0,
+    toolCallsMade: 0,
+    cacheHits: 0,
+    totalComments: 1,
+  },
+  summary: "One verified finding.",
+  duration: 120,
+  tokenUsage: { input: 100, output: 200, total: 300 },
+  costEstimate: 0.5,
+  sessionId: "yama-test-1234",
+  completion: {
+    stopReason: "step-cap",
+    stepsUsed: 100,
+    jsonTruncated: false,
+    jsonRepaired: false,
+    partial: true,
+  },
+  issues: [
+    {
+      id: "abc",
+      severity: "MAJOR",
+      category: "correctness",
+      title: "Envelope may still exceed the cap",
+      description: "d",
+      filePath: "src/features/tara/services/mcp.ts",
+      line: 122,
+    },
+  ],
+  ungatedIssues: [
+    {
+      id: "issue-4",
+      severity: "MAJOR",
+      category: "conventions",
+      title: "Fabricated rule restatement",
+      description: "d",
+    },
+  ],
+});
+
+describe("RunReporter", () => {
+  it("writes a markdown report containing findings, quarantine, and timeline", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "yama-report-"));
+    const reporter = new RunReporter(meta());
+    reporter.record({ kind: "bootstrap", chars: 1670 });
+    reporter.record({
+      kind: "explore",
+      task: "Check truncateMCPResult envelope math",
+      cached: false,
+      summary: "Envelope can exceed maxBytes after per-item shrink.",
+    });
+    reporter.record({
+      kind: "submit",
+      mode: "basic",
+      accepted: [
+        {
+          severity: "MAJOR",
+          title: "Envelope may still exceed the cap",
+          filePath: "src/features/tara/services/mcp.ts",
+          line: 122,
+        },
+      ],
+      rejected: [
+        {
+          severity: "MINOR",
+          title: "Weak claim",
+          reason: "refuted by verification: no evidence",
+        },
+      ],
+    });
+    reporter.record({ kind: "finalization", outcome: "verdict" });
+
+    const path = await reporter.write({ enabled: true, path: dir }, result());
+    expect(path).toBe(join(dir, "yama-test-1234.md"));
+
+    const markdown = await readFile(path as string, "utf8");
+    expect(markdown).toContain("PICAF/curator PR #496");
+    expect(markdown).toContain("**PARTIAL**");
+    expect(markdown).toContain("Envelope may still exceed the cap");
+    expect(markdown).toContain("Quarantined claims (1)");
+    expect(markdown).toContain("Fabricated rule restatement");
+    expect(markdown).toContain(
+      "🔎 Explore: Check truncateMCPResult envelope math",
+    );
+    expect(markdown).toContain("1 accepted, 1 rejected");
+    expect(markdown).toContain("📮 Finalization: verdict");
+
+    const raw = JSON.parse(
+      await readFile(join(dir, "yama-test-1234.json"), "utf8"),
+    );
+    expect(raw.timeline).toHaveLength(4);
+    expect(raw.outcome.decision).toBe("CHANGES_REQUESTED");
+  });
+
+  it("is disabled by config and never throws on unwritable paths", async () => {
+    const reporter = new RunReporter(meta());
+    expect(await reporter.write({ enabled: false }, result())).toBeNull();
+
+    const broken = new RunReporter(meta());
+    // Report dir nested under a regular file — mkdir must fail.
+    const base = await mkdtemp(join(tmpdir(), "yama-report-"));
+    const blocker = join(base, "blocker");
+    await writeFile(blocker, "x", "utf8");
+    const path = await broken.write(
+      { enabled: true, path: join(blocker, "nope") },
+      result(),
+    );
+    expect(path).toBeNull();
+  });
+
+  it("writes an error-only report when the run failed before a result", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "yama-report-"));
+    const reporter = new RunReporter(meta());
+    reporter.record({ kind: "bootstrap", chars: 10 });
+    const path = await reporter.write(
+      { enabled: true, path: dir },
+      undefined,
+      "provider \\| exploded\nwith a stack trace",
+    );
+    expect(path).toBe(join(dir, "yama-test-1234.md"));
+    const markdown = await readFile(path as string, "utf8");
+    // Free text is flattened, with backslashes escaped BEFORE pipes — a
+    // pre-existing "\|" in the input must not re-arm the pipe and break the
+    // table row (CodeQL js/incomplete-sanitization).
+    expect(markdown).toContain(
+      "| Error | provider \\\\\\| exploded with a stack trace |",
+    );
+    expect(markdown).toContain("🧭 Bootstrapped repo standards");
+  });
+});

--- a/tests/v2/unit/verdictReconciler.test.ts
+++ b/tests/v2/unit/verdictReconciler.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Verdict reconciliation — the gate anchor that stops fabricated verdicts
+ * (observed: a partial run's tools-off verdict recovery invented an issues
+ * list from the rules prompt and BLOCKED a PR on findings nobody verified).
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { reconcileVerdictWithGate } from "../../../src/v2/harness/verdictReconciler.js";
+import { LocalReviewFinding } from "../../../src/v2/types/index.js";
+
+const finding = (
+  over: Partial<LocalReviewFinding> = {},
+): LocalReviewFinding => ({
+  id: "id-1",
+  severity: "MAJOR",
+  category: "correctness",
+  title: "Truncation drops the closing brace",
+  description: "short",
+  filePath: "src/core/utils/json.ts",
+  line: 42,
+  ...over,
+});
+
+describe("reconcileVerdictWithGate", () => {
+  it("keeps every gated finding and quarantines verdict issues that match none", () => {
+    const gated = [finding()];
+    const fabricated = finding({
+      id: "issue-1",
+      title: "interface keyword used instead of type",
+      filePath: "src/features/tara/tools/commands/index.ts",
+      line: undefined,
+    });
+    const { issues, ungatedIssues } = reconcileVerdictWithGate({
+      gatedFindings: gated,
+      verdictIssues: [fabricated],
+    });
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].title).toBe("Truncation drops the closing brace");
+    expect(ungatedIssues).toHaveLength(1);
+    expect(ungatedIssues[0].title).toBe(
+      "interface keyword used instead of type",
+    );
+  });
+
+  it("matches a rephrased verdict issue by file+line+severity and enriches prose", () => {
+    const gated = [finding({ description: "short" })];
+    const rephrased = finding({
+      id: "issue-1",
+      title: "JSON truncation loses the terminating brace of the envelope",
+      description:
+        "A much longer, richer description written after deeper analysis of the change.",
+      suggestion: "Close containers from the salvage stack.",
+    });
+    const { issues, ungatedIssues } = reconcileVerdictWithGate({
+      gatedFindings: gated,
+      verdictIssues: [rephrased],
+    });
+
+    expect(ungatedIssues).toHaveLength(0);
+    expect(issues[0].description).toContain("richer description");
+    expect(issues[0].suggestion).toBe(
+      "Close containers from the salvage stack.",
+    );
+    // Gate stays authoritative for identity and severity.
+    expect(issues[0].id).toBe("id-1");
+    expect(issues[0].severity).toBe("MAJOR");
+  });
+
+  it("matches by file+title when the line moved", () => {
+    const gated = [finding({ line: 42 })];
+    const moved = finding({ id: "issue-9", line: 58 });
+    const { issues, ungatedIssues } = reconcileVerdictWithGate({
+      gatedFindings: gated,
+      verdictIssues: [moved],
+    });
+    expect(issues).toHaveLength(1);
+    expect(ungatedIssues).toHaveLength(0);
+  });
+
+  it("never matches when either side lacks a filePath", () => {
+    const gated = [finding({ filePath: undefined })];
+    const sameTitleNoFile = finding({ id: "issue-3", filePath: undefined });
+    const { issues, ungatedIssues } = reconcileVerdictWithGate({
+      gatedFindings: gated,
+      verdictIssues: [sameTitleNoFile],
+    });
+    // The gated finding survives untouched; the location-less verdict issue
+    // must not glue onto it by title alone.
+    expect(issues).toHaveLength(1);
+    expect(ungatedIssues).toHaveLength(1);
+  });
+
+  it("never matches across files", () => {
+    const gated = [finding()];
+    const otherFile = finding({ id: "issue-2", filePath: "src/other.ts" });
+    const { ungatedIssues } = reconcileVerdictWithGate({
+      gatedFindings: gated,
+      verdictIssues: [otherFile],
+    });
+    expect(ungatedIssues).toHaveLength(1);
+  });
+
+  it("returns gated findings untouched when the verdict is empty", () => {
+    const gated = [finding(), finding({ id: "id-2", title: "Second" })];
+    const { issues, ungatedIssues } = reconcileVerdictWithGate({
+      gatedFindings: gated,
+      verdictIssues: [],
+    });
+    expect(issues).toHaveLength(2);
+    expect(ungatedIssues).toHaveLength(0);
+  });
+
+  it("claims each verdict issue at most once", () => {
+    const gated = [
+      finding({ id: "id-1", title: "Same title", line: 10 }),
+      finding({ id: "id-2", title: "Same title", line: 20 }),
+    ];
+    const verdict = [finding({ id: "issue-1", title: "Same title", line: 10 })];
+    const { issues, ungatedIssues } = reconcileVerdictWithGate({
+      gatedFindings: gated,
+      verdictIssues: verdict,
+    });
+    expect(issues).toHaveLength(2);
+    expect(ungatedIssues).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Problem

A live run (curator PR #496) exposed three reliability failures in the review loop:

1. **Fabricated verdict blocked a PR.** The 15m default wall clock cut the loop mid-review (`stopReason=time-limit`); the tools-off verdict recovery then reconstructed a plausible issues list from the rules prompt — 4 MAJOR "findings" about files not even in the diff — and `deriveDecision` counted them into BLOCKED.
2. **Accepted findings never reached the PR.** Posting is the last step of the agent workflow, so anything after the cut (including all gate-accepted comments) was silently lost; nothing after the tools-off fallback can ever post.
3. **The run's reasoning evaporated.** Explore investigations, critic verdicts, and gate decisions lived only in stdout.

## Changes

- **No default wall clock** — `performance.maxReviewDuration` default removed; the loop is bounded by work (`loop.maxSteps`, per-step `ai.timeout`, `toolTimeoutMs`/`stallTimeoutMs` hang guards), not time. Explicit configs still honored (MIGRATION note added).
- **Gate-anchored verdicts** — `parseReviewResult` now takes a `ReviewGateSnapshot`; once `submit_review` ran, only gate-accepted (deduped + critic-verified) findings drive the decision. Unmatched verdict issues are quarantined into `result.ungatedIssues`: excluded from counts, comments, and state; ungated CRITICALs cap an APPROVED at CHANGES_REQUESTED (fail-safe both directions). Partial runs get a deterministic summary built from verified findings. Pure matcher in `src/v2/harness/verdictReconciler.ts`.
- **Finalization turn** — before the tools-off verdict fallback, one bounded tools-ON follow-up in the same session verifies/posts every accepted-but-unposted finding, then returns the verdict. Step-bounded, no wall clock. Prompt now also instructs post-immediately-after-acceptance.
- **Honest stats** — `totalComments` counts gate-verified findings, not verdict issue length.
- **Per-run report artifact** — `RunReporter` writes `.yama/reports/<sessionId>.{md,json}`: bootstrap standards, explore calls with conclusions, gate batches with accept/reject reasons, finalization outcome, quarantined claims, reconciled decision. Config `monitoring.report` (default on); best-effort, never affects the review.
- **CLI** — `setMaxListeners(100)` to silence NeuroLink's per-step abort-listener `MaxListenersExceededWarning` (upstream issue).

## Safety notes

- `deriveDecision` itself is untouched; anchoring narrows its *input* to verified findings only. When the gate was never invoked, legacy behavior is preserved exactly (no weakening of rule 8).
- Dry runs skip the posting pass; the report is a local file (log-like), not a PR side effect.

## Testing

- New: `verdictReconciler.test.ts`, `runReporter.test.ts`, `defaultConfig.test.ts`; parser gate-anchoring suite reproduces the PR #496 fabrication scenario.
- `pnpm type-check` / `lint` (0 errors) / `test` (244 passing, 17 suites) / `build` all green.

## Deployment notes

Consumers fetching the review prompt from Langfuse (`yama-review`) need the updated prompt synced (done for curator). CI should archive `.yama/reports/` alongside the state artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-run Markdown and JSON review reports, including timelines, findings, outcomes, and error details.
  * Final review decisions now reflect findings verified by the review gate.
  * Unverified findings are quarantined and surfaced separately.
  * Added finalization to verify and post accepted inline findings.

* **Configuration**
  * Reports are enabled by default at `.yama/reports`.
  * Wall-clock review duration is now unset by default; step and tool safeguards remain active.

* **Documentation**
  * Updated migration guidance for the revised duration default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->