### PR TITLE
fix: bump @juspay/neurolink to 10.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   },
   "dependencies": {
     "@juspay/hippocampus": "^0.1.7",
-    "@juspay/neurolink": "^10.4.1",
+    "@juspay/neurolink": "^10.8.3",
     "@nexus2520/bitbucket-mcp-server": "2.0.4",
     "chalk": "^4.1.2",
     "commander": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,10 +18,10 @@ importers:
     dependencies:
       "@juspay/hippocampus":
         specifier: ^0.1.7
-        version: 0.1.7(@juspay/neurolink@10.4.1)
+        version: 0.1.7(@juspay/neurolink@10.8.3)
       "@juspay/neurolink":
-        specifier: ^10.4.1
-        version: 10.4.1(@juspay/hippocampus@0.1.7)(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@types/node@20.19.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)
+        specifier: ^10.8.3
+        version: 10.8.3(@juspay/hippocampus@0.1.7)(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@types/node@20.19.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)
       "@nexus2520/bitbucket-mcp-server":
         specifier: 2.0.4
         version: 2.0.4(@cfworker/json-schema@4.1.1)(debug@4.4.1)(zod@4.3.6)
@@ -2187,10 +2187,10 @@ packages:
       better-sqlite3:
         optional: true
 
-  "@juspay/neurolink@10.4.1":
+  "@juspay/neurolink@10.8.3":
     resolution:
       {
-        integrity: sha512-Im4zIChv6rgSiaprXm/AFk4LrCnJQ7hlcYXJtj7S9hZmy5DOXCIbkMVLLwlBiqa/mimemBW8nJhSS+0hPX4DVw==,
+        integrity: sha512-zT9qDyiwMV3ga8nZEN3jDh7HQ1U/VTIHTEK+R8uCxYYPhES2KYa2W0GaSJXC685WRw7ac93ZEyAByK0Pqtg7UQ==,
       }
     engines: { node: ">=20.18.1", npm: ">=10.0.0", pnpm: ">=8.0.0" }
     os: [darwin, linux, win32]
@@ -13277,15 +13277,15 @@ snapshots:
   "@js-sdsl/ordered-map@4.4.2":
     optional: true
 
-  "@juspay/hippocampus@0.1.7(@juspay/neurolink@10.4.1)":
+  "@juspay/hippocampus@0.1.7(@juspay/neurolink@10.8.3)":
     dependencies:
       "@aws-sdk/client-s3": 3.1004.0
-      "@juspay/neurolink": 10.4.1(@juspay/hippocampus@0.1.7)(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@types/node@20.19.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)
+      "@juspay/neurolink": 10.8.3(@juspay/hippocampus@0.1.7)(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@types/node@20.19.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)
       redis: 4.7.1
     transitivePeerDependencies:
       - aws-crt
 
-  "@juspay/neurolink@10.4.1(@juspay/hippocampus@0.1.7)(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@types/node@20.19.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)":
+  "@juspay/neurolink@10.8.3(@juspay/hippocampus@0.1.7)(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@types/node@20.19.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)":
     dependencies:
       "@ai-sdk/anthropic": 3.0.64(zod@4.3.6)
       "@ai-sdk/mistral": 3.0.27(zod@4.3.6)
@@ -13351,7 +13351,7 @@ snapshots:
       "@google-cloud/vertexai": 1.10.0(encoding@0.1.13)
       "@hono/node-server": 1.19.14(hono@4.12.25)
       "@huggingface/inference": 4.13.15
-      "@juspay/hippocampus": 0.1.7(@juspay/neurolink@10.4.1)
+      "@juspay/hippocampus": 0.1.7(@juspay/neurolink@10.8.3)
       "@koa/cors": 5.0.0
       "@koa/router": 15.3.1(koa@3.1.2)
       "@langfuse/otel": 5.0.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))


### PR DESCRIPTION
Bumps @juspay/neurolink from 10.4.1 to 10.8.3 (the version proven with the local Anthropic-format proxy in Curator). No code changes — Yama is provider-agnostic; running via the proxy is config/env only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Neurolink dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->