### PR TITLE
fix: correct commit example in README to Conventional Commits so releases publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 1. **Fork** the repository
 2. **Create** a feature branch (`git checkout -b feature/amazing-feature`)
-3. **Commit** your changes (`git commit -m 'Add amazing feature'`)
+3. **Commit** your changes with a [Conventional Commit](https://www.conventionalcommits.org/) message (`git commit -m 'feat: add amazing feature'`) — semantic-release derives the published version from commit types
 4. **Push** to the branch (`git push origin feature/amazing-feature`)
 5. **Open** a Pull Request
 


### PR DESCRIPTION
## Summary

The README's Contributing section instructed contributors to commit with a plain message (`git commit -m 'Add amazing feature'`), which contradicts the Conventional Commits requirement documented in CONTRIBUTING.md. Since this repo publishes via semantic-release, commits that don't follow the convention are ignored by the commit analyzer and never trigger a version bump — so the example actively steered contributors toward changes that can't be released.

This fixes the example to use a conventional `feat:` message and notes that semantic-release derives the published version from commit types.

## Changes

- README.md Contributing section: one-line fix to the commit example, aligning it with CONTRIBUTING.md and the semantic-release publish pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to require Conventional Commit messages.
  * Clarified that published versions are determined automatically from commit types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->